### PR TITLE
Improve the map style

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,6 +190,8 @@ dependencies {
             implementation(libs.maps.compose.utils)
             implementation(libs.play.services.auth)
 
+    // add material icons
+    implementation(libs.androidx.material.icons.extended)
             // Firebase
             implementation(libs.firebase.database.ktx)
             implementation(libs.firebase.firestore)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -265,6 +265,7 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         "**/*Test*.*",
         "android/**/*.*",
         "**/sigchecks/**",
+        "**/preview/**"
     )
     val debugTree = fileTree("${layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
         exclude(fileFilter)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -33,5 +33,10 @@ class MapScreenTest : TestCase() {
 
     composeTestRule.onNodeWithTag("MapScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("BottomNavigationBar").assertIsDisplayed()
+
+    // Assert that the zoom controls are displayed
+    composeTestRule.onNodeWithTag("ZoomControls").assertIsDisplayed()
+    // Assert that the add button is displayed
+    composeTestRule.onNodeWithTag("AddButton").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -1,64 +1,29 @@
 package com.github.se.cyrcle.ui.map
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement.End
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.ui.map.overlay.AddButton
+import com.github.se.cyrcle.ui.map.overlay.ZoomControls
 import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
-import com.github.se.cyrcle.ui.theme.Cerulean
-import com.github.se.cyrcle.ui.theme.CyrcleTheme
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mapbox.maps.extension.compose.style.GenericStyle
-
-@Composable
-fun ZoomControls(onZoomIn: () -> Unit, onZoomOut: () -> Unit) {
-  CyrcleTheme {
-    Row(horizontalArrangement = End, modifier = Modifier.fillMaxWidth()) {
-      Column(
-          modifier =
-              Modifier.padding(top = 35.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
-                  .background(Cerulean.copy(alpha = 0.75f), shape = RoundedCornerShape(8.dp))
-                  .sizeIn(maxWidth = 35.dp)) {
-            Box {
-              IconButton(onClick = onZoomIn) {
-                Icon(Icons.Default.Add, contentDescription = "Zoom In", tint = Color.White)
-              }
-            }
-            HorizontalDivider(thickness = 1.dp, color = Color.Gray)
-            Box {
-              IconButton(onClick = onZoomOut) {
-                Icon(Icons.Default.Remove, contentDescription = "Zoom Out", tint = Color.White)
-              }
-            }
-          }
-    }
-  }
-}
 
 @Composable
 fun MapScreen(navigationActions: NavigationActions) {
@@ -86,28 +51,31 @@ fun MapScreen(navigationActions: NavigationActions) {
             selectedItem = Route.MAP)
       }) { padding ->
         MapboxMap(
-            Modifier.fillMaxSize().padding(padding),
+            Modifier.fillMaxSize().padding(padding).testTag("MapScreen"),
             mapViewportState = mapViewportState,
             style = { GenericStyle(style = "mapbox://styles/mapbox/light-v11") })
 
-        Box {
-          ZoomControls(
-              onZoomIn = {
-                mapViewportState.setCameraOptions {
-                  zoom(mapViewportState.cameraState!!.zoom + 1.0)
-                }
-              },
-              onZoomOut = {
-                mapViewportState.setCameraOptions {
-                  zoom(mapViewportState.cameraState!!.zoom - 1.0)
-                }
-              })
-        }
+        Column(
+            Modifier.padding(padding).fillMaxHeight(),
+            verticalArrangement = Arrangement.SpaceBetween) {
+              Row(Modifier.padding(16.dp).fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                ZoomControls(
+                    onZoomIn = {
+                      mapViewportState.setCameraOptions {
+                        zoom(mapViewportState.cameraState!!.zoom + 1.0)
+                      }
+                    },
+                    onZoomOut = {
+                      mapViewportState.setCameraOptions {
+                        zoom(mapViewportState.cameraState!!.zoom - 1.0)
+                      }
+                    })
+              }
+              Row(
+                  Modifier.padding(top = 16.dp).fillMaxWidth(),
+                  horizontalArrangement = Arrangement.Start) {
+                    AddButton { println("Add button clicked") }
+                  }
+            }
       }
-}
-// Zoom controls preview
-@Preview
-@Composable
-fun ZoomControlsPreview() {
-  ZoomControls(onZoomIn = {}, onZoomOut = {})
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -21,7 +21,7 @@ import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
-import com.mapbox.maps.extension.compose.style.GenericStyle
+import com.mapbox.maps.extension.compose.style.MapStyle
 
 @Composable
 fun MapScreen(navigationActions: NavigationActions) {
@@ -44,7 +44,7 @@ fun MapScreen(navigationActions: NavigationActions) {
         MapboxMap(
             Modifier.fillMaxSize().padding(padding).testTag("MapScreen"),
             mapViewportState = mapViewportState,
-            style = { GenericStyle(style = "mapbox://styles/mapbox/light-v11") })
+            style = { MapStyle("mapbox://styles/seanprz/cm27wh9ff00jl01r21jz3hcb1") })
 
         Column(
             Modifier.padding(padding).fillMaxHeight(),

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -1,24 +1,84 @@
 package com.github.se.cyrcle.ui.map
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.End
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
+import com.github.se.cyrcle.ui.theme.Cerulean
+import com.github.se.cyrcle.ui.theme.CyrcleTheme
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mapbox.maps.extension.compose.style.GenericStyle
+
+@Composable
+fun ZoomControls(onZoomIn: () -> Unit, onZoomOut: () -> Unit) {
+  CyrcleTheme {
+    Row(horizontalArrangement = End, modifier = Modifier.fillMaxWidth()) {
+      Column(
+          modifier =
+              Modifier.padding(top = 35.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
+                  .background(Cerulean.copy(alpha = 0.75f), shape = RoundedCornerShape(8.dp))
+                  .sizeIn(maxWidth = 35.dp)) {
+            Box {
+              IconButton(onClick = onZoomIn) {
+                Icon(Icons.Default.Add, contentDescription = "Zoom In", tint = Color.White)
+              }
+            }
+            HorizontalDivider(thickness = 1.dp, color = Color.Gray)
+            Box {
+              IconButton(onClick = onZoomOut) {
+                Icon(Icons.Default.Remove, contentDescription = "Zoom Out", tint = Color.White)
+              }
+            }
+          }
+    }
+  }
+}
 
 @Composable
 fun MapScreen(navigationActions: NavigationActions) {
-
+  val mapViewportState = rememberMapViewportState {
+    setCameraOptions {
+      zoom(16.0)
+      center(Point.fromLngLat(6.566, 46.519))
+      pitch(0.0)
+      bearing(0.0)
+    }
+  }
+  LaunchedEffect(mapViewportState.cameraState) {
+    snapshotFlow { mapViewportState.cameraState?.center }
+        .collect { centerPoint ->
+          centerPoint?.let {
+            println("Center Point: Latitude = ${it.latitude()}, Longitude = ${it.longitude()}")
+          }
+        }
+  }
   Scaffold(
-      modifier = Modifier.fillMaxSize().testTag("MapScreen"),
       bottomBar = {
         BottomNavigationBar(
             onTabSelect = { navigationActions.navigateTo(it) },
@@ -27,14 +87,27 @@ fun MapScreen(navigationActions: NavigationActions) {
       }) { padding ->
         MapboxMap(
             Modifier.fillMaxSize().padding(padding),
-            mapViewportState =
-                rememberMapViewportState {
-                  setCameraOptions {
-                    zoom(2.0)
-                    center(Point.fromLngLat(-98.0, 39.5))
-                    pitch(0.0)
-                    bearing(0.0)
-                  }
-                })
+            mapViewportState = mapViewportState,
+            style = { GenericStyle(style = "mapbox://styles/mapbox/light-v11") })
+
+        Box {
+          ZoomControls(
+              onZoomIn = {
+                mapViewportState.setCameraOptions {
+                  zoom(mapViewportState.cameraState!!.zoom + 1.0)
+                }
+              },
+              onZoomOut = {
+                mapViewportState.setCameraOptions {
+                  zoom(mapViewportState.cameraState!!.zoom - 1.0)
+                }
+              })
+        }
       }
+}
+// Zoom controls preview
+@Preview
+@Composable
+fun ZoomControlsPreview() {
+  ZoomControls(onZoomIn = {}, onZoomOut = {})
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -35,14 +33,7 @@ fun MapScreen(navigationActions: NavigationActions) {
       bearing(0.0)
     }
   }
-  LaunchedEffect(mapViewportState.cameraState) {
-    snapshotFlow { mapViewportState.cameraState?.center }
-        .collect { centerPoint ->
-          centerPoint?.let {
-            println("Center Point: Latitude = ${it.latitude()}, Longitude = ${it.longitude()}")
-          }
-        }
-  }
+
   Scaffold(
       bottomBar = {
         BottomNavigationBar(

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.ui.theme.Cerulean
 
@@ -29,10 +28,4 @@ fun AddButton(onClick: () -> Unit) {
           Icon(Icons.Default.Add, contentDescription = "Add", tint = Color.White)
         }
   }
-}
-
-@Preview
-@Composable
-fun AddButtonPreview() {
-  AddButton({})
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
@@ -9,23 +9,26 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.se.cyrcle.ui.theme.Cerulean
+import com.github.se.cyrcle.ui.theme.CyrcleTheme
 
 @Composable
 fun AddButton(onClick: () -> Unit) {
-  Box(Modifier.padding(16.dp)) {
-    IconButton(
-        onClick = onClick,
-        modifier =
-            Modifier.size(48.dp)
-                .background(color = Cerulean, shape = CircleShape)
-                .testTag("AddButton")) {
-          Icon(Icons.Default.Add, contentDescription = "Add", tint = Color.White)
-        }
+  CyrcleTheme {
+    Box(Modifier.padding(16.dp)) {
+      IconButton(
+          onClick = onClick,
+          modifier =
+              Modifier.size(48.dp)
+                  .background(color = MaterialTheme.colorScheme.primary, shape = CircleShape)
+                  .testTag("AddButton")) {
+            Icon(Icons.Default.Add, contentDescription = "Add", tint = Color.White)
+          }
+    }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.ui.theme.Cerulean
@@ -21,7 +22,10 @@ fun AddButton(onClick: () -> Unit) {
   Box(Modifier.padding(16.dp)) {
     IconButton(
         onClick = onClick,
-        modifier = Modifier.size(48.dp).background(color = Cerulean, shape = CircleShape)) {
+        modifier =
+            Modifier.size(48.dp)
+                .background(color = Cerulean, shape = CircleShape)
+                .testTag("AddButton")) {
           Icon(Icons.Default.Add, contentDescription = "Add", tint = Color.White)
         }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
@@ -1,0 +1,34 @@
+package com.github.se.cyrcle.ui.map.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.ui.theme.Cerulean
+
+@Composable
+fun AddButton(onClick: () -> Unit) {
+  Box(Modifier.padding(16.dp)) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.size(48.dp).background(color = Cerulean, shape = CircleShape)) {
+          Icon(Icons.Default.Add, contentDescription = "Add", tint = Color.White)
+        }
+  }
+}
+
+@Preview
+@Composable
+fun AddButtonPreview() {
+  AddButton({})
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/ZoomControls.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/ZoomControls.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.ui.theme.CyrcleTheme
@@ -26,7 +27,8 @@ fun ZoomControls(onZoomIn: () -> Unit, onZoomOut: () -> Unit) {
         modifier =
             Modifier.padding(15.dp)
                 .background(Color.Black.copy(alpha = 0.70f), shape = RoundedCornerShape(8.dp))
-                .sizeIn(maxWidth = 35.dp)) {
+                .sizeIn(maxWidth = 35.dp)
+                .testTag("ZoomControls")) {
           Box {
             IconButton(onClick = onZoomIn) {
               Icon(Icons.Default.Add, contentDescription = "Zoom In", tint = Color.White)

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/ZoomControls.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/ZoomControls.kt
@@ -1,0 +1,50 @@
+package com.github.se.cyrcle.ui.map.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.ui.theme.CyrcleTheme
+
+@Composable
+fun ZoomControls(onZoomIn: () -> Unit, onZoomOut: () -> Unit) {
+  CyrcleTheme {
+    Column(
+        modifier =
+            Modifier.padding(15.dp)
+                .background(Color.Black.copy(alpha = 0.70f), shape = RoundedCornerShape(8.dp))
+                .sizeIn(maxWidth = 35.dp)) {
+          Box {
+            IconButton(onClick = onZoomIn) {
+              Icon(Icons.Default.Add, contentDescription = "Zoom In", tint = Color.White)
+            }
+          }
+          HorizontalDivider(thickness = 1.dp, color = Color.Gray)
+          Box {
+            IconButton(onClick = onZoomOut) {
+              Icon(Icons.Default.Remove, contentDescription = "Zoom Out", tint = Color.White)
+            }
+          }
+        }
+  }
+}
+
+// Zoom controls preview
+@Preview
+@Composable
+fun ZoomControlsPreview() {
+  ZoomControls(onZoomIn = {}, onZoomOut = {})
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/ZoomControls.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/ZoomControls.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.ui.theme.CyrcleTheme
 
@@ -42,11 +41,4 @@ fun ZoomControls(onZoomIn: () -> Unit, onZoomOut: () -> Unit) {
           }
         }
   }
-}
-
-// Zoom controls preview
-@Preview
-@Composable
-fun ZoomControlsPreview() {
-  ZoomControls(onZoomIn = {}, onZoomOut = {})
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/preview/Preview.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/preview/Preview.kt
@@ -1,0 +1,19 @@
+package com.github.se.cyrcle.ui.map.overlay.preview
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.github.se.cyrcle.ui.map.overlay.AddButton
+import com.github.se.cyrcle.ui.map.overlay.ZoomControls
+
+// Zoom controls preview
+@Preview
+@Composable
+fun ZoomControlsPreview() {
+  ZoomControls(onZoomIn = {}, onZoomOut = {})
+}
+
+@Preview
+@Composable
+fun AddButtonPreview() {
+  AddButton({})
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ gms = "4.4.2"
 ktfmt = "0.17.0"
 
 # UI Compose
+materialIconsFilled = "1.0.0-alpha06"
 mockitoAndroid = "5.13.0"
 ui = "1.6.8"
 uiTestJunit4 = "1.6.8"
@@ -79,6 +80,8 @@ androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-material = { module = "androidx.compose.material:material", version.ref = "material" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+androidx-material-icons-filled = { module = "androidx.compose.material3:material-icons-filled", version.ref = "materialIconsFilled" }
 androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationCompose" }


### PR DESCRIPTION
_Closes #35_ 
### Improving the user interface of the map. 
This PR adds buttons to zoom in/out and another one to launch the process of adding new parking spots.
It also improves the style of the map to a monochromatic one, and center it by default on EPFL with an appropriate zoom level.


<img width="337" alt="image" src="https://github.com/user-attachments/assets/c76d4679-9c69-454e-8fbd-b5dbe0819161">


**Note** The add buttons onClick behaviour is not defined in this PR. 

-- -
Code coverage screenshot while Sonar CI is not setup
<img width="848" alt="image" src="https://github.com/user-attachments/assets/67f6aba8-3058-4618-b029-124d9a295909">

PS: Please let me merge my PR.
Thanks for the review, Sean