### PR TITLE
Fix: use our colors for the theme instead of default one

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/Theme.kt
@@ -1,20 +1,16 @@
 package com.github.se.cyrcle.ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme =
     darkColorScheme(primary = Cerulean, secondary = White, tertiary = Black)
 
 private val LightColorScheme =
-    lightColorScheme(primary = DarkBlue, secondary = LightBlue, tertiary = Black)
+    lightColorScheme(primary = Cerulean, secondary = LightBlue, tertiary = Black)
 
 /* Other default colors to override if/when needed
 background = Color(0xFFFFFBFE),
@@ -27,20 +23,12 @@ onSurface = Color(0xFF1C1B1F),
 */
 
 @Composable
-fun CyrcleTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
-    content: @Composable () -> Unit
-) {
+fun CyrcleTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
   val colorScheme =
-      when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-          val context = LocalContext.current
-          if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+      if (darkTheme) {
+        DarkColorScheme
+      } else {
+        LightColorScheme
       }
-
   MaterialTheme(colorScheme = colorScheme, typography = Typography, content = content)
 }


### PR DESCRIPTION
_Closes #40_
### What
This smalls PR simplifes the theme by removing the dynamic color (Colors based on user setting/wallpaper ect).
### Why
We will not need to use dynamic color for our app, and this feature prevented our colors from being displayed.
We can now use `colors = MaterialTheme.colorScheme.primary` instead of hardcoded value