### PR TITLE
Implement user favourite parkings

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 class MockParkingRepository @Inject constructor() : ParkingRepository {
   private var uid = 0
-  private val parkings = mutableListOf<Parking>(TestInstancesParking.parking1)
+  private val parkings = mutableListOf(TestInstancesParking.parking1)
 
   override fun getNewUid(): String {
     return (uid++).toString()
@@ -19,7 +19,7 @@ class MockParkingRepository @Inject constructor() : ParkingRepository {
     onSuccess()
   }
 
-  override fun getParkings(onSuccess: (List<Parking>) -> Unit, onFailure: (Exception) -> Unit) {
+  override fun getAllParkings(onSuccess: (List<Parking>) -> Unit, onFailure: (Exception) -> Unit) {
     if (parkings.none { it.uid == "" }) onSuccess(parkings)
     else onFailure(Exception("Error getting parkings"))
   }
@@ -97,5 +97,14 @@ class MockParkingRepository @Inject constructor() : ParkingRepository {
       parkings.remove(parkings.find { it.uid == id })
       onSuccess()
     }
+  }
+
+  override fun getParkingsByListOfIds(
+      ids: List<String>,
+      onSuccess: (List<Parking>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (ids.any { it == "" }) onFailure(Exception("Error getting parkings"))
+    else onSuccess(parkings.filter { it.uid in ids })
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
@@ -23,7 +23,7 @@ interface ParkingRepository {
    * @param onSuccess a callback that is called when the parkings are retrieved
    * @param onFailure a callback that is called when an error occurs
    */
-  fun getParkings(onSuccess: (List<Parking>) -> Unit, onFailure: (Exception) -> Unit)
+  fun getAllParkings(onSuccess: (List<Parking>) -> Unit, onFailure: (Exception) -> Unit)
 
   /**
    * Get a parking by its identifier

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
@@ -82,4 +82,18 @@ interface ParkingRepository {
    * @param onFailure a callback that is called when an error occurs
    */
   fun deleteParkingById(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
+   * Get parkings by a list of identifiers. This is useful for getting the parkings that are in the
+   * list of favorite parkings of a user without having to make multiple requests.
+   *
+   * @param ids the list of identifiers of the parkings
+   * @param onSuccess a callback that is called when the parkings are retrieved
+   * @param onFailure a callback that is called when an error occurs
+   */
+  fun getParkingsByListOfIds(
+      ids: List<String>,
+      onSuccess: (List<Parking>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
@@ -59,6 +59,24 @@ class ParkingRepositoryFirestore @Inject constructor(private val db: FirebaseFir
         .addOnFailureListener { onFailure(it) }
   }
 
+  override fun getParkingsByListOfIds(
+      ids: List<String>,
+      onSuccess: (List<Parking>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereIn("uid", ids)
+        .get()
+        .addOnSuccessListener { querySnapshot ->
+          val parkings =
+              querySnapshot.documents.mapNotNull { document ->
+                document.data?.let { deserializeParking(it) }
+              }
+          onSuccess(parkings)
+        }
+        .addOnFailureListener { onFailure(it) }
+  }
+
   override fun getParkingsBetween(
       start: Point,
       end: Point,

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
@@ -27,7 +27,7 @@ class ParkingRepositoryFirestore @Inject constructor(private val db: FirebaseFir
     return db.collection(collectionPath).document().id
   }
 
-  override fun getParkings(onSuccess: (List<Parking>) -> Unit, onFailure: (Exception) -> Unit) {
+  override fun getAllParkings(onSuccess: (List<Parking>) -> Unit, onFailure: (Exception) -> Unit) {
     db.collection(collectionPath)
         .get()
         .addOnSuccessListener { querySnapshot ->
@@ -64,6 +64,10 @@ class ParkingRepositoryFirestore @Inject constructor(private val db: FirebaseFir
       onSuccess: (List<Parking>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
+    if (ids.isEmpty()) {
+      onSuccess(emptyList())
+      return
+    }
     db.collection(collectionPath)
         .whereIn("uid", ids)
         .get()

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
@@ -80,7 +80,7 @@ class ParkingRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.toObject(Parking::class.java)).thenReturn(parking)
 
     // Call the method under test
-    parkingRepositoryFirestore.getParkings(
+    parkingRepositoryFirestore.getAllParkings(
         onSuccess = { parkings ->
           // Assert that the returned list contains the expected Parking object
           assert(parkings.size == 1)
@@ -105,7 +105,7 @@ class ParkingRepositoryFirestoreTest {
     `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
 
     // Call the method under test
-    parkingRepositoryFirestore.getParkings(
+    parkingRepositoryFirestore.getAllParkings(
         onSuccess = { fail("Expected failure but got success") }, onFailure = { assert(true) })
 
     // Complete the task to trigger the addOnCompleteListener with an exception
@@ -136,6 +136,42 @@ class ParkingRepositoryFirestoreTest {
         onFailure = { assert(true) })
 
     verify(timeout(100)) { mockDocumentReference.get() }
+  }
+
+  @Test
+  fun getParkingsByListOfIds_returnsCorrectValues() {
+    // Create a TaskCompletionSource to manually complete the task
+    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
+
+    // Ensure that mockParkingQuerySnapshot is properly initialized and mocked
+    `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
+
+    // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
+    `when`(mockParkingQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+
+    // Ensure that the DocumentSnapshot returns the expected Parking object
+    `when`(mockDocumentSnapshot.toObject(Parking::class.java)).thenReturn(parking)
+
+    // Mock the CollectionReference to return Parking objects with the given IDs
+    `when`(mockCollectionReference.whereIn(any<String>(), any()))
+        .thenReturn(mockCollectionReference)
+
+    // Call the method under test
+    parkingRepositoryFirestore.getParkingsByListOfIds(
+        listOf(parking.uid),
+        onSuccess = { parkings ->
+          // Assert that the returned list contains the expected Parking object
+          assert(parkings.size == 1)
+          assert(parkings[0] == parking)
+        },
+        onFailure = { fail("Expected success but got failure") })
+
+    // Complete the task to trigger the addOnCompleteListener
+    taskCompletionSource.setResult(mockParkingQuerySnapshot)
+
+    // Verify that the 'documents' field was accessed
+    verify(timeout(100)) { mockParkingQuerySnapshot.documents }
+    verify(timeout(100)) { mockDocumentSnapshot.toObject(Parking::class.java) }
   }
 
   @Test

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -18,14 +18,14 @@ import org.robolectric.RobolectricTestRunner
 class ParkingViewModelTest {
 
   @Mock private lateinit var parkingViewModel: ParkingViewModel
-  @Mock private lateinit var parkingRepositoryFirestore: ParkingRepositoryFirestore
+  @Mock private lateinit var parkingRepository: ParkingRepository
   @Mock private lateinit var imageRepository: ImageRepository
 
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
 
-    parkingViewModel = ParkingViewModel(imageRepository, parkingRepositoryFirestore)
+    parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
   }
 
   @Test
@@ -33,7 +33,7 @@ class ParkingViewModelTest {
     parkingViewModel.addParking(TestInstancesParking.parking1)
 
     // Check if the parking was added to the repository
-    verify(parkingRepositoryFirestore).addParking(eq(TestInstancesParking.parking1), any(), any())
+    verify(parkingRepository).addParking(eq(TestInstancesParking.parking1), any(), any())
   }
 
   @Test
@@ -52,7 +52,7 @@ class ParkingViewModelTest {
 
   @Test
   fun getParkingsBetweenTest() {
-    `when`(parkingRepositoryFirestore.getParkingsBetween(any(), any(), any(), any())).then {
+    `when`(parkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
       it.getArgument<(List<Parking>) -> Unit>(2)(
           listOf(TestInstancesParking.parking1, TestInstancesParking.parking2))
     }
@@ -69,7 +69,7 @@ class ParkingViewModelTest {
 
   @Test
   fun getParkingLocationKIs0() {
-    `when`(parkingRepositoryFirestore.getKClosestParkings(any(), any(), any(), any())).then {
+    `when`(parkingRepository.getKClosestParkings(any(), any(), any(), any())).then {
       it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
     }
 
@@ -82,7 +82,7 @@ class ParkingViewModelTest {
 
   @Test
   fun getParkingLocationKIs1() {
-    `when`(parkingRepositoryFirestore.getKClosestParkings(any(), any(), any(), any())).then {
+    `when`(parkingRepository.getKClosestParkings(any(), any(), any(), any())).then {
       it.getArgument<(List<Parking>) -> Unit>(2)(listOf(TestInstancesParking.parking3))
     }
 


### PR DESCRIPTION
Closes #83 

This PR introduces a new feature to retrieve a user's favorite parkings, improving the app's personalization capabilities.

### Key Implementations:

##### UserViewModel Enhancements
- Introduced a StateFlow to manage favorite parkings
- Implemented a function to fetch and update user's favorite parkings using a ParkingRepository

##### ParkingRepository Improvements
- Added `getParkingsByListOfIds()` method for efficient bulk parking retrieval
  - Rationale: Optimizes database queries by fetching multiple parkings in a single operation

### Testing Strategy
- Updated UserViewModel unit tests to cover new StateFlow and functionality
- Added unit tests for ParkingRepository's new method
- Implemented the `getParkingsByListOfIds()` function in MockParkingRepository
- Included integration test in androidTests/ParkingRepositoryFirestore (I made them before we decided to get rid of them)

### Code Refinements
- Standardized ParkingRepository type declarations in viewModel tests
- Renamed `getParkings()` to `getAllParkings()` for clarity