### PR TITLE
Patch to prevent query density 

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -82,6 +82,7 @@ fun MapScreen(
             style = { MapStyle("mapbox://styles/seanprz/cm27wh9ff00jl01r21jz3hcb1") }) {
               DisposableMapEffect { mapView ->
 
+                // Lock rotations of the map
                 mapView.gestures.getGesturesManager().rotateGestureDetector.isEnabled = false
 
                 // Set camera bounds options

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -43,6 +43,7 @@ import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
+import com.mapbox.maps.plugin.gestures.gestures
 
 const val defaultZoom = 16.0
 const val maxZoom = 18.0
@@ -80,6 +81,8 @@ fun MapScreen(
             mapViewportState = mapViewportState,
             style = { MapStyle("mapbox://styles/seanprz/cm27wh9ff00jl01r21jz3hcb1") }) {
               DisposableMapEffect { mapView ->
+
+                mapView.gestures.getGesturesManager().rotateGestureDetector.isEnabled = false
 
                 // Set camera bounds options
                 val cameraBoundsOptions =
@@ -220,7 +223,7 @@ private fun getScreenCorners(mapView: MapView, useBuffer: Boolean = true): Pair<
   val centerPixel = mapView.mapboxMap.pixelForCoordinate(mapView.mapboxMap.cameraState.center)
 
   // Calculate the multiplier for the buffer
-  val multiplier = if (useBuffer) 2.0 else 1.0
+  val multiplier = if (useBuffer) 3.0 else 1.0
 
   val bottomLeftCorner =
       mapView.mapboxMap.coordinateForPixel(


### PR DESCRIPTION
## PR content

This PR is a small patch that aims to prevent making too much queries of parking while using the map. 

## Why ? 

While using a `CameraListener` to update the markers of the map, we found out that the map makes too much queries (one batch of query for each pixel displacement). This was addressed in a previous PR. This PR address the issue of the rotation motion which is a edge case. 

## How ? 

I disabled the `rotateGestureDetector` so that the map doesn't detect rotating movement from the user. I also make the buffer bigger as a safety measure. 

## Testing

This can be tested by using the map and try to rotate it. 