### PR TITLE
Feature implement interaction with markers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,10 @@ android {
 
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
 
+    buildFeatures {
+        viewBinding = true
+    }
+
 
     defaultConfig {
         applicationId = "com.github.se.cyrcle"

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Log
+import android.view.View
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -78,7 +79,7 @@ fun MapScreen(
     }
   }
 
-  val cancelables = remember<List<Cancelable>> { emptyList() }.toMutableList()
+  var cancelables = remember<List<Cancelable>> { emptyList() }.toMutableList()
 
   val context = LocalContext.current
 
@@ -138,8 +139,15 @@ fun MapScreen(
                       textNativeView.text = "Custom text here"
                     }
                   }
-                  cancelables += mapView.mapboxMap.subscribeMapIdle(listener)
+                  cancelables.forEach(Cancelable::cancel)
+                  cancelables = listOf(mapView.mapboxMap.subscribeMapIdle(listener)).toMutableList()
                   true
+                })
+
+            mapView.setOnClickListener(
+                View.OnClickListener {
+                  cancelables.forEach(Cancelable::cancel)
+                  viewAnnotationManager.removeAllViewAnnotations()
                 })
 
             var (loadedBottomLeft, loadedTopRight) = getScreenCorners(mapView, useBuffer = true)

--- a/app/src/main/res/layout/item_callout_view.xml
+++ b/app/src/main/res/layout/item_callout_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- item_callout_view.xml -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+android:layout_width="wrap_content"
+android:layout_height="wrap_content"
+    android:background="#FFFFFF"
+android:orientation="vertical">
+
+<TextView
+    android:id="@+id/textNativeView"
+    android:layout_width="wrap_content"
+    android:background="#FFFFFF"
+    android:layout_height="wrap_content" />
+<Button
+    android:id="@+id/selectButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="SELECT" />
+</LinearLayout>


### PR DESCRIPTION
## Content of the PR 

This PR enables interaction with the markers. On click , the camera move to put the selected marker in the center of the Screen and a preview of the marker's content is displayed.  

## Why ? 

This allows the user to be informed quickly of important information about the selected parking without having to go to CardScreen.  This also enhance the interaction between the user and the map improving the number of things that the user can do just with one click. 

## How ? 

The preview card is defined in `layout/item_callout_view.xml`. Then it is displayed in MapScreen using a `ViewAnnotationManager`. There is a lot of listeners that are being used in the code. They aim to implement the expected behavior displayed to the user and to prevent any unexpected behavior that could be linked to the fact that MapBox works concurrently on multiple threads and this needs to be handled. 

## Additional resources
![image](https://github.com/user-attachments/assets/78bf6d71-4dcd-48a8-92f1-4be243cbbb2c)
