### PR TITLE
Navigation for the process of adding new parking spots

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/add/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/add/AddScreensNavigationTest.kt
@@ -1,7 +1,7 @@
-// MapScreenToAddScreenTest.kt
 package com.github.se.cyrcle.ui.add
 
 import CyrcleNavHost
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
@@ -14,8 +14,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.ui.map.MapScreen
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.navigation.Screen
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,16 +24,22 @@ import org.junit.runner.RunWith
 class AddScreensNavigationTest {
   @get:Rule val composeTestRule = createComposeRule()
 
+  @Composable
+  fun setUp(): Pair<NavigationActions, ParkingViewModel> {
+    val navController = rememberNavController()
+    val navigationActions = NavigationActions(navController)
+    val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
+    CyrcleNavHost(navigationActions, navController, parkingViewModel)
+    return Pair(navigationActions, parkingViewModel)
+  }
+
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun testAddButtonNavigatesToLocationPicker() {
 
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
-      CyrcleNavHost(navigationActions, navController, parkingViewModel)
-      navigationActions.navigateTo(Screen.MAP)
+      val (navigationActions, parkingViewModel) = setUp()
+      MapScreen(navigationActions, parkingViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("addButton"))
     // Perform click on the add button
@@ -48,11 +54,8 @@ class AddScreensNavigationTest {
   fun testNavigationToAttribute() {
 
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
-      CyrcleNavHost(navigationActions, navController, parkingViewModel)
-      navigationActions.navigateTo(Screen.LOCATION_PICKER)
+      val (navigationActions, parkingViewModel) = setUp()
+      LocationPicker(navigationActions, parkingViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("nextButton"))
     // Perform click on the add button
@@ -70,7 +73,7 @@ class AddScreensNavigationTest {
       val navigationActions = NavigationActions(navController)
       val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
       CyrcleNavHost(navigationActions, navController, parkingViewModel)
-      navigationActions.navigateTo(Screen.ATTRIBUTES_PICKER)
+      AttributesPicker(navigationActions, parkingViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("submitButton"))
     // Perform click on the add button
@@ -84,11 +87,8 @@ class AddScreensNavigationTest {
   @Test
   fun testCancel() {
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
-      CyrcleNavHost(navigationActions, navController, parkingViewModel)
-      navigationActions.navigateTo(Screen.ATTRIBUTES_PICKER)
+      val (navigationActions, parkingViewModel) = setUp()
+      AttributesPicker(navigationActions, parkingViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("cancelButton"))
     // Perform click on the add button
@@ -102,17 +102,12 @@ class AddScreensNavigationTest {
   @Test
   fun testCancel2() {
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
-      CyrcleNavHost(navigationActions, navController, parkingViewModel)
-      navigationActions.navigateTo(Screen.MAP)
+      val (navigationActions, parkingViewModel) = setUp()
+      LocationPicker(navigationActions, parkingViewModel)
     }
-    composeTestRule.onNodeWithTag("addButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("cancelButton"))
-    // Perform click on the add button
+    composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag("cancelButton").performClick()
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MapScreen"))
+    composeTestRule.waitUntilExactlyOneExists((hasTestTag("MapScreen")))
     composeTestRule.onNodeWithTag("MapScreen").assertExists().assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/add/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/add/AddScreensNavigationTest.kt
@@ -1,0 +1,118 @@
+// MapScreenToAddScreenTest.kt
+package com.github.se.cyrcle.ui.add
+
+import CyrcleNavHost
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddScreensNavigationTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testAddButtonNavigatesToLocationPicker() {
+
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
+      CyrcleNavHost(navigationActions, navController, parkingViewModel)
+      navigationActions.navigateTo(Screen.MAP)
+    }
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("addButton"))
+    // Perform click on the add button
+    composeTestRule.onNodeWithTag("addButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("LocationPickerScreen"))
+    // Wait until the Location Picker screen is displayed
+    composeTestRule.onNodeWithText("Where is the Parking ?").assertExists().isDisplayed()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testNavigationToAttribute() {
+
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
+      CyrcleNavHost(navigationActions, navController, parkingViewModel)
+      navigationActions.navigateTo(Screen.LOCATION_PICKER)
+    }
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("nextButton"))
+    // Perform click on the add button
+    composeTestRule.onNodeWithTag("nextButton").performClick()
+
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("AttributesPickerScreen"))
+    composeTestRule.onNodeWithTag("AttributesPickerScreen").assertExists().assertIsDisplayed()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testSubmit() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
+      CyrcleNavHost(navigationActions, navController, parkingViewModel)
+      navigationActions.navigateTo(Screen.ATTRIBUTES_PICKER)
+    }
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("submitButton"))
+    // Perform click on the add button
+    composeTestRule.onNodeWithTag("submitButton").performClick()
+
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MapScreen"))
+    composeTestRule.onNodeWithTag("MapScreen").assertExists().assertIsDisplayed()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testCancel() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
+      CyrcleNavHost(navigationActions, navController, parkingViewModel)
+      navigationActions.navigateTo(Screen.ATTRIBUTES_PICKER)
+    }
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("cancelButton"))
+    // Perform click on the add button
+    composeTestRule.onNodeWithTag("cancelButton").performClick()
+
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MapScreen"))
+    composeTestRule.onNodeWithTag("MapScreen").assertExists().assertIsDisplayed()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testCancel2() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
+      CyrcleNavHost(navigationActions, navController, parkingViewModel)
+      navigationActions.navigateTo(Screen.MAP)
+    }
+    composeTestRule.onNodeWithTag("addButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("cancelButton"))
+    // Perform click on the add button
+    composeTestRule.onNodeWithTag("cancelButton").performClick()
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MapScreen"))
+    composeTestRule.onNodeWithTag("MapScreen").assertExists().assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -57,7 +57,7 @@ class MapScreenTest : TestCase() {
     composeTestRule.onNodeWithTag("ZoomControlsOut").assertIsDisplayed()
 
     // Assert that the add button is displayed
-    composeTestRule.onNodeWithTag("AddButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addButton").assertIsDisplayed()
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -1,0 +1,50 @@
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.ui.add.AttributesPicker
+import com.github.se.cyrcle.ui.add.LocationPicker
+import com.github.se.cyrcle.ui.authentication.SignInScreen
+import com.github.se.cyrcle.ui.card.CardScreen
+import com.github.se.cyrcle.ui.list.SpotListScreen
+import com.github.se.cyrcle.ui.map.MapScreen
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Route
+import com.github.se.cyrcle.ui.navigation.Screen
+
+@Composable
+fun CyrcleNavHost(
+    navigationActions: NavigationActions,
+    navController: NavHostController,
+    parkingViewModel: ParkingViewModel
+) {
+  NavHost(navController = navController, startDestination = Route.AUTH) {
+    navigation(
+        startDestination = Screen.AUTH,
+        route = Route.AUTH,
+    ) {
+      composable(Screen.AUTH) { SignInScreen(navigationActions) }
+    }
+
+    navigation(
+        startDestination = Screen.LIST,
+        route = Route.LIST,
+    ) {
+      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel) }
+      composable(Screen.CARD) { CardScreen(navigationActions, parkingViewModel) }
+    }
+
+    navigation(
+        startDestination = Screen.MAP,
+        route = Route.MAP,
+    ) {
+      composable(Screen.MAP) { MapScreen(navigationActions, parkingViewModel) }
+    }
+    navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
+      composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, parkingViewModel) }
+      composable(Screen.ATTRIBUTES_PICKER) { AttributesPicker(navigationActions, parkingViewModel) }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle
 
+import CyrcleNavHost
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,20 +8,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navigation
 import com.github.se.cyrcle.model.parking.ImageRepositoryCloudStorage
 import com.github.se.cyrcle.model.parking.ParkingRepositoryFirestore
 import com.github.se.cyrcle.model.parking.ParkingViewModel
-import com.github.se.cyrcle.ui.authentication.SignInScreen
-import com.github.se.cyrcle.ui.card.CardScreen
-import com.github.se.cyrcle.ui.list.SpotListScreen
-import com.github.se.cyrcle.ui.map.MapScreen
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.navigation.Route
-import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.CyrcleTheme
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
@@ -46,34 +38,10 @@ class MainActivity : ComponentActivity() {
   fun CyrcleApp() {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
-
     val db = Firebase.firestore
     val parkingRepository = ParkingRepositoryFirestore(db)
     val imageRepository = ImageRepositoryCloudStorage(auth)
     val parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
-
-    NavHost(navController = navController, startDestination = Route.AUTH) {
-      navigation(
-          startDestination = Screen.AUTH,
-          route = Route.AUTH,
-      ) {
-        composable(Screen.AUTH) { SignInScreen(navigationActions) }
-      }
-
-      navigation(
-          startDestination = Screen.LIST,
-          route = Route.LIST,
-      ) {
-        composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel) }
-        composable(Screen.CARD) { CardScreen(navigationActions, parkingViewModel) }
-      }
-
-      navigation(
-          startDestination = Screen.MAP,
-          route = Route.MAP,
-      ) {
-        composable(Screen.MAP) { MapScreen(navigationActions, parkingViewModel) }
-      }
-    }
+    CyrcleNavHost(navigationActions, navController, parkingViewModel)
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/add/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/add/AttributesPicker.kt
@@ -1,0 +1,80 @@
+package com.github.se.cyrcle.ui.add
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
+import com.github.se.cyrcle.ui.theme.CyrcleTheme
+
+@Composable
+fun AttributesPicker(navigationActions: NavigationActions, parkingViewModel: ParkingViewModel) {
+  Scaffold(bottomBar = { BottomBarAddAttr(navigationActions) }) { padding ->
+    Column(modifier = Modifier.padding(padding)) {
+      Text("Attributes Picker", modifier = Modifier.testTag("AttributesPickerScreen"))
+    }
+    Text("Attributes Picker screen, where user select capaacites/rack , add pics ect...")
+  }
+}
+
+@Composable
+fun BottomBarAddAttr(navigationActions: NavigationActions) {
+  CyrcleTheme {
+    Box(Modifier.background(Color.White)) {
+      Row(
+          Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically) {
+            Button(
+                { navigationActions.navigateTo(TopLevelDestinations.MAP) },
+                modifier = Modifier.testTag("cancelButton"),
+                colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                  Text(
+                      "Cancel",
+                      color = MaterialTheme.colorScheme.primary,
+                      fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                      fontWeight = FontWeight.Bold,
+                      textAlign = TextAlign.Center)
+                }
+
+            VerticalDivider(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.height(32.dp).width(1.dp),
+                thickness = 2.dp)
+            Button(
+                { navigationActions.navigateTo(TopLevelDestinations.MAP) },
+                modifier = Modifier.testTag("submitButton"),
+                colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                  Text(
+                      "Submit",
+                      modifier = Modifier.width(100.dp),
+                      color = MaterialTheme.colorScheme.primary,
+                      fontWeight = FontWeight.Bold,
+                      textAlign = TextAlign.Center)
+                }
+          }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
@@ -1,0 +1,121 @@
+package com.github.se.cyrcle.ui.add
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import com.github.se.cyrcle.ui.theme.CyrcleTheme
+import com.mapbox.geojson.Point
+import com.mapbox.maps.extension.compose.MapboxMap
+import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mapbox.maps.extension.compose.style.MapStyle
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun LocationPicker(navigationActions: NavigationActions, parkingViewModel: ParkingViewModel) {
+  val mapViewportState = rememberMapViewportState {
+    setCameraOptions {
+      zoom(16.0)
+      center(Point.fromLngLat(6.566, 46.519))
+      pitch(0.0)
+      bearing(0.0)
+    }
+  }
+
+  Scaffold(bottomBar = { BottomBarAdd(navigationActions) }, topBar = { TopBarAdd() }) { padding ->
+    MapboxMap(
+        mapViewportState = mapViewportState,
+        style = { MapStyle("mapbox://styles/seanprz/cm27wh9ff00jl01r21jz3hcb1") },
+        modifier = Modifier.testTag("LocationPickerScreen"))
+  }
+}
+
+@Composable
+fun BottomBarAdd(navigationActions: NavigationActions) {
+  CyrcleTheme {
+    Box(Modifier.background(Color.White)) {
+      Row(
+          Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically) {
+            Button(
+                { navigationActions.goBack() },
+                modifier = Modifier.testTag("cancelButton"),
+                colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                  Text(
+                      "Cancel",
+                      modifier = Modifier.width(100.dp),
+                      color = MaterialTheme.colorScheme.primary,
+                      fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                      fontWeight = FontWeight.Bold,
+                      textAlign = TextAlign.Center)
+                }
+
+            VerticalDivider(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.height(32.dp).width(1.dp),
+                thickness = 2.dp)
+            Button(
+                { navigationActions.navigateTo(Screen.ATTRIBUTES_PICKER) },
+                modifier = Modifier.testTag("nextButton"),
+                colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                  Text(
+                      "Next",
+                      modifier = Modifier.width(100.dp),
+                      color = MaterialTheme.colorScheme.primary,
+                      fontWeight = FontWeight.Bold,
+                      textAlign = TextAlign.Center)
+                }
+          }
+    }
+  }
+}
+
+@Preview
+@Composable
+fun TopBarAdd() {
+  CyrcleTheme {
+    Box(Modifier.background(Color.White)) {
+      Row(
+          Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
+          horizontalArrangement = Arrangement.SpaceAround,
+          verticalAlignment = Alignment.CenterVertically) {
+            Column {
+              Text(
+                  "Where is the Parking ?",
+                  color = MaterialTheme.colorScheme.primary,
+                  fontSize = MaterialTheme.typography.headlineLarge.fontSize,
+                  fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                  modifier = Modifier.padding(start = 16.dp),
+                  fontWeight = FontWeight.Bold)
+              Text("Click on the location of the new parking")
+            }
+          }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
@@ -64,7 +64,7 @@ fun BottomBarAdd(navigationActions: NavigationActions) {
           horizontalArrangement = Arrangement.SpaceBetween,
           verticalAlignment = Alignment.CenterVertically) {
             Button(
-                { navigationActions.goBack() },
+                { navigationActions.navigateTo(Screen.MAP) },
                 modifier = Modifier.testTag("cancelButton"),
                 colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
                   Text(

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -181,7 +181,7 @@ fun MapScreen(
               Row(
                   Modifier.padding(top = 16.dp).fillMaxWidth(),
                   horizontalArrangement = Arrangement.Start) {
-                    AddButton { println("Add button clicked") }
+                    AddButton { navigationActions.navigateTo(Route.ADD_SPOTS) }
                   }
             }
       }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/overlay/AddButton.kt
@@ -26,7 +26,7 @@ fun AddButton(onClick: () -> Unit) {
           modifier =
               Modifier.size(48.dp)
                   .background(color = MaterialTheme.colorScheme.primary, shape = CircleShape)
-                  .testTag("AddButton")) {
+                  .testTag("addButton")) {
             Icon(Icons.Default.Add, contentDescription = "Add", tint = Color.White)
           }
     }

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -12,6 +12,7 @@ object Route {
   const val LIST = "List"
   const val MAP = "Map"
   const val CARD = "Card"
+  const val ADD_SPOTS = "Add Spots"
 }
 
 object Screen {
@@ -19,6 +20,8 @@ object Screen {
   const val LIST = "List Screen"
   const val MAP = "Map Screen"
   const val CARD = "Card Screen"
+  const val LOCATION_PICKER = "Location Picker"
+  const val ATTRIBUTES_PICKER = "Attributes Picker"
 }
 
 /**


### PR DESCRIPTION
_Closes #45_
### (What)  This PR provides placeholders screens for adding new parking spots, and implement the navigation between them.

<img width="755" alt="image" src="https://github.com/user-attachments/assets/bfed5018-f95a-4019-8aa5-976facf79ec2">


### (How) Key changes 
- The navigation graph defined inside the navHost has been moved to its own file, making the Main cleaner and the navGraph reusable for testing purposes.
- This PR adds for the first time the viewModel to the App


#### Notes
- This PR is not about the UI.
- The mechanism to select location and add attributes is not defined yet.
- 80% cc is reached
<img width="755" alt="image" src="https://github.com/user-attachments/assets/ba61fb7c-0ab0-4b06-867c-ffe19e18cbaf">
