### PR TITLE
cicd: add Sonar code coverage communication

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,8 +26,8 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of Sonar analysis
 
       # Caused issues during the bootcamp. If any arise in this project, uncomment these lines
-      - name: Remove current gradle cache
-        run: rm -rf ~/.gradle
+      #- name: Remove current gradle cache
+      #  run: rm -rf ~/.gradle
 
       # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux.
       # Enabling it allows the Android emulator to run faster.

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -120,8 +120,8 @@ jobs:
           ./gradlew jacocoTestReport
 
       # Upload the various reports to sonar
-      #- name: Upload report to SonarCloud
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #  run: ./gradlew sonar --parallel --build-cache
+      - name: Upload report to SonarCloud
+        env:
+          GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --parallel --build-cache

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.gms)
+    alias(libs.plugins.sonar)
 
 }
 
@@ -144,7 +145,20 @@ android {
 }
 
 
-
+sonar {
+    properties {
+        property("sonar.projectKey", "gf_android-sample")
+        property("sonar.projectName", "Android-Sample")
+        property("sonar.organization", "gabrielfleischer")
+        property("sonar.host.url", "https://sonarcloud.io")
+        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
+        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
+        property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+        // Paths to JaCoCo XML coverage report files.
+        property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+    }
+}
 
 dependencies {
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,13 +8,11 @@ plugins {
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.gms)
     alias(libs.plugins.sonar)
-
 }
 
 android {
     namespace = "com.github.se.cyrcle"
     compileSdk = 34
-
 
     // Load the API key from local.properties
     val localProperties = Properties()
@@ -24,7 +22,6 @@ android {
     }
 
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
-
 
     defaultConfig {
         applicationId = "com.github.se.cyrcle"
@@ -59,7 +56,6 @@ android {
     } else {
         throw GradleException("mapbox_access_token not found in local.properties")
     }
-
 
     buildTypes {
         release {
@@ -103,7 +99,6 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
-
             isReturnDefaultValues = true
         }
         packaging {
@@ -112,7 +107,6 @@ android {
             }
         }
     }
-
 
     buildFeatures {
         compose = true
@@ -140,8 +134,6 @@ android {
         res.setSrcDirs(emptyList<File>())
         resources.setSrcDirs(emptyList<File>())
     }
-
-
 }
 
 
@@ -160,8 +152,8 @@ sonar {
     }
 }
 
-dependencies {
 
+dependencies {
     // Core
     implementation(libs.core.ktx)
     implementation(libs.androidx.core.ktx)
@@ -245,10 +237,7 @@ dependencies {
         exclude(group = "com.google.protobuf", module = "protobuf-lite")
     }
 
-
             testImplementation(libs.kotlinx.coroutines.test)
-
-
 }
 
 
@@ -289,8 +278,3 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
 }
-
-
-
-
-

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,9 +139,9 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "gf_android-sample")
-        property("sonar.projectName", "Android-Sample")
-        property("sonar.organization", "gabrielfleischer")
+        property("sonar.projectKey", "SwEnt-Fall-2024-Group-22_Cyrcle")
+        property("sonar.projectName", "Cyrcle")
+        property("sonar.organization", "swent-fall-2024-group-22")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ mockkAgent = "1.13.7"
 mockkAndroid = "1.13.7"
 navigationCompose = "2.7.7"
 robolectric = "4.11.1"
+sonar = "4.4.1.3373"
 
 
 # AndroidX and Core Libraries
@@ -128,3 +129,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
+sonar = { id = "org.sonarqube", version.ref = "sonar" }


### PR DESCRIPTION
Add SonarCloud Code coverage.
- Requirement is 80%

NOTE : The secret name has been change because `GITHUB_` isn't a valid prefix to declare secrets on the repo.

Close #31 