### PR TITLE
Implement MapViewModel

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/add/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/add/AddScreensNavigationTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.ui.map.MapScreen
@@ -26,13 +27,14 @@ class AddScreensNavigationTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Composable
-  fun setUp(): Triple<NavigationActions, ParkingViewModel, ReviewViewModel> {
+  fun setUp(): List<Any> {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
     val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
     val reviewViewModel: ReviewViewModel = viewModel(factory = ReviewViewModel.Factory)
-    CyrcleNavHost(navigationActions, navController, parkingViewModel, reviewViewModel)
-    return Triple(navigationActions, parkingViewModel, reviewViewModel)
+    val mapViewModel: MapViewModel = viewModel(factory = MapViewModel.Factory)
+    CyrcleNavHost(navigationActions, navController, parkingViewModel, reviewViewModel, mapViewModel)
+    return listOf<Any>(navigationActions, parkingViewModel, reviewViewModel, mapViewModel)
   }
 
   @OptIn(ExperimentalTestApi::class)
@@ -40,8 +42,11 @@ class AddScreensNavigationTest {
   fun testAddButtonNavigatesToLocationPicker() {
 
     composeTestRule.setContent {
-      val (navigationActions, parkingViewModel) = setUp()
-      MapScreen(navigationActions, parkingViewModel)
+      val list = setUp()
+      val navigationActions = list[0] as NavigationActions
+      val parkingViewModel = list[1] as ParkingViewModel
+      val mapViewModel = list[3] as MapViewModel
+      MapScreen(navigationActions, parkingViewModel, mapViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("addButton"))
     // Perform click on the add button
@@ -56,8 +61,11 @@ class AddScreensNavigationTest {
   fun testNavigationToAttribute() {
 
     composeTestRule.setContent {
-      val (navigationActions, parkingViewModel) = setUp()
-      LocationPicker(navigationActions, parkingViewModel)
+      val list = setUp()
+      val navigationActions = list[0] as NavigationActions
+      val parkingViewModel = list[1] as ParkingViewModel
+      val mapViewModel = list[3] as MapViewModel
+      LocationPicker(navigationActions, parkingViewModel, mapViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("nextButton"))
     // Perform click on the add button
@@ -71,11 +79,11 @@ class AddScreensNavigationTest {
   @Test
   fun testSubmit() {
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
-      val reviewViewModel: ReviewViewModel = viewModel(factory = ReviewViewModel.Factory)
-      CyrcleNavHost(navigationActions, navController, parkingViewModel, reviewViewModel)
+      val list = setUp()
+      val navigationActions = list[0] as NavigationActions
+      val parkingViewModel = list[1] as ParkingViewModel
+      val reviewViewModel = list[2] as ReviewViewModel
+      val mapViewModel = list[3] as MapViewModel
       AttributesPicker(navigationActions, parkingViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("submitButton"))
@@ -90,7 +98,10 @@ class AddScreensNavigationTest {
   @Test
   fun testCancel() {
     composeTestRule.setContent {
-      val (navigationActions, parkingViewModel) = setUp()
+      val list = setUp()
+      val navigationActions = list[0] as NavigationActions
+      val parkingViewModel = list[1] as ParkingViewModel
+      val mapViewModel = list[3] as MapViewModel
       AttributesPicker(navigationActions, parkingViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("cancelButton"))
@@ -105,8 +116,11 @@ class AddScreensNavigationTest {
   @Test
   fun testCancel2() {
     composeTestRule.setContent {
-      val (navigationActions, parkingViewModel) = setUp()
-      LocationPicker(navigationActions, parkingViewModel)
+      val list = setUp()
+      val navigationActions = list[0] as NavigationActions
+      val parkingViewModel = list[1] as ParkingViewModel
+      val mapViewModel = list[3] as MapViewModel
+      LocationPicker(navigationActions, parkingViewModel, mapViewModel)
     }
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag("cancelButton").performClick()

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -3,6 +3,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.ui.add.AttributesPicker
@@ -21,7 +22,8 @@ fun CyrcleNavHost(
     navigationActions: NavigationActions,
     navController: NavHostController,
     parkingViewModel: ParkingViewModel,
-    reviewViewModel: ReviewViewModel
+    reviewViewModel: ReviewViewModel,
+    mapViewModel: MapViewModel
 ) {
   NavHost(navController = navController, startDestination = Route.AUTH) {
     navigation(
@@ -46,10 +48,12 @@ fun CyrcleNavHost(
         startDestination = Screen.MAP,
         route = Route.MAP,
     ) {
-      composable(Screen.MAP) { MapScreen(navigationActions, parkingViewModel) }
+      composable(Screen.MAP) { MapScreen(navigationActions, parkingViewModel, mapViewModel) }
     }
     navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
-      composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, parkingViewModel) }
+      composable(Screen.LOCATION_PICKER) {
+        LocationPicker(navigationActions, parkingViewModel, mapViewModel)
+      }
       composable(Screen.ATTRIBUTES_PICKER) { AttributesPicker(navigationActions, parkingViewModel) }
     }
   }

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ImageRepositoryCloudStorage
 import com.github.se.cyrcle.model.parking.ParkingRepositoryFirestore
 import com.github.se.cyrcle.model.parking.ParkingViewModel
@@ -58,6 +59,7 @@ class MainActivity : ComponentActivity() {
     val imageRepository = ImageRepositoryCloudStorage(auth)
     val parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
     val reviewViewModel = ReviewViewModel(reviewRepository)
-    CyrcleNavHost(navigationActions, navController, parkingViewModel, reviewViewModel)
+    val mapViewModel = MapViewModel()
+    CyrcleNavHost(navigationActions, navController, parkingViewModel, reviewViewModel, mapViewModel)
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -1,0 +1,31 @@
+package com.github.se.cyrcle.model.map
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraState
+import com.mapbox.maps.EdgeInsets
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class MapViewModel : ViewModel() {
+
+  private val _cameraPosition =
+      MutableStateFlow<CameraState?>(
+          CameraState(Point.fromLngLat(0.0, 0.0), EdgeInsets(0.0, 0.0, 0.0, 0.0), 0.0, 0.0, 0.0))
+  val cameraPosition: StateFlow<CameraState?> = _cameraPosition
+
+  fun updateCameraPosition(cameraPosition: CameraState) {
+    _cameraPosition.value = cameraPosition
+  }
+  // create factory (imported from bootcamp)
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return MapViewModel() as T
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -15,8 +15,15 @@ class MapViewModel : ViewModel() {
           CameraState(Point.fromLngLat(0.0, 0.0), EdgeInsets(0.0, 0.0, 0.0, 0.0), 0.0, 0.0, 0.0))
   val cameraPosition: StateFlow<CameraState?> = _cameraPosition
 
+  private val _selectedPoint = MutableStateFlow<Point?>(null)
+  val selectedPoint: StateFlow<Point?> = _selectedPoint
+
   fun updateCameraPosition(cameraPosition: CameraState) {
     _cameraPosition.value = cameraPosition
+  }
+
+  fun updateSelectedPoint(point: Point) {
+    _selectedPoint.value = point
   }
   // create factory (imported from bootcamp)
   companion object {

--- a/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
@@ -31,7 +31,6 @@ import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.CyrcleTheme
-import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mapbox.maps.extension.compose.style.MapStyle

--- a/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/add/LocationPicker.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
@@ -37,13 +38,18 @@ import com.mapbox.maps.extension.compose.style.MapStyle
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun LocationPicker(navigationActions: NavigationActions, parkingViewModel: ParkingViewModel) {
+fun LocationPicker(
+    navigationActions: NavigationActions,
+    parkingViewModel: ParkingViewModel,
+    mapViewModel: MapViewModel = MapViewModel()
+) {
   val mapViewportState = rememberMapViewportState {
     setCameraOptions {
-      zoom(16.0)
-      center(Point.fromLngLat(6.566, 46.519))
-      pitch(0.0)
-      bearing(0.0)
+      val camPos = mapViewModel.cameraPosition.value!!
+      center(camPos.center)
+      zoom(camPos.zoom)
+      bearing(camPos.bearing)
+      pitch(camPos.pitch)
     }
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.ui.map.overlay.AddButton
 import com.github.se.cyrcle.ui.map.overlay.ZoomControls
@@ -52,6 +53,7 @@ const val minZoom = 8.0
 fun MapScreen(
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel,
+    mapViewModel: MapViewModel = MapViewModel(),
     state: MutableState<Double> = remember { mutableDoubleStateOf(defaultZoom) }
 ) {
 
@@ -171,7 +173,10 @@ fun MapScreen(
           Row(
               Modifier.padding(top = 16.dp).fillMaxWidth(),
               horizontalArrangement = Arrangement.Start) {
-                AddButton { navigationActions.navigateTo(Route.ADD_SPOTS) }
+                AddButton {
+                  navigationActions.navigateTo(Route.ADD_SPOTS)
+                  mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
+                }
               }
         }
   }

--- a/app/src/test/java/com/github/se/cyrcle/model/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/map/MapViewModelTest.kt
@@ -1,0 +1,27 @@
+package com.github.se.cyrcle.model.map
+
+import android.annotation.SuppressLint
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraState
+import com.mapbox.maps.EdgeInsets
+import org.junit.Test
+
+class MapViewModelTest {
+
+  @SuppressLint("StateFlowValueCalledInComposition")
+  @Test
+  fun MapViewModelTestCameraState() {
+    val mapViewModel = MapViewModel()
+
+    val cameraState =
+        CameraState(Point.fromLngLat(6.566, 46.519), EdgeInsets(0.0, 0.0, 0.0, 0.0), 17.0, 0.0, 0.0)
+
+    mapViewModel.updateCameraPosition(cameraState)
+    val returnedCamera = mapViewModel.cameraPosition.value
+    assert(returnedCamera?.zoom == 17.0)
+    assert(returnedCamera?.center?.latitude() == 46.519)
+    assert(returnedCamera?.center?.longitude() == 6.566)
+    assert(returnedCamera?.pitch == 0.0)
+    assert(returnedCamera?.bearing == 0.0)
+  }
+}


### PR DESCRIPTION
_Closes #77_
#### (What) This PR adds a viewModel for the Map.
This PR adds two states to the viewModel :
The camera. with a setter (_updateCameraPosition_) and a getter (._cameraPosition_)
The Point selected with a setter (_updateSelectedPoint_) and a getter (_.selectedPoint_)

#### (Why) This PR makes the User experience smoother when navigating between screens.

Instead of being respawned at the default location every time a map is rerender, the user can continue browsing the map where he left.
Especially when navigating from the MapScreen to the LocationPicker: the Map was reset at the default location, instead of where the user was.

And

The Point state is useful to share the location selected by the user in the first step of the process of adding new parking spots to the other steps

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/699755fe-4f9e-41bd-bcbc-15a00fa98cda">

