### PR TITLE
cicd: add MapBox secrets to decode

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,12 +29,6 @@ jobs:
       #- name: Remove current gradle cache
       #  run: rm -rf ~/.gradle
 
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+=="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
       # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux.
       # Enabling it allows the Android emulator to run faster.
       - name: Enable KVM group perms
@@ -59,9 +53,15 @@ jobs:
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAP_ACCESS_TOKEN }}
+          MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAP_DOWNLOADS_TOKEN }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo "\n" >> ./local.properties
+          echo "$MAPBOX_ACCESS_TOKEN" | base64 --decode >> ./local.properties
+          echo "\n" >> ./local.properties
+          echo "$MAPBOX_DOWNLOADS_TOKEN" | base64 --decode >> ./local.properties
 
       # Cache the Emulator, if the cache does not hit, create the emulator
       - name: AVD cache

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,9 +57,7 @@ jobs:
           MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAP_DOWNLOADS_TOKEN }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-          echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
-          echo "\n" >> ./local.properties
-          echo "$MAPBOX_ACCESS_TOKEN" | base64 --decode >> ./local.properties
+          echo "$MAPBOX_ACCESS_TOKEN" | base64 --decode > ./local.properties
           echo "\n" >> ./local.properties
           echo "$MAPBOX_DOWNLOADS_TOKEN" | base64 --decode >> ./local.properties
 


### PR DESCRIPTION
Access and Downloads Tokens were added to the decode step.

Removed a duplicated step (Enable KVM group perms)