### PR TITLE
Refactor the (de)serialization using an adapter

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
@@ -3,10 +3,11 @@ package com.github.se.cyrcle.model.parking
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.gson.Gson
+import com.google.gson.*
 import com.google.gson.reflect.TypeToken
 import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfMeasurement
+import java.lang.reflect.Type
 
 class ParkingRepositoryFirestore(private val db: FirebaseFirestore) : ParkingRepository {
 
@@ -157,124 +158,44 @@ class ParkingRepositoryFirestore(private val db: FirebaseFirestore) : ParkingRep
         .addOnFailureListener { onFailure(it) }
   }
 
-  /**
-   * Serializes a Parking object to a Map
-   *
-   * @param parking The Parking object to serialize
-   * @return The serialized Map
-   */
   private fun serializeParking(parking: Parking): Map<String, Any> {
-    val gson = Gson()
-    val type = object : TypeToken<Map<String, Any>>() {}.type
-    val parkingMap: MutableMap<String, Any> = gson.fromJson(gson.toJson(parking), type)
-
-    // Replace Mapbox Point with Point2D serialization
-    val locationMap = (parkingMap["location"] as? Map<*, *>)?.toMutableMap()
-    locationMap?.let { location ->
-      location["center"] = Point2D.fromMapboxPoint(parking.location.center).toSerializedMap()
-      parking.location.topLeft?.let { point ->
-        location["topLeft"] = Point2D.fromMapboxPoint(point).toSerializedMap()
-      }
-      parking.location.topRight?.let { point ->
-        location["topRight"] = Point2D.fromMapboxPoint(point).toSerializedMap()
-      }
-      parking.location.bottomLeft?.let { point ->
-        location["bottomLeft"] = Point2D.fromMapboxPoint(point).toSerializedMap()
-      }
-      parking.location.bottomRight?.let { point ->
-        location["bottomRight"] = Point2D.fromMapboxPoint(point).toSerializedMap()
-      }
-      parkingMap["location"] = location
-    }
-    return parkingMap
+    val gson = GsonBuilder().registerTypeAdapter(Point::class.java, PointAdapter()).create()
+    val json = gson.toJson(parking)
+    return gson.fromJson(json, object : TypeToken<Map<String, Any>>() {}.type)
   }
 
-  /**
-   * Deserializes a Map to a Parking object
-   *
-   * @param map The map to deserialize
-   * @return The deserialized Parking object
-   */
   private fun deserializeParking(map: Map<String, Any>): Parking {
-    val gson = Gson()
-    val type = object : TypeToken<Map<String, Any>>() {}.type
-    val parkingMap: MutableMap<String, Any> = gson.fromJson(gson.toJson(map), type)
-
-    // Replace Point2D serialization with Mapbox Point
-    val locationMap = (parkingMap["location"] as? Map<*, *>)?.toMutableMap()
-    locationMap?.let { location ->
-      location["center"] =
-          Point2D.fromSerializedMap(location["center"] as Map<String, Double>).toMapboxPoint()
-      location["topLeft"]?.let {
-        location["topLeft"] = Point2D.fromSerializedMap(it as Map<String, Double>).toMapboxPoint()
-      }
-      location["topRight"]?.let {
-        location["topRight"] = Point2D.fromSerializedMap(it as Map<String, Double>).toMapboxPoint()
-      }
-      location["bottomLeft"]?.let {
-        location["bottomLeft"] =
-            Point2D.fromSerializedMap(it as Map<String, Double>).toMapboxPoint()
-      }
-      location["bottomRight"]?.let {
-        location["bottomRight"] =
-            Point2D.fromSerializedMap(it as Map<String, Double>).toMapboxPoint()
-      }
-
-      parkingMap["location"] = location
-    }
-
-    return gson.fromJson(gson.toJson(parkingMap), Parking::class.java)
+    val gson = GsonBuilder().registerTypeAdapter(Point::class.java, PointAdapter()).create()
+    val json = gson.toJson(map)
+    return gson.fromJson(json, Parking::class.java)
   }
 }
 
 /**
- * Helper class to serialize and deserialize Mapbox Point to and from a Map to be stored in
- * Firestore. Storing Mapbox Point directly in Firestore does not meet our needs as the coordinates
- * are stored as an array of doubles. This prevents querying for parkings within a certain range of
- * a location.
- *
- * @param longitude The longitude of the point
- * @param latitude The latitude of the point
+ * Adapter for serializing and deserializing Point objects. This is necessary as we need to store
+ * the points as an object with two fields, longitude and latitude, in Firestore to be able to make
+ * complex queries.
  */
-private data class Point2D(val longitude: Double, val latitude: Double) {
-  /** Companion object to provide helper functions to convert between Mapbox Point and Point2D */
-  companion object {
-    /**
-     * Converts a Mapbox Point to a Point2D
-     *
-     * @param point The Mapbox Point to convert
-     * @return The converted Point2D
-     */
-    fun fromMapboxPoint(point: Point): Point2D {
-      return Point2D(point.longitude(), point.latitude())
-    }
-
-    /**
-     * Converts a Map to a Point2D object for deserialization
-     *
-     * @param map The map to convert
-     * @return The converted Point2D
-     */
-    fun fromSerializedMap(map: Map<String, Double>): Point2D {
-      return Point2D(map["longitude"]!!, map["latitude"]!!)
+class PointAdapter : JsonSerializer<Point>, JsonDeserializer<Point> {
+  override fun serialize(
+      src: Point,
+      typeOfSrc: Type,
+      context: JsonSerializationContext
+  ): JsonElement {
+    return JsonObject().apply {
+      addProperty("longitude", src.longitude())
+      addProperty("latitude", src.latitude())
     }
   }
 
-  /**
-   * Converts the Point2D to a Mapbox Point
-   *
-   * @return The converted Mapbox Point
-   */
-  fun toMapboxPoint(): Point {
+  override fun deserialize(
+      json: JsonElement,
+      typeOfT: Type,
+      context: JsonDeserializationContext
+  ): Point {
+    val jsonObject = json.asJsonObject
+    val longitude = jsonObject.get("longitude").asDouble
+    val latitude = jsonObject.get("latitude").asDouble
     return Point.fromLngLat(longitude, latitude)
-  }
-
-  /**
-   * Converts the Point2D to a Map for serialization
-   *
-   * @return The converted Map
-   */
-  fun toSerializedMap(): Map<String, Any> {
-    return Gson().fromJson(Gson().toJson(this), object : TypeToken<Map<String, Any>>() {}.type)
   }
 }


### PR DESCRIPTION
This PR simplifies and improves the serialization and deserialization of `Parking` objects, focusing on the proper handling of `Point` objects within the `Location` structure.

### Changes
- Removed the `Point2D` helper class, directly working with Mapbox `Point` objects.
- Simplified `serializeParking` and `deserializeParking` methods using the new `PointAdapter`.

### Benefits
- Cleaner, more maintainable code with reduced complexity.
- Improved performance by eliminating multiple conversions between different point representations.

### Testing
- Verified that serialization produces the correct format for Firestore storage.
- Ensured deserialization correctly reconstructs `Parking` objects from serialized data.
- Confirmed that queries based on geographical data still function as expected.