### PR TITLE
Address Model, Repository, and ViewModel for Reverse Geocoding

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/MockRepoModule.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/MockRepoModule.kt
@@ -1,9 +1,11 @@
 package com.github.se.cyrcle.di
 
+import com.github.se.cyrcle.di.mocks.MockAddressRepository
 import com.github.se.cyrcle.di.mocks.MockImageRepository
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockReviewRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
+import com.github.se.cyrcle.model.address.AddressRepository
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.review.ReviewRepository
@@ -39,4 +41,11 @@ abstract class MockRepoModule {
   @Singleton
   /** Binds the [MockUserRepository] implementation to the [UserRepository] interface. */
   abstract fun bindUserRepository(mockUserRepositoryFirestore: MockUserRepository): UserRepository
+
+  @Binds
+  @Singleton
+  /** Binds the [MockAddressRepository] implementation to the [AddressRepository] interface. */
+  abstract fun bindAddressRepository(
+      mockAddressRepository: MockAddressRepository
+  ): AddressRepository
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockAddressRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockAddressRepository.kt
@@ -1,0 +1,26 @@
+package com.github.se.cyrcle.di.mocks
+
+import com.github.se.cyrcle.model.address.Address
+import com.github.se.cyrcle.model.address.AddressRepository
+import javax.inject.Inject
+
+class MockAddressRepository @Inject constructor() : AddressRepository {
+  private val mockAddress =
+      Address(
+          publicName = "Mock Park",
+          house = "Mock House",
+          road = "Mock Road",
+          suburb = "Mock Suburb",
+          city = "Mock City",
+          region = "Mock State",
+          postcode = "Mock Postcode",
+          country = "Mock Country")
+
+  override fun search(query: String, onSuccess: (Address) -> Unit, onFailure: (Exception) -> Unit) {
+    if (query.isEmpty() || query.isBlank()) {
+      onFailure(Exception("Query is empty"))
+      return
+    }
+    onSuccess(mockAddress)
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
+import com.github.se.cyrcle.model.address.AddressRepository
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
@@ -29,6 +30,8 @@ class MainActivity : ComponentActivity() {
   @Inject lateinit var imageRepository: ImageRepository
 
   @Inject lateinit var userRepository: UserRepository
+
+  @Inject lateinit var addressRepository: AddressRepository
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/github/se/cyrcle/di/AppModule.kt
+++ b/app/src/main/java/com/github/se/cyrcle/di/AppModule.kt
@@ -10,6 +10,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+import okhttp3.OkHttpClient
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -48,5 +49,15 @@ object AppModule {
       auth.signOut()
     }
     return auth
+  }
+
+  @Provides
+  @Singleton
+  /**
+   * Instantiates an instance of the OkHttpClient with the correct settings for the whole lifetime
+   * of the run.
+   */
+  fun provideOkHttpClient(): OkHttpClient {
+    return OkHttpClient()
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/di/RepoModule.kt
+++ b/app/src/main/java/com/github/se/cyrcle/di/RepoModule.kt
@@ -1,5 +1,7 @@
 package com.github.se.cyrcle.di
 
+import com.github.se.cyrcle.model.address.AddressRepository
+import com.github.se.cyrcle.model.address.AddressRepositoryNominatim
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.ImageRepositoryCloudStorage
 import com.github.se.cyrcle.model.parking.ParkingRepository
@@ -43,4 +45,11 @@ abstract class RepoModule {
   @Singleton
   /** Binds the [UserRepositoryFirestore] implementation to the [UserRepository] interface. */
   abstract fun bindUserRepository(userRepositoryFirestore: UserRepositoryFirestore): UserRepository
+
+  @Binds
+  @Singleton
+  /** Binds the [AddressRepositoryNominatim] implementation to the [AddressRepository] interface. */
+  abstract fun bindAddressRepository(
+      addressRepositoryNominatim: AddressRepositoryNominatim
+  ): AddressRepository
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/address/Address.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/address/Address.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.model.address
 
-import android.util.Log
 import com.google.gson.annotations.SerializedName
 
 /**
@@ -76,12 +75,6 @@ data class Address(
     // they are present.
     val fieldPriorities =
         listOf(publicName, house, road, cityBlock, neighbourhood, hamlet, suburb, city)
-
-    // We filter out empty fields and take the first three non-empty fields
-    val nonemptyFields = fieldPriorities.filter { it.isNotEmpty() }
-    Log.d("Address", "nonemptyFields: $nonemptyFields")
-    val relevantFields = nonemptyFields.take(3)
-    Log.d("Address", "relevantFields: $relevantFields")
     return fieldPriorities.filter { it.isNotEmpty() }.take(3).joinToString(", ")
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/address/Address.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/address/Address.kt
@@ -1,0 +1,87 @@
+package com.github.se.cyrcle.model.address
+
+import android.util.Log
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents an address.
+ *
+ * @property publicName The public name of the address. This can be for example the name of a
+ *   hospital or a park.
+ * @property house The house number or name.
+ * @property road The road name.
+ * @property cityBlock The city block, residential, farm, farmyard, industrial, commercial or
+ *   retail.
+ * @property neighbourhood The neighbourhood, quarter or allotments.
+ * @property hamlet The hamlet, isolated dwelling or croft.
+ * @property suburb The suburb, city district, district, borough or subdivision.
+ * @property city The city, town, municipality or village.
+ * @property postcode The postcode.
+ * @property region The region, state, state district, county or ISO3166-2-lvl.
+ * @property country The country.
+ * @property continent The continent.
+ */
+data class Address(
+    @SerializedName(
+        "amenity",
+        alternate =
+            [
+                "emergency",
+                "historic",
+                "military",
+                "natural",
+                "landuse",
+                "place",
+                "railway",
+                "man_made",
+                "aerialway",
+                "boundary",
+                "aeroway",
+                "club",
+                "craft",
+                "leisure",
+                "office",
+                "mountain_pass",
+                "shop",
+                "tourism",
+                "bridge",
+                "tunnel",
+                "waterway"])
+    val publicName: String = "",
+    @SerializedName("house_number", alternate = ["house_name"]) val house: String = "",
+    @SerializedName("road") val road: String = "",
+    @SerializedName(
+        "city_block",
+        alternate = ["residential", "farm", "farmyard", "industrial", "commercial", "retail"])
+    val cityBlock: String = "",
+    @SerializedName("neighbourhood", alternate = ["quarter", "allotments"])
+    val neighbourhood: String = "",
+    @SerializedName("hamlet", alternate = ["isolated_dwelling, croft"]) val hamlet: String = "",
+    @SerializedName("suburb", alternate = ["city_district", "district", "borough", "subdivision"])
+    val suburb: String = "",
+    @SerializedName("city", alternate = ["municipality", "village, town"]) val city: String = "",
+    @SerializedName("postcode") val postcode: String = "",
+    @SerializedName("region", alternate = ["state", "state_district", "county", "ISO3166-2-lvl"])
+    val region: String = "",
+    @SerializedName("country") val country: String = "",
+    @SerializedName("continent") val continent: String = ""
+) {
+  /**
+   * Among the fields of the address, we choose the most relevant ones to display.
+   *
+   * @return The most relevant fields of the address.
+   */
+  fun displayRelevantFields(): String {
+    // The order of the fields is important. We choose not to display some fields at all, even if
+    // they are present.
+    val fieldPriorities =
+        listOf(publicName, house, road, cityBlock, neighbourhood, hamlet, suburb, city)
+
+    // We filter out empty fields and take the first three non-empty fields
+    val nonemptyFields = fieldPriorities.filter { it.isNotEmpty() }
+    Log.d("Address", "nonemptyFields: $nonemptyFields")
+    val relevantFields = nonemptyFields.take(3)
+    Log.d("Address", "relevantFields: $relevantFields")
+    return fieldPriorities.filter { it.isNotEmpty() }.take(3).joinToString(", ")
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/model/address/AddressRepository.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/address/AddressRepository.kt
@@ -1,0 +1,13 @@
+package com.github.se.cyrcle.model.address
+
+/** Repository for searching addresses. */
+interface AddressRepository {
+  /**
+   * Search for an address.
+   *
+   * @param query The query to search for.
+   * @param onSuccess The callback to be called when the search is successful.
+   * @param onFailure The callback to be called when the search fails.
+   */
+  fun search(query: String, onSuccess: (Address) -> Unit, onFailure: (Exception) -> Unit)
+}

--- a/app/src/main/java/com/github/se/cyrcle/model/address/AddressRepositoryNominatim.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/address/AddressRepositoryNominatim.kt
@@ -1,0 +1,60 @@
+package com.github.se.cyrcle.model.address
+
+import com.google.gson.Gson
+import java.io.IOException
+import javax.inject.Inject
+import okhttp3.*
+import org.json.JSONArray
+
+class AddressRepositoryNominatim @Inject constructor(private val client: OkHttpClient) :
+    AddressRepository {
+  override fun search(query: String, onSuccess: (Address) -> Unit, onFailure: (Exception) -> Unit) {
+    val url =
+        HttpUrl.Builder()
+            .scheme("https")
+            .host("nominatim.openstreetmap.org")
+            .addPathSegment("search")
+            .addQueryParameter("q", query)
+            .addQueryParameter("format", "json")
+            .addQueryParameter("addressdetails", "1")
+            .build()
+    val request = Request.Builder().url(url).header("User-Agent", "Cyrcle").build()
+
+    client
+        .newCall(request)
+        .enqueue(
+            object : Callback {
+              override fun onFailure(call: Call, e: IOException) {
+                onFailure(e)
+              }
+
+              override fun onResponse(call: Call, response: Response) {
+                response.use {
+                  if (!response.isSuccessful) {
+                    onFailure(Exception("Unexpected code $response"))
+                    return
+                  }
+
+                  val body = response.body?.string()
+                  if (body != null) {
+                    val address = addressFromBody(body)
+                    onSuccess(address)
+                  } else {
+                    onSuccess(Address())
+                  }
+                }
+              }
+            })
+  }
+
+  /** Extracts an address from the response body. */
+  private fun addressFromBody(body: String): Address {
+    val jsonArray = JSONArray(body)
+    if (jsonArray.length() == 0) {
+      return Address()
+    }
+    val jsonObject = jsonArray.getJSONObject(0)
+    val address = jsonObject.getJSONObject("address")
+    return Gson().fromJson(address.toString(), Address::class.java)
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/model/address/AddressViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/address/AddressViewModel.kt
@@ -1,0 +1,43 @@
+package com.github.se.cyrcle.model.address
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.mapbox.geojson.Point
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import okhttp3.OkHttpClient
+
+/**
+ * View model for an address.
+ *
+ * @property repository The repository for searching addresses.
+ */
+class AddressViewModel(private val repository: AddressRepository) : ViewModel() {
+  private val _address = MutableStateFlow(Address())
+  val address: StateFlow<Address>
+    get() = _address
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return AddressViewModel(AddressRepositoryNominatim(OkHttpClient())) as T
+          }
+        }
+  }
+
+  /**
+   * Searches for an address and updates the address state.
+   *
+   * @param point The point to search for.
+   */
+  fun search(point: Point) {
+    val query = "${point.latitude()},${point.longitude()}"
+    repository.search(
+        query,
+        onSuccess = { _address.value = it },
+        onFailure = { Log.e("AddressViewModel", "Failed to search for address", it) })
+  }
+}

--- a/app/src/test/java/com/github/se/cyrcle/model/address/AddressRepositoryNominatimTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/address/AddressRepositoryNominatimTest.kt
@@ -1,0 +1,182 @@
+package com.github.se.cyrcle.model.address
+
+import com.mapbox.geojson.Point
+import java.io.IOException
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AddressRepositoryNominatimTest {
+  @Mock private lateinit var mockClient: OkHttpClient
+  @Mock private lateinit var mockCall: Call
+
+  private lateinit var addressRepositoryNominatim: AddressRepositoryNominatim
+  private val whiteHouse = Point.fromLngLat(-77.036571, 38.897870)
+  private val whiteHouseString = "${whiteHouse.latitude()},${whiteHouse.longitude()}"
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    addressRepositoryNominatim = AddressRepositoryNominatim(mockClient)
+    `when`(mockClient.newCall(any())).thenReturn(mockCall)
+  }
+
+  @Test
+  fun testSearchMakesCallsOnClientAndCall() {
+    addressRepositoryNominatim.search(whiteHouseString, {}, {})
+    verify(mockClient).newCall(any())
+    verify(mockCall).enqueue(any())
+  }
+
+  @Test
+  fun testSearchSuccessWithValidResponse() {
+    val mockResponse =
+        MockResponse(
+            200,
+            """[      
+          {
+            "place_id": 303453880,
+            "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright",
+            "osm_type": "way",
+            "osm_id": 238241022,
+            "lat": "38.897699700000004",
+            "lon": "-77.03655315",
+            "class": "office",
+            "type": "government",
+            "place_rank": 30,
+            "importance": 0.63472115416811,
+            "addresstype": "office",
+            "name": "White House",
+            "display_name": "White House, 1600, Pennsylvania Avenue Northwest, Ward 2, Washington, District of Columbia, 20500, United States",
+            "address": {
+              "office": "White House",
+              "house_number": "1600",
+              "road": "Pennsylvania Avenue Northwest",
+              "borough": "Ward 2",
+              "city": "Washington",
+              "state": "District of Columbia",
+              "ISO3166-2-lvl4": "US-DC",
+              "postcode": "20500",
+              "country": "United States",
+              "country_code": "us"
+            },
+            "boundingbox": [
+              "38.8974908",
+              "38.8979110",
+              "-77.0368537",
+              "-77.0362519"
+            ]
+          }
+        ]"""
+                .trimIndent())
+
+    setupMockResponse(mockResponse)
+
+    var resultAddress: Address? = null
+    addressRepositoryNominatim.search(whiteHouseString, { address -> resultAddress = address }, {})
+
+    assertNotNull(resultAddress)
+
+    assertEquals("Washington", resultAddress?.city)
+    assertEquals("United States", resultAddress?.country)
+    assertEquals("White House", resultAddress?.publicName)
+    assertEquals("1600", resultAddress?.house)
+    assertEquals("Pennsylvania Avenue Northwest", resultAddress?.road)
+    assertEquals("20500", resultAddress?.postcode)
+    assertEquals("District of Columbia", resultAddress?.region)
+  }
+
+  @Test
+  fun testSearchFailureWithNetworkError() {
+    `when`(mockCall.enqueue(any())).thenAnswer { invocation ->
+      val callback = invocation.arguments[0] as Callback
+      callback.onFailure(mockCall, IOException("Network error"))
+    }
+
+    var resultException: Exception? = null
+    addressRepositoryNominatim.search(
+        whiteHouseString, {}, { exception -> resultException = exception })
+
+    assertNotNull(resultException)
+    assertEquals("Network error", resultException?.message)
+  }
+
+  @Test
+  fun testSearchFailureWithUnsuccessfulResponse() {
+    val mockResponse = MockResponse(404, "Not Found")
+    setupMockResponse(mockResponse)
+
+    var resultException: Exception? = null
+    addressRepositoryNominatim.search(
+        whiteHouseString, {}, { exception -> resultException = exception })
+
+    assertNotNull(resultException)
+    assertEquals(
+        "Unexpected code Response{protocol=http/1.1, code=404, message=Error, url=http://localhost/}",
+        resultException?.message)
+  }
+
+  @Test
+  fun testSearchSuccessWithEmptyResponse() {
+    val mockResponse = MockResponse(200, "[]")
+    setupMockResponse(mockResponse)
+
+    var resultAddress: Address? = null
+    addressRepositoryNominatim.search("0.0,0.0", { address -> resultAddress = address }, {})
+
+    assertNotNull(resultAddress)
+    assertEquals(Address(), resultAddress)
+  }
+
+  @Test
+  fun testSearchRequestUrl() {
+    val urlCaptor = argumentCaptor<Request>()
+    `when`(mockClient.newCall(urlCaptor.capture())).thenReturn(mockCall)
+
+    setupMockResponse(MockResponse(200, "[]"))
+
+    addressRepositoryNominatim.search(whiteHouseString, {}, {})
+
+    val capturedRequest = urlCaptor.firstValue
+    assertEquals(
+        "https://nominatim.openstreetmap.org/search?q=38.89787%2C-77.036571&format=json&addressdetails=1",
+        capturedRequest.url.toString())
+    assertEquals("Cyrcle", capturedRequest.header("User-Agent"))
+  }
+
+  private fun setupMockResponse(mockResponse: MockResponse) {
+    `when`(mockCall.enqueue(any())).thenAnswer { invocation ->
+      val callback = invocation.arguments[0] as Callback
+      callback.onResponse(mockCall, mockResponse.toResponse())
+    }
+  }
+
+  private data class MockResponse(val code: Int, val body: String) {
+    fun toResponse(): Response {
+      return Response.Builder()
+          .code(code)
+          .message(if (code == 200) "OK" else "Error")
+          .protocol(Protocol.HTTP_1_1)
+          .request(Request.Builder().url("http://localhost/").build())
+          .body(body.toResponseBody(null))
+          .build()
+    }
+  }
+}

--- a/app/src/test/java/com/github/se/cyrcle/model/address/AddressTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/address/AddressTest.kt
@@ -1,0 +1,54 @@
+package com.github.se.cyrcle.model.address
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AddressTest {
+
+  @Test
+  fun testConstructor() {
+    val address =
+        Address(
+            country = "Switzerland", city = "Lausanne", road = "Avenue de la Gare", house = "14")
+    assertEquals("Switzerland", address.country)
+    assertEquals("Lausanne", address.city)
+    assertEquals("Avenue de la Gare", address.road)
+    assertEquals("14", address.house)
+
+    // Assert other fields are empty
+    assertEquals("", address.publicName)
+    assertEquals("", address.cityBlock)
+    assertEquals("", address.neighbourhood)
+    assertEquals("", address.hamlet)
+    assertEquals("", address.suburb)
+    assertEquals("", address.postcode)
+    assertEquals("", address.region)
+    assertEquals("", address.continent)
+  }
+
+  @Test
+  fun testConstructorWithEmptyValues() {
+    val address = Address()
+    assertEquals("", address.country)
+    assertEquals("", address.city)
+    assertEquals("", address.road)
+    assertEquals("", address.house)
+  }
+
+  @Test
+  fun testDisplayRelevantFields() {
+    val address1 =
+        Address(
+            country = "Switzerland", city = "Lausanne", road = "Avenue de la Gare", house = "14")
+    assertEquals("14, Avenue de la Gare, Lausanne", address1.displayRelevantFields())
+
+    val address2 =
+        Address(
+            publicName = "Palais de L'Élysée",
+            city = "Paris",
+            road = "Rue du Faubourg Saint-Honoré",
+            house = "55")
+    assertEquals(
+        "Palais de L'Élysée, 55, Rue du Faubourg Saint-Honoré", address2.displayRelevantFields())
+  }
+}

--- a/app/src/test/java/com/github/se/cyrcle/model/address/AddressViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/address/AddressViewModelTest.kt
@@ -1,0 +1,48 @@
+package com.github.se.cyrcle.model.address
+
+import com.mapbox.geojson.Point
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+
+class AddressViewModelTest {
+  @Mock private lateinit var addressRepositoryNominatim: AddressRepositoryNominatim
+  private lateinit var addressViewModel: AddressViewModel
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    addressViewModel = AddressViewModel(addressRepositoryNominatim)
+  }
+
+  @Test
+  fun testSearchCallsRepository() {
+    val point = Point.fromLngLat(0.0, 0.0)
+    addressViewModel.search(point)
+
+    // Check if the search method was called with the correct query
+    verify(addressRepositoryNominatim).search(eq("0.0,0.0"), any(), any())
+  }
+
+  @Test
+  fun testSearchSetsAddress() {
+    `when`(addressRepositoryNominatim.search(any(), any(), any())).then {
+      it.getArgument<(Address) -> Unit>(1)(
+          Address(
+              city = "Paris",
+              country = "France",
+          ))
+    }
+    val point = Point.fromLngLat(0.0, 0.0)
+    addressViewModel.search(point)
+
+    // Check that the address state is not empty
+    assert(addressViewModel.address.value != Address())
+  }
+}


### PR DESCRIPTION
Closes #87 

This pull request introduces a comprehensive solution for reverse geocoding within our application, leveraging the OpenStreetMap Nominatim API. The following components have been implemented:

### Description:

##### Address Data Class:
- Introduced a new Address data class to represent various address components.
- Utilized @SerializedName annotations to manage inconsistencies in API response labels (e.g., city/town and district/suburb).

##### AddressRepositoryNominatim:
- Implemented a repository using OkHttpClient to perform reverse geocoding requests via the Nominatim API.
Chose Nominatim over Mapbox given the very limited amount of free requests the latter provides

##### AddressViewModel:
Developed AddressViewModel to manage address state and facilitate searches through the repository.
The search function accepts a Point and returns an Address

### Tests:

Comprehensive unit tests have been implemented for all new components:

##### AddressTest:
- Verifies correct construction of Address objects with various parameters.
- Ensures proper functionality of the displayRelevantFields method.

##### AddressRepositoryNominatimTest:
Tests the repository's search functionality with mock HTTP responses.
Verifies correct handling of successful and failed API requests.
Checks proper URL construction and request headers.

##### AddressViewModelTest:
Confirms that the ViewModel correctly interacts with the repository.
Verifies that search results update the ViewModel's state.

### Future Work:
Integrate the address search functionality with the parking suggestion feature

### Coverage
![image](https://github.com/user-attachments/assets/a0cf176f-9bab-48bd-a56d-c2396200474e)
