### PR TITLE
Integrate MapBox Points in the code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -176,6 +176,9 @@ dependencies {
             implementation ("com.mapbox.extension:maps-compose:11.7.0")
             implementation("com.mapbox.maps:android:11.7.0")
 
+            // Turf for MapBox
+            implementation (libs.mapbox.sdk.turf)
+
             // Coil
             implementation(libs.coil.compose)
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
@@ -7,6 +7,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestoreSettings
 import com.google.firebase.firestore.memoryCacheSettings
 import com.google.firebase.firestore.persistentCacheSettings
+import com.mapbox.geojson.Point
 import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
@@ -74,8 +75,8 @@ class ParkingRepositoryFirestoreTest {
   fun getParkingsBetweenTest() = runBlocking {
     val countDownLatch = CountDownLatch(1)
     parkingRepositoryFirestore.getParkingsBetween(
-        Point(46.0, 6.0),
-        Point(47.0, 7.0),
+        Point.fromLngLat(6.0, 46.0),
+        Point.fromLngLat(7.0, 47.0),
         { parkings ->
           assert(parkings.size == 2)
           assert(parkings.contains(TestInstancesParking.parking1))
@@ -93,7 +94,7 @@ class ParkingRepositoryFirestoreTest {
 
     // Get the two closest parkings to the location
     parkingRepositoryFirestore.getKClosestParkings(
-        Point(47.1, 7.1),
+        Point.fromLngLat(7.1, 47.1),
         0,
         { parkings ->
           assert(parkings.isEmpty())
@@ -109,7 +110,7 @@ class ParkingRepositoryFirestoreTest {
     val latch = CountDownLatch(1)
     // Get the closest parkings to the location
     parkingRepositoryFirestore.getKClosestParkings(
-        Point(47.1, 7.1),
+        Point.fromLngLat(7.1, 47.1),
         1,
         { parkings ->
           assert(parkings.size == 1)
@@ -126,7 +127,7 @@ class ParkingRepositoryFirestoreTest {
     val latch = CountDownLatch(1)
     // Get the two closest parkings to the location
     parkingRepositoryFirestore.getKClosestParkings(
-        Point(46.69, 6.9),
+        Point.fromLngLat(6.9, 46.69),
         2,
         { parkings ->
           assert(parkings.size == 2)
@@ -144,7 +145,7 @@ class ParkingRepositoryFirestoreTest {
     val latch = CountDownLatch(1)
     // Get the two closest parkings to the location
     parkingRepositoryFirestore.getKClosestParkings(
-        Point(46.9, 6.7),
+        Point.fromLngLat(6.7, 46.9),
         2,
         { parkings ->
           assert(parkings.size == 1)
@@ -152,5 +153,7 @@ class ParkingRepositoryFirestoreTest {
           latch.countDown()
         },
         { fail("Failed to get parkings") })
+
+    latch.await()
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
@@ -1,5 +1,7 @@
 package com.github.se.cyrcle.model.parking
 
+import com.mapbox.geojson.Point
+
 /**
  * Data class representing a parking spot.
  *
@@ -57,19 +59,19 @@ enum class ParkingProtection {
 }
 
 data class Location(
-    val center: com.mapbox.geojson.Point,
-    val topLeft: com.mapbox.geojson.Point?,
-    val topRight: com.mapbox.geojson.Point?,
-    val bottomLeft: com.mapbox.geojson.Point?,
-    val bottomRight: com.mapbox.geojson.Point?,
+    val center: Point,
+    val topLeft: Point?,
+    val topRight: Point?,
+    val bottomLeft: Point?,
+    val bottomRight: Point?,
 ) {
   constructor(
-      topLeft: com.mapbox.geojson.Point,
-      topRight: com.mapbox.geojson.Point,
-      bottomLeft: com.mapbox.geojson.Point,
-      bottomRight: com.mapbox.geojson.Point
+      topLeft: Point,
+      topRight: Point,
+      bottomLeft: Point,
+      bottomRight: Point
   ) : this(
-      com.mapbox.geojson.Point.fromLngLat(
+      Point.fromLngLat(
           (topLeft.longitude() + bottomRight.longitude()) / 2,
           (topLeft.latitude() + bottomRight.latitude()) / 2),
       topLeft,
@@ -77,5 +79,5 @@ data class Location(
       bottomLeft,
       bottomRight)
 
-  constructor(center: com.mapbox.geojson.Point) : this(center, null, null, null, null)
+  constructor(center: Point) : this(center, null, null, null, null)
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
@@ -1,8 +1,5 @@
 package com.github.se.cyrcle.model.parking
 
-import kotlin.math.pow
-import kotlin.math.sqrt
-
 /**
  * Data class representing a parking spot.
  *
@@ -59,37 +56,26 @@ enum class ParkingProtection {
   NONE
 }
 
-data class Point(val latitude: Double, val longitude: Double) {
-  override fun toString(): String {
-    return "Point(latitude=$latitude, longitude=$longitude)"
-  }
-
-  fun distanceTo(other: Point): Double {
-    return sqrt((latitude - other.latitude).pow(2) + (longitude - other.longitude).pow(2))
-  }
-}
-
 data class Location(
-    // TODO replace with Point Mapbox.Point
-    val topLeft: Point?,
-    val topRight: Point?,
-    val bottomLeft: Point?,
-    val bottomRight: Point?,
-    val center: Point?
+    val center: com.mapbox.geojson.Point,
+    val topLeft: com.mapbox.geojson.Point?,
+    val topRight: com.mapbox.geojson.Point?,
+    val bottomLeft: com.mapbox.geojson.Point?,
+    val bottomRight: com.mapbox.geojson.Point?,
 ) {
   constructor(
-      topLeft: Point,
-      topRight: Point,
-      bottomLeft: Point,
-      bottomRight: Point
+      topLeft: com.mapbox.geojson.Point,
+      topRight: com.mapbox.geojson.Point,
+      bottomLeft: com.mapbox.geojson.Point,
+      bottomRight: com.mapbox.geojson.Point
   ) : this(
+      com.mapbox.geojson.Point.fromLngLat(
+          (topLeft.longitude() + bottomRight.longitude()) / 2,
+          (topLeft.latitude() + bottomRight.latitude()) / 2),
       topLeft,
       topRight,
       bottomLeft,
-      bottomRight,
-      Point(
-          (topLeft.latitude + bottomRight.latitude) / 2,
-          (topLeft.longitude + bottomRight.longitude) / 2))
+      bottomRight)
 
-  constructor(center: Point) : this(null, null, null, null, center)
+  constructor(center: com.mapbox.geojson.Point) : this(center, null, null, null, null)
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
@@ -1,5 +1,7 @@
 package com.github.se.cyrcle.model.parking
 
+import com.mapbox.geojson.Point
+
 interface ParkingRepository {
   /**
    * Get a new unique identifier for a parking

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
@@ -157,6 +157,12 @@ class ParkingRepositoryFirestore(private val db: FirebaseFirestore) : ParkingRep
         .addOnFailureListener { onFailure(it) }
   }
 
+  /**
+   * Serializes a Parking object to a Map
+   *
+   * @param parking The Parking object to serialize
+   * @return The serialized Map
+   */
   private fun serializeParking(parking: Parking): Map<String, Any> {
     val gson = Gson()
     val type = object : TypeToken<Map<String, Any>>() {}.type
@@ -183,6 +189,12 @@ class ParkingRepositoryFirestore(private val db: FirebaseFirestore) : ParkingRep
     return parkingMap
   }
 
+  /**
+   * Deserializes a Map to a Parking object
+   *
+   * @param map The map to deserialize
+   * @return The deserialized Parking object
+   */
   private fun deserializeParking(map: Map<String, Any>): Parking {
     val gson = Gson()
     val type = object : TypeToken<Map<String, Any>>() {}.type
@@ -215,21 +227,53 @@ class ParkingRepositoryFirestore(private val db: FirebaseFirestore) : ParkingRep
   }
 }
 
+/**
+ * Helper class to serialize and deserialize Mapbox Point to and from a Map to be stored in
+ * Firestore. Storing Mapbox Point directly in Firestore does not meet our needs as the coordinates
+ * are stored as an array of doubles. This prevents querying for parkings within a certain range of
+ * a location.
+ *
+ * @param longitude The longitude of the point
+ * @param latitude The latitude of the point
+ */
 private data class Point2D(val longitude: Double, val latitude: Double) {
+  /** Companion object to provide helper functions to convert between Mapbox Point and Point2D */
   companion object {
+    /**
+     * Converts a Mapbox Point to a Point2D
+     *
+     * @param point The Mapbox Point to convert
+     * @return The converted Point2D
+     */
     fun fromMapboxPoint(point: Point): Point2D {
       return Point2D(point.longitude(), point.latitude())
     }
 
+    /**
+     * Converts a Map to a Point2D object for deserialization
+     *
+     * @param map The map to convert
+     * @return The converted Point2D
+     */
     fun fromSerializedMap(map: Map<String, Double>): Point2D {
       return Point2D(map["longitude"]!!, map["latitude"]!!)
     }
   }
 
+  /**
+   * Converts the Point2D to a Mapbox Point
+   *
+   * @return The converted Mapbox Point
+   */
   fun toMapboxPoint(): Point {
     return Point.fromLngLat(longitude, latitude)
   }
 
+  /**
+   * Converts the Point2D to a Map for serialization
+   *
+   * @return The converted Map
+   */
   fun toSerializedMap(): Map<String, Any> {
     return Gson().fromJson(Gson().toJson(this), object : TypeToken<Map<String, Any>>() {}.type)
   }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.mapbox.geojson.Point
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -1,12 +1,14 @@
 package com.github.se.cyrcle.model.parking
 
+import com.mapbox.geojson.Point
+
 object TestInstancesParking {
   val parking1 =
       Parking(
           "Test_spot_1",
           null,
           null,
-          Location(Point(46.2, 6.6)),
+          Location(Point.fromLngLat(6.6, 46.2)),
           listOf(
               "https://en.wikipedia.org/wiki/Bicycle_parking#/media/File:Bicycle_parking_at_Alewife_station,_August_2001.jpg"),
           ParkingCapacity.LARGE,
@@ -19,7 +21,7 @@ object TestInstancesParking {
           "Test_spot_2",
           null,
           null,
-          Location(Point(46.3, 6.7)),
+          Location(Point.fromLngLat(6.7, 46.3)),
           listOf(
               "https://en.wikipedia.org/wiki/Bicycle_parking#/media/File:Bicycle_parking_at_Alewife_station,_August_2001.jpg"),
           ParkingCapacity.SMALL,
@@ -32,7 +34,7 @@ object TestInstancesParking {
           "Test_spot_3",
           null,
           null,
-          Location(Point(47.1, 7.1)),
+          Location(Point.fromLngLat(7.1, 47.1)),
           listOf(
               "https://en.wikipedia.org/wiki/Bicycle_parking#/media/File:Bicycle_parking_at_Alewife_station,_August_2001.jpg"),
           ParkingCapacity.LARGE,

--- a/app/src/main/java/com/github/se/cyrcle/ui/card/CardScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/card/CardScreen.kt
@@ -34,10 +34,10 @@ import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
-import com.github.se.cyrcle.model.parking.Point
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.Cerulean
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+import com.mapbox.geojson.Point
 
 // Function to convert ParkingProtection enum to human-readable string
 fun convertProtectionToString(protection: ParkingProtection): String {
@@ -79,7 +79,7 @@ val parking1 =
         "Test_spot_1",
         null,
         null,
-        Location(Point(46.2, 6.6)),
+        Location(Point.fromLngLat(6.6, 46.2)),
         listOf(
             "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg",
             "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg",
@@ -96,7 +96,7 @@ val parking2 =
         "Test_spot_2",
         null,
         null,
-        Location(Point(46.3, 6.7)),
+        Location(Point.fromLngLat(6.7, 46.3)),
         listOf(
             "https://upload.wikimedia.org/wikipedia/commons/6/6b/Bicycle_parking_at_Alewife_station%2C_August_2001.jpg"), // Corrected URL
         ParkingCapacity.SMALL,
@@ -111,7 +111,7 @@ val parking3 =
         "Test_spot_3",
         null,
         null,
-        Location(Point(47.1, 7.1)),
+        Location(Point.fromLngLat(7.1, 47.1)),
         listOf(
             "https://upload.wikimedia.org/wikipedia/commons/6/6b/Bicycle_parking_at_Alewife_station%2C_August_2001.jpg"), // Corrected URL
         ParkingCapacity.LARGE,

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/List.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/List.kt
@@ -20,22 +20,20 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.DarkBlue
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.sin
-import kotlin.math.sqrt
+import com.mapbox.geojson.Point
+import com.mapbox.turf.TurfMeasurement
 
 // EXAMPLES
 
-val referencePoint1 =
-    Point(0.0, 0.0) // Hardcoded. Will be the location via GPS of the user of the app.
+val referencePoint1: Point =
+    Point.fromLngLat(0.0, 0.0) // Hardcoded. Will be the location via GPS of the user of the app.
 val parkingSpots1 =
     listOf(
         Parking(
             uid = "1",
             optName = "City Center Parking",
             optDescription = "Covered parking near the city center",
-            location = Location(Point(0.3, 0.3)),
+            location = Location(Point.fromLngLat(0.3, 0.3)),
             images = listOf(),
             capacity = ParkingCapacity.MEDIUM,
             rackType = ParkingRackType.U_RACK,
@@ -46,7 +44,7 @@ val parkingSpots1 =
             uid = "2",
             optName = "Bike Hub Downtown",
             optDescription = "Secure indoor bike hub with surveillance",
-            location = Location(Point(0.5, 0.5)),
+            location = Location(Point.fromLngLat(0.5, 0.5)),
             images = listOf(),
             capacity = ParkingCapacity.LARGE,
             rackType = ParkingRackType.TWO_TIER,
@@ -57,7 +55,7 @@ val parkingSpots1 =
             uid = "3",
             optName = "Mall Parking",
             optDescription = "Outdoor parking at the shopping mall",
-            location = Location(Point(1.2, 1.2)),
+            location = Location(Point.fromLngLat(1.2, 1.2)),
             images = listOf(),
             capacity = ParkingCapacity.SMALL,
             rackType = ParkingRackType.POST_AND_RING,
@@ -68,7 +66,7 @@ val parkingSpots1 =
             uid = "4",
             optName = "Green Park Bike Racks",
             optDescription = "Bike parking near the park entrance",
-            location = Location(Point(0.8, 0.8)),
+            location = Location(Point.fromLngLat(0.8, 0.8)),
             images = listOf(),
             capacity = ParkingCapacity.XSMALL,
             rackType = ParkingRackType.WALL_BUTTERFLY,
@@ -79,7 +77,7 @@ val parkingSpots1 =
             uid = "5",
             optName = "Office Tower Garage",
             optDescription = "Indoor parking with two-tier racks",
-            location = Location(Point(2.1, 2.1)),
+            location = Location(Point.fromLngLat(2.1, 2.1)),
             images = listOf(),
             capacity = ParkingCapacity.LARGE,
             rackType = ParkingRackType.TWO_TIER,
@@ -90,7 +88,7 @@ val parkingSpots1 =
             uid = "6",
             optName = "Station Parking",
             optDescription = "Covered parking next to the train station",
-            location = Location(Point(1.5, 1.5)),
+            location = Location(Point.fromLngLat(1.5, 1.5)),
             images = listOf(),
             capacity = ParkingCapacity.MEDIUM,
             rackType = ParkingRackType.GRID,
@@ -101,7 +99,7 @@ val parkingSpots1 =
             uid = "7",
             optName = "University Bike Shelter",
             optDescription = "Secure parking for students and staff",
-            location = Location(Point(3.0, 3.0)),
+            location = Location(Point.fromLngLat(3.0, 3.0)),
             images = listOf(),
             capacity = ParkingCapacity.XLARGE,
             rackType = ParkingRackType.WAVE,
@@ -112,7 +110,7 @@ val parkingSpots1 =
             uid = "8",
             optName = "Residential Parking",
             optDescription = "Outdoor parking for residents",
-            location = Location(Point(0.9, 0.9)),
+            location = Location(Point.fromLngLat(0.9, 0.9)),
             images = listOf(),
             capacity = ParkingCapacity.SMALL,
             rackType = ParkingRackType.U_RACK,
@@ -123,7 +121,7 @@ val parkingSpots1 =
             uid = "9",
             optName = "Beachfront Bike Racks",
             optDescription = "Bike parking near the beach with no cover",
-            location = Location(Point(1.8, 1.8)),
+            location = Location(Point.fromLngLat(1.8, 1.8)),
             images = listOf(),
             capacity = ParkingCapacity.XSMALL,
             rackType = ParkingRackType.GRID,
@@ -134,7 +132,7 @@ val parkingSpots1 =
             uid = "10",
             optName = "Suburban Garage",
             optDescription = "Spacious indoor parking in suburban areas",
-            location = Location(Point(2.5, 2.5)),
+            location = Location(Point.fromLngLat(2.5, 2.5)),
             images = listOf(),
             capacity = ParkingCapacity.MEDIUM,
             rackType = ParkingRackType.VERTICAL,
@@ -333,7 +331,7 @@ fun SpotListScreen(
 ) {
   val sortedParkingSpots =
       parkingSpots.map { parking ->
-        parking to calculateDistance(referencePoint, parking.location.center!!)
+        parking to TurfMeasurement.distance(referencePoint, parking.location.center)
       }
 
   var selectedProtection by remember { mutableStateOf<Set<ParkingProtection>>(emptySet()) }
@@ -418,25 +416,4 @@ fun SpotListScreen(
               }
             }
       }
-}
-
-// Extension fuction to toggle selection
-fun <T> Set<T>.toggle(item: T): Set<T> {
-  return if (this.contains(item)) this - item else this + item
-}
-
-fun calculateDistance(point1: Point, point2: Point): Double {
-  val R = 6371.0 // Radius of the Earth in kilometers
-  val latDistance = Math.toRadians(point2.latitude - point1.latitude)
-  val lonDistance = Math.toRadians(point2.longitude - point1.longitude)
-
-  val a =
-      sin(latDistance / 2) * sin(latDistance / 2) +
-          cos(Math.toRadians(point1.latitude)) *
-              cos(Math.toRadians(point2.latitude)) *
-              sin(lonDistance / 2) *
-              sin(lonDistance / 2)
-
-  val c = 2 * atan2(sqrt(a), sqrt(1 - a))
-  return R * c // Distance in kilometers
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
@@ -236,4 +236,40 @@ class ParkingRepositoryFirestoreTest {
 
     verify(mockDocumentReference).delete()
   }
+
+  /*
+  // This test is commented out because the serializeParking and deserializeParking methods are
+  // private
+  private val parking2 =
+      Parking(
+          uid = "2",
+          optName = "Parking",
+          optDescription = null,
+          location =
+              Location(
+                  Point.fromLngLat(6.545, 46.518),
+                  Point.fromLngLat(6.546, 46.518),
+                  Point.fromLngLat(6.546, 46.519),
+                  Point.fromLngLat(6.545, 46.519)),
+          images = listOf(imageUrl),
+          capacity = ParkingCapacity.LARGE,
+          rackType = ParkingRackType.U_RACK,
+          protection = ParkingProtection.COVERED,
+          price = 0.0,
+          hasSecurity = true)
+
+  @Test
+  fun serializeParking_and_deserializeParking() {
+    val serializedParking = parkingRepositoryFirestore.serializeParking(parking)
+    val deserializedParking = parkingRepositoryFirestore.deserializeParking(serializedParking)
+
+    assert(parking == deserializedParking)
+
+    val serializedParking2 = parkingRepositoryFirestore.serializeParking(parking2)
+    val deserializedParking2 = parkingRepositoryFirestore.deserializeParking(serializedParking2)
+
+    assert(parking2 == deserializedParking2)
+  }
+
+   */
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
@@ -9,6 +9,7 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import com.mapbox.geojson.Point
 import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
@@ -39,7 +40,7 @@ class ParkingRepositoryFirestoreTest {
           uid = "1",
           optName = "Parking",
           optDescription = null,
-          location = Location(Point(46.518, 6.545)),
+          location = Location(Point.fromLngLat(6.545, 46.518), null, null, null, null),
           images = listOf(imageUrl),
           capacity = ParkingCapacity.LARGE,
           rackType = ParkingRackType.U_RACK,
@@ -162,8 +163,8 @@ class ParkingRepositoryFirestoreTest {
 
     // Call the method under test
     parkingRepositoryFirestore.getParkingsBetween(
-        start = Point(46.5, 6.5),
-        end = Point(46.6, 6.6),
+        start = Point.fromLngLat(6.5, 46.5),
+        end = Point.fromLngLat(6.6, 46.6),
         onSuccess = { parkings ->
           // Assert that the returned list contains the expected Parking object
           assert(parkings.size == 1)
@@ -195,7 +196,7 @@ class ParkingRepositoryFirestoreTest {
 
     // Call the method under test
     parkingRepositoryFirestore.getKClosestParkings(
-        location = Point(46.5, 6.5),
+        location = Point.fromLngLat(6.5, 46.5),
         k = 1,
         onSuccess = { parkings ->
           // Assert that the returned list contains the expected Parking object

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.parking
 
+import com.mapbox.geojson.Point
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -9,7 +10,7 @@ class ParkingsTest {
 
   @Test
   fun testConstructor() {
-    val point = Point(46.518, 6.545)
+    val point = Point.fromLngLat(6.545, 46.518)
     val location = Location(point)
     val parking =
         Parking(
@@ -43,7 +44,7 @@ class ParkingsTest {
             uid = "1",
             optName = "Parking",
             optDescription = null,
-            location = Location(Point(46.518, 6.545)),
+            location = Location(Point.fromLngLat(6.545, 46.518)),
             images = listOf("image_url"),
             capacity = ParkingCapacity.LARGE,
             rackType = ParkingRackType.U_RACK,
@@ -56,7 +57,7 @@ class ParkingsTest {
             uid = "1",
             optName = "Parking",
             optDescription = null,
-            location = Location(Point(46.518, 6.545)),
+            location = Location(Point.fromLngLat(6.545, 46.518)),
             images = listOf("image_url"),
             capacity = ParkingCapacity.LARGE,
             rackType = ParkingRackType.U_RACK,

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.parking
 
+import com.mapbox.geojson.Point
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -57,7 +58,7 @@ class ParkingViewModelTest {
     }
 
     // Get parkings between the two points
-    parkingViewModel.getParkingsInRect(Point(46.0, 6.0), Point(47.0, 7.0))
+    parkingViewModel.getParkingsInRect(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(7.0, 47.0))
 
     // Check if the parkings returned are the correct ones
     val parkingsReturned = parkingViewModel.rectParkings.value
@@ -73,7 +74,7 @@ class ParkingViewModelTest {
     }
 
     // Get the two closest parkings to the location
-    parkingViewModel.getKClosestParkings(Point(47.1, 7.1), 0)
+    parkingViewModel.getKClosestParkings(Point.fromLngLat(7.1, 47.1), 0)
 
     // Check if the parkings returned are the correct ones
     assert(parkingViewModel.kClosestParkings.value.isEmpty())
@@ -86,7 +87,7 @@ class ParkingViewModelTest {
     }
 
     // Get the two closest parkings to the location
-    parkingViewModel.getKClosestParkings(Point(47.1, 7.1), 1)
+    parkingViewModel.getKClosestParkings(Point.fromLngLat(7.1, 47.1), 1)
 
     // Check if the parkings returned are the correct ones
     val parkingsReturned = parkingViewModel.kClosestParkings.value

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ gms = "4.4.2"
 ktfmt = "0.17.0"
 
 # UI Compose
+mapboxSdkTurf = "5.8.0"
 materialIconsFilled = "1.0.0-alpha06"
 mockitoAndroid = "5.13.0"
 ui = "1.6.8"
@@ -108,6 +109,7 @@ kaspresso-allure-support = { module = "com.kaspersky.android-components:kaspress
 kaspresso-compose-support = { module = "com.kaspersky.android-components:kaspresso-compose-support", version.ref = "kaspressoComposeSupport" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+mapbox-sdk-turf = { module = "com.mapbox.mapboxsdk:mapbox-sdk-turf", version.ref = "mapboxSdkTurf" }
 maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 maps-compose-utils = { module = "com.google.maps.android:maps-compose-utils", version.ref = "mapsComposeUtils" }
 material = { module = "com.google.android.material:material", version.ref = "materialVersion" }


### PR DESCRIPTION
Closes #41

This pull request implements the solution proposed in the related issue. We've created a custom serialization and deserialization process for MapBox Points to meet our database requirements while still leveraging MapBox's functionality.

### Testing
A commented test (given that serializeParking and deserializeParking are private) has been added/updated to cover the new serialization/deserialization process
Manual testing has been performed to ensure seamless integration with existing functionality.

### Additional Notes
There are changes across multiple files, but the core functionality remains unaltered.
The TurfMeasurement dependency has been added to allow easy computations with Mapbox Points
The "center" attribute of Location can no longer be null. It has been moved to be the first attribute

### Use of com.mapbox.geojson.Point
**Create a point**: Use Point.fromLngLat(longitude, latitude)
**get the longitude of a point:** point.longitude()
**get the latitude of a point:** point.latitude()
**More functions** in the documentation: [Point documentation](https://docs.mapbox.com/android/java/api/libjava-geojson/7.2.0/com/mapbox/geojson/Point.html)