### PR TITLE
User Profile Screen First Version

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -2,29 +2,29 @@ package com.github.se.cyrcle.ui.profile
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 
 @RunWith(AndroidJUnit4::class)
 class ProfileScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var mockNavController: NavHostController
 
-  private fun setupProfileScreen() {
-    composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      ProfileScreen(navigationActions = navigationActions)
-    }
+  @Before
+  fun setupProfileScreen() {
+    mockNavController = mock(NavHostController::class.java)
+    val navigationActions = NavigationActions(mockNavController)
+    composeTestRule.setContent { ProfileScreen(navigationActions = navigationActions) }
   }
 
   @Test
   fun testInitialDisplayMode() {
-    setupProfileScreen()
-
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
     }
@@ -40,8 +40,6 @@ class ProfileScreenTest {
 
   @Test
   fun testEditModeTransition() {
-    setupProfileScreen()
-
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
     }
@@ -63,8 +61,6 @@ class ProfileScreenTest {
 
   @Test
   fun testCancelEditMode() {
-    setupProfileScreen()
-
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
     }
@@ -102,8 +98,6 @@ class ProfileScreenTest {
 
   @Test
   fun testSaveChanges() {
-    setupProfileScreen()
-
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
     }
@@ -135,8 +129,6 @@ class ProfileScreenTest {
 
   @Test
   fun testFavoriteParkingsSection() {
-    setupProfileScreen()
-
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("FavoriteParkingsTitle").fetchSemanticsNodes().isNotEmpty()
     }
@@ -150,8 +142,6 @@ class ProfileScreenTest {
 
   @Test
   fun testProfileImageInteraction() {
-    setupProfileScreen()
-
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
     }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class ProfileScreenTest {
 
-
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -11,163 +11,162 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ProfileScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private fun setupProfileScreen() {
-        composeTestRule.setContent {
-            val navController = rememberNavController()
-            val navigationActions = NavigationActions(navController)
-            ProfileScreen(navigationActions = navigationActions)
-        }
+  private fun setupProfileScreen() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      ProfileScreen(navigationActions = navigationActions)
+    }
+  }
+
+  @Test
+  fun testInitialDisplayMode() {
+    setupProfileScreen()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
     }
 
-    @Test
-    fun testInitialDisplayMode() {
-        setupProfileScreen()
+    // Verify initial display mode elements
+    composeTestRule.onNodeWithTag("ProfileImage").assertExists()
+    composeTestRule.onNodeWithTag("EditButton").assertExists()
+    composeTestRule.onNodeWithTag("DisplayFirstName").assertExists()
+    composeTestRule.onNodeWithTag("DisplayLastName").assertExists()
+    composeTestRule.onNodeWithTag("DisplayUsername").assertExists()
+    composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
+  }
 
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
-        }
+  @Test
+  fun testEditModeTransition() {
+    setupProfileScreen()
 
-        // Verify initial display mode elements
-        composeTestRule.onNodeWithTag("ProfileImage").assertExists()
-        composeTestRule.onNodeWithTag("EditButton").assertExists()
-        composeTestRule.onNodeWithTag("DisplayFirstName").assertExists()
-        composeTestRule.onNodeWithTag("DisplayLastName").assertExists()
-        composeTestRule.onNodeWithTag("DisplayUsername").assertExists()
-        composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
     }
 
-    @Test
-    fun testEditModeTransition() {
-        setupProfileScreen()
+    // Enter edit mode
+    composeTestRule.onNodeWithTag("EditButton").performClick()
 
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Enter edit mode
-        composeTestRule.onNodeWithTag("EditButton").performClick()
-
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("SaveButton").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Verify edit mode elements
-        composeTestRule.onNodeWithTag("FirstNameField").assertExists()
-        composeTestRule.onNodeWithTag("LastNameField").assertExists()
-        composeTestRule.onNodeWithTag("UsernameField").assertExists()
-        composeTestRule.onNodeWithTag("SaveButton").assertExists()
-        composeTestRule.onNodeWithTag("CancelButton").assertExists()
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("SaveButton").fetchSemanticsNodes().isNotEmpty()
     }
 
-    @Test
-    fun testCancelEditMode() {
-        setupProfileScreen()
+    // Verify edit mode elements
+    composeTestRule.onNodeWithTag("FirstNameField").assertExists()
+    composeTestRule.onNodeWithTag("LastNameField").assertExists()
+    composeTestRule.onNodeWithTag("UsernameField").assertExists()
+    composeTestRule.onNodeWithTag("SaveButton").assertExists()
+    composeTestRule.onNodeWithTag("CancelButton").assertExists()
+  }
 
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
-        }
+  @Test
+  fun testCancelEditMode() {
+    setupProfileScreen()
 
-        // Enter edit mode
-        composeTestRule.onNodeWithTag("EditButton").performClick()
-
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Clear existing text and modify fields
-        composeTestRule.onNodeWithTag("FirstNameField").performTextClearance()
-        composeTestRule.onNodeWithTag("FirstNameField").performTextInput("New")
-
-        composeTestRule.onNodeWithTag("LastNameField").performTextClearance()
-        composeTestRule.onNodeWithTag("LastNameField").performTextInput("Name")
-
-        composeTestRule.onNodeWithTag("UsernameField").performTextClearance()
-        composeTestRule.onNodeWithTag("UsernameField").performTextInput("newuser")
-
-        // Cancel edit mode
-        composeTestRule.onNodeWithTag("CancelButton").performClick()
-
-        // Add a small delay to ensure state updates
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("DisplayFirstName").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Verify return to display mode with unchanged values
-        composeTestRule.onNodeWithTag("DisplayFirstName").assertTextEquals("John")
-        composeTestRule.onNodeWithTag("DisplayLastName").assertTextEquals("Doe")
-        composeTestRule.onNodeWithTag("DisplayUsername").assertTextEquals("@johndoe")
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
     }
 
-    @Test
-    fun testSaveChanges() {
-        setupProfileScreen()
+    // Enter edit mode
+    composeTestRule.onNodeWithTag("EditButton").performClick()
 
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Enter edit mode
-        composeTestRule.onNodeWithTag("EditButton").performClick()
-
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Modify fields
-        composeTestRule.onNodeWithTag("FirstNameField").performTextReplacement("Jane")
-        composeTestRule.onNodeWithTag("LastNameField").performTextReplacement("Smith")
-        composeTestRule.onNodeWithTag("UsernameField").performTextReplacement("janesmith")
-
-        // Save changes
-        composeTestRule.onNodeWithTag("SaveButton").performClick()
-
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("DisplayFirstName").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Verify updated values in display mode
-        composeTestRule.onNodeWithTag("DisplayFirstName").assertTextEquals("Jane")
-        composeTestRule.onNodeWithTag("DisplayLastName").assertTextEquals("Smith")
-        composeTestRule.onNodeWithTag("DisplayUsername").assertTextEquals("@janesmith")
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
     }
 
-    @Test
-    fun testFavoriteParkingsSection() {
-        setupProfileScreen()
+    // Clear existing text and modify fields
+    composeTestRule.onNodeWithTag("FirstNameField").performTextClearance()
+    composeTestRule.onNodeWithTag("FirstNameField").performTextInput("New")
 
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("FavoriteParkingsTitle").fetchSemanticsNodes().isNotEmpty()
-        }
+    composeTestRule.onNodeWithTag("LastNameField").performTextClearance()
+    composeTestRule.onNodeWithTag("LastNameField").performTextInput("Name")
 
-        // Check favorite parkings section exists
-        composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
+    composeTestRule.onNodeWithTag("UsernameField").performTextClearance()
+    composeTestRule.onNodeWithTag("UsernameField").performTextInput("newuser")
 
-        // If no favorites, verify empty state message
-        composeTestRule.onNodeWithTag("NoFavoritesMessage").assertExists()
+    // Cancel edit mode
+    composeTestRule.onNodeWithTag("CancelButton").performClick()
+
+    // Add a small delay to ensure state updates
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("DisplayFirstName").fetchSemanticsNodes().isNotEmpty()
     }
 
-    @Test
-    fun testProfileImageInteraction() {
-        setupProfileScreen()
+    // Verify return to display mode with unchanged values
+    composeTestRule.onNodeWithTag("DisplayFirstName").assertTextEquals("John")
+    composeTestRule.onNodeWithTag("DisplayLastName").assertTextEquals("Doe")
+    composeTestRule.onNodeWithTag("DisplayUsername").assertTextEquals("@johndoe")
+  }
 
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
-        }
+  @Test
+  fun testSaveChanges() {
+    setupProfileScreen()
 
-        // Verify profile image exists
-        composeTestRule.onNodeWithTag("ProfileImage").assertExists()
-
-        // Enter edit mode
-        composeTestRule.onNodeWithTag("EditButton").performClick()
-
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        // Verify profile image is clickable in edit mode
-        composeTestRule.onNodeWithTag("ProfileImage").assertHasClickAction()
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
     }
+
+    // Enter edit mode
+    composeTestRule.onNodeWithTag("EditButton").performClick()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Modify fields
+    composeTestRule.onNodeWithTag("FirstNameField").performTextReplacement("Jane")
+    composeTestRule.onNodeWithTag("LastNameField").performTextReplacement("Smith")
+    composeTestRule.onNodeWithTag("UsernameField").performTextReplacement("janesmith")
+
+    // Save changes
+    composeTestRule.onNodeWithTag("SaveButton").performClick()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("DisplayFirstName").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Verify updated values in display mode
+    composeTestRule.onNodeWithTag("DisplayFirstName").assertTextEquals("Jane")
+    composeTestRule.onNodeWithTag("DisplayLastName").assertTextEquals("Smith")
+    composeTestRule.onNodeWithTag("DisplayUsername").assertTextEquals("@janesmith")
+  }
+
+  @Test
+  fun testFavoriteParkingsSection() {
+    setupProfileScreen()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FavoriteParkingsTitle").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Check favorite parkings section exists
+    composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
+
+    // If no favorites, verify empty state message
+    composeTestRule.onNodeWithTag("NoFavoritesMessage").assertExists()
+  }
+
+  @Test
+  fun testProfileImageInteraction() {
+    setupProfileScreen()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Verify profile image exists
+    composeTestRule.onNodeWithTag("ProfileImage").assertExists()
+
+    // Enter edit mode
+    composeTestRule.onNodeWithTag("EditButton").performClick()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Verify profile image is clickable in edit mode
+    composeTestRule.onNodeWithTag("ProfileImage").assertHasClickAction()
+  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -1,130 +1,173 @@
 package com.github.se.cyrcle.ui.profile
 
-import ProfileScreen
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.ui.navigation.NavigationActions
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ProfileScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
-  @get:Rule val composeTestRule = createComposeRule()
-
-  @Test
-  fun testProfileScreenDisplaysUserInfo() {
-    val user =
-        User(
-            userId = "12345",
-            username = "eggsampluser",
-            firstName = "Eggsam",
-            lastName = "P.LU. Sir",
-            email = "eggsampleruser@epfl.ch",
-            profilePictureUrl = "",
-            favoriteParkings = listOf("Parking A", "Parking B", "Parking C"))
-
-    composeTestRule.setContent { ProfileScreen(user) }
-
-    composeTestRule.waitUntil(timeoutMillis = 5000) {
-      composeTestRule.onAllNodesWithTag("ProfilePicture").fetchSemanticsNodes().isNotEmpty()
+    private fun setupProfileScreen() {
+        composeTestRule.setContent {
+            val navController = rememberNavController()
+            val navigationActions = NavigationActions(navController)
+            ProfileScreen(navigationActions = navigationActions)
+        }
     }
 
-    composeTestRule.onNodeWithTag("UserNameDisplay").assertTextContains("Eggsam P.LU. Sir")
-    composeTestRule.onNodeWithTag("UserHandleDisplay").assertTextContains("@eggsampluser")
-    composeTestRule.onNodeWithTag("ParkingItem_0").assertTextContains("Parking A")
-  }
+    @Test
+    fun testInitialDisplayMode() {
+        setupProfileScreen()
 
-  @Test
-  fun testToggleFavoriteParking() {
-    val user =
-        User(
-            userId = "12345",
-            username = "eggsampluser",
-            firstName = "Eggsam",
-            lastName = "P.LU. Sir",
-            email = "eggsampleruser@epfl.ch",
-            profilePictureUrl = "",
-            favoriteParkings = listOf("Parking A", "Parking B"))
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
+        }
 
-    composeTestRule.setContent { ProfileScreen(user) }
-
-    // Ensure the list of favorite parkings is displayed
-    composeTestRule.waitUntil(timeoutMillis = 5000) {
-      composeTestRule.onAllNodesWithTag("FavoriteParkingList").fetchSemanticsNodes().isNotEmpty()
+        // Verify initial display mode elements
+        composeTestRule.onNodeWithTag("ProfileImage").assertExists()
+        composeTestRule.onNodeWithTag("EditButton").assertExists()
+        composeTestRule.onNodeWithTag("DisplayFirstName").assertExists()
+        composeTestRule.onNodeWithTag("DisplayLastName").assertExists()
+        composeTestRule.onNodeWithTag("DisplayUsername").assertExists()
+        composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
     }
 
-    // Initial state: filled star for first parking
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsDisplayed()
+    @Test
+    fun testEditModeTransition() {
+        setupProfileScreen()
 
-    // Perform click to toggle to empty star
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
+        }
 
-    // Check if the first star is empty now
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsDisplayed()
+        // Enter edit mode
+        composeTestRule.onNodeWithTag("EditButton").performClick()
 
-    // Perform click to toggle back to filled star
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("SaveButton").fetchSemanticsNodes().isNotEmpty()
+        }
 
-    // Check if the first star is filled again
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsDisplayed()
-  }
-
-  @Test
-  fun testEditModeSwitch() {
-    val user =
-        User(
-            userId = "12345",
-            username = "eggsampluser",
-            firstName = "Eggsam",
-            lastName = "P.LU. Sir",
-            email = "eggsampleruser@epfl.ch",
-            profilePictureUrl = "",
-            favoriteParkings = listOf("Parking A", "Parking B"))
-
-    composeTestRule.setContent { ProfileScreen(user) }
-
-    composeTestRule.onNodeWithTag("ModifyButton").performClick()
-
-    composeTestRule.waitUntil(timeoutMillis = 5000) {
-      composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
+        // Verify edit mode elements
+        composeTestRule.onNodeWithTag("FirstNameField").assertExists()
+        composeTestRule.onNodeWithTag("LastNameField").assertExists()
+        composeTestRule.onNodeWithTag("UsernameField").assertExists()
+        composeTestRule.onNodeWithTag("SaveButton").assertExists()
+        composeTestRule.onNodeWithTag("CancelButton").assertExists()
     }
 
-    composeTestRule.onNodeWithTag("FirstNameField").assertExists()
-    composeTestRule.onNodeWithTag("LastNameField").assertExists()
-    composeTestRule.onNodeWithTag("UsernameField").assertExists()
-  }
+    @Test
+    fun testCancelEditMode() {
+        setupProfileScreen()
 
-  @Test
-  fun testSaveChangesButton() {
-    val testUser =
-        User(
-            userId = "12345",
-            username = "eggsampluser",
-            firstName = "Eggsam",
-            lastName = "P.LU. Sir",
-            email = "eggsampleruser@epfl.ch",
-            profilePictureUrl = "",
-            favoriteParkings = listOf("Parking A", "Parking B", "Parking C"))
-    composeTestRule.setContent { ProfileScreen(testUser) }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
+        }
 
-    // Enter edit mode
-    composeTestRule.onNodeWithTag("ModifyButton").performClick()
+        // Enter edit mode
+        composeTestRule.onNodeWithTag("EditButton").performClick()
 
-    // Modify fields
-    composeTestRule.onNodeWithTag("FirstNameField").performTextInput("NewName")
-    composeTestRule.onNodeWithTag("LastNameField").performTextInput("NewLastName")
-    composeTestRule.onNodeWithTag("UsernameField").performTextInput("newusername")
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
+        }
 
-    // Save changes
-    composeTestRule.onNodeWithTag("SaveButton").performClick()
+        // Clear existing text and modify fields
+        composeTestRule.onNodeWithTag("FirstNameField").performTextClearance()
+        composeTestRule.onNodeWithTag("FirstNameField").performTextInput("New")
 
-    // Verify display mode is active
-    composeTestRule.onNodeWithTag("ModifyButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("FirstNameField").assertDoesNotExist()
-    composeTestRule.onNodeWithTag("SaveButton").assertDoesNotExist()
-    composeTestRule.onNodeWithTag("CancelButton").assertDoesNotExist()
-  }
+        composeTestRule.onNodeWithTag("LastNameField").performTextClearance()
+        composeTestRule.onNodeWithTag("LastNameField").performTextInput("Name")
+
+        composeTestRule.onNodeWithTag("UsernameField").performTextClearance()
+        composeTestRule.onNodeWithTag("UsernameField").performTextInput("newuser")
+
+        // Cancel edit mode
+        composeTestRule.onNodeWithTag("CancelButton").performClick()
+
+        // Add a small delay to ensure state updates
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("DisplayFirstName").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verify return to display mode with unchanged values
+        composeTestRule.onNodeWithTag("DisplayFirstName").assertTextEquals("John")
+        composeTestRule.onNodeWithTag("DisplayLastName").assertTextEquals("Doe")
+        composeTestRule.onNodeWithTag("DisplayUsername").assertTextEquals("@johndoe")
+    }
+
+    @Test
+    fun testSaveChanges() {
+        setupProfileScreen()
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("EditButton").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Enter edit mode
+        composeTestRule.onNodeWithTag("EditButton").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Modify fields
+        composeTestRule.onNodeWithTag("FirstNameField").performTextReplacement("Jane")
+        composeTestRule.onNodeWithTag("LastNameField").performTextReplacement("Smith")
+        composeTestRule.onNodeWithTag("UsernameField").performTextReplacement("janesmith")
+
+        // Save changes
+        composeTestRule.onNodeWithTag("SaveButton").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("DisplayFirstName").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verify updated values in display mode
+        composeTestRule.onNodeWithTag("DisplayFirstName").assertTextEquals("Jane")
+        composeTestRule.onNodeWithTag("DisplayLastName").assertTextEquals("Smith")
+        composeTestRule.onNodeWithTag("DisplayUsername").assertTextEquals("@janesmith")
+    }
+
+    @Test
+    fun testFavoriteParkingsSection() {
+        setupProfileScreen()
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("FavoriteParkingsTitle").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Check favorite parkings section exists
+        composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
+
+        // If no favorites, verify empty state message
+        composeTestRule.onNodeWithTag("NoFavoritesMessage").assertExists()
+    }
+
+    @Test
+    fun testProfileImageInteraction() {
+        setupProfileScreen()
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verify profile image exists
+        composeTestRule.onNodeWithTag("ProfileImage").assertExists()
+
+        // Enter edit mode
+        composeTestRule.onNodeWithTag("EditButton").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithTag("ProfileImage").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Verify profile image is clickable in edit mode
+        composeTestRule.onNodeWithTag("ProfileImage").assertHasClickAction()
+    }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class ProfileScreenTest {
 
+
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -14,8 +14,6 @@ class ProfileScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-
-
   @Test
   fun testProfileScreenDisplaysUserInfo() {
     val user =
@@ -99,40 +97,34 @@ class ProfileScreenTest {
     composeTestRule.onNodeWithTag("UsernameField").assertExists()
   }
 
+  @Test
+  fun testSaveChangesButton() {
+    val testUser =
+        User(
+            userId = "12345",
+            username = "eggsampluser",
+            firstName = "Eggsam",
+            lastName = "P.LU. Sir",
+            email = "eggsampleruser@epfl.ch",
+            profilePictureUrl = "",
+            favoriteParkings = listOf("Parking A", "Parking B", "Parking C"))
+    composeTestRule.setContent { ProfileScreen(testUser) }
 
+    // Enter edit mode
+    composeTestRule.onNodeWithTag("ModifyButton").performClick()
 
-    @Test
-    fun testSaveChangesButton() {
-        val testUser =
-            User(
-                userId = "12345",
-                username = "eggsampluser",
-                firstName = "Eggsam",
-                lastName = "P.LU. Sir",
-                email = "eggsampleruser@epfl.ch",
-                profilePictureUrl = "",
-                favoriteParkings = listOf("Parking A", "Parking B", "Parking C"))
-        composeTestRule.setContent { ProfileScreen(testUser) }
+    // Modify fields
+    composeTestRule.onNodeWithTag("FirstNameField").performTextInput("NewName")
+    composeTestRule.onNodeWithTag("LastNameField").performTextInput("NewLastName")
+    composeTestRule.onNodeWithTag("UsernameField").performTextInput("newusername")
 
-        // Enter edit mode
-        composeTestRule.onNodeWithTag("ModifyButton").performClick()
+    // Save changes
+    composeTestRule.onNodeWithTag("SaveButton").performClick()
 
-        // Modify fields
-        composeTestRule.onNodeWithTag("FirstNameField")
-            .performTextInput("NewName")
-        composeTestRule.onNodeWithTag("LastNameField")
-            .performTextInput("NewLastName")
-        composeTestRule.onNodeWithTag("UsernameField")
-            .performTextInput("newusername")
-
-        // Save changes
-        composeTestRule.onNodeWithTag("SaveButton").performClick()
-
-        // Verify display mode is active
-        composeTestRule.onNodeWithTag("ModifyButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("FirstNameField").assertDoesNotExist()
-        composeTestRule.onNodeWithTag("SaveButton").assertDoesNotExist()
-        composeTestRule.onNodeWithTag("CancelButton").assertDoesNotExist()
-    }
-
+    // Verify display mode is active
+    composeTestRule.onNodeWithTag("ModifyButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("FirstNameField").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("SaveButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("CancelButton").assertDoesNotExist()
+  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -1,0 +1,138 @@
+package com.github.se.cyrcle.ui.profile
+
+import ProfileScreen
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.model.user.User
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProfileScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+
+
+  @Test
+  fun testProfileScreenDisplaysUserInfo() {
+    val user =
+        User(
+            userId = "12345",
+            username = "eggsampluser",
+            firstName = "Eggsam",
+            lastName = "P.LU. Sir",
+            email = "eggsampleruser@epfl.ch",
+            profilePictureUrl = "",
+            favoriteParkings = listOf("Parking A", "Parking B", "Parking C"))
+
+    composeTestRule.setContent { ProfileScreen(user) }
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("ProfilePicture").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag("UserNameDisplay").assertTextContains("Eggsam P.LU. Sir")
+    composeTestRule.onNodeWithTag("UserHandleDisplay").assertTextContains("@eggsampluser")
+    composeTestRule.onNodeWithTag("ParkingItem_0").assertTextContains("Parking A")
+  }
+
+  @Test
+  fun testToggleFavoriteParking() {
+    val user =
+        User(
+            userId = "12345",
+            username = "eggsampluser",
+            firstName = "Eggsam",
+            lastName = "P.LU. Sir",
+            email = "eggsampleruser@epfl.ch",
+            profilePictureUrl = "",
+            favoriteParkings = listOf("Parking A", "Parking B"))
+
+    composeTestRule.setContent { ProfileScreen(user) }
+
+    // Ensure the list of favorite parkings is displayed
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FavoriteParkingList").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Initial state: filled star for first parking
+    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsDisplayed()
+
+    // Perform click to toggle to empty star
+    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+
+    // Check if the first star is empty now
+    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsDisplayed()
+
+    // Perform click to toggle back to filled star
+    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+
+    // Check if the first star is filled again
+    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsDisplayed()
+  }
+
+  @Test
+  fun testEditModeSwitch() {
+    val user =
+        User(
+            userId = "12345",
+            username = "eggsampluser",
+            firstName = "Eggsam",
+            lastName = "P.LU. Sir",
+            email = "eggsampleruser@epfl.ch",
+            profilePictureUrl = "",
+            favoriteParkings = listOf("Parking A", "Parking B"))
+
+    composeTestRule.setContent { ProfileScreen(user) }
+
+    composeTestRule.onNodeWithTag("ModifyButton").performClick()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag("FirstNameField").assertExists()
+    composeTestRule.onNodeWithTag("LastNameField").assertExists()
+    composeTestRule.onNodeWithTag("UsernameField").assertExists()
+  }
+
+
+
+    @Test
+    fun testSaveChangesButton() {
+        val testUser =
+            User(
+                userId = "12345",
+                username = "eggsampluser",
+                firstName = "Eggsam",
+                lastName = "P.LU. Sir",
+                email = "eggsampleruser@epfl.ch",
+                profilePictureUrl = "",
+                favoriteParkings = listOf("Parking A", "Parking B", "Parking C"))
+        composeTestRule.setContent { ProfileScreen(testUser) }
+
+        // Enter edit mode
+        composeTestRule.onNodeWithTag("ModifyButton").performClick()
+
+        // Modify fields
+        composeTestRule.onNodeWithTag("FirstNameField")
+            .performTextInput("NewName")
+        composeTestRule.onNodeWithTag("LastNameField")
+            .performTextInput("NewLastName")
+        composeTestRule.onNodeWithTag("UsernameField")
+            .performTextInput("newusername")
+
+        // Save changes
+        composeTestRule.onNodeWithTag("SaveButton").performClick()
+
+        // Verify display mode is active
+        composeTestRule.onNodeWithTag("ModifyButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("FirstNameField").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("SaveButton").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("CancelButton").assertDoesNotExist()
+    }
+
+}

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -16,6 +16,7 @@ import com.github.se.cyrcle.ui.map.MapScreen
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
+import com.github.se.cyrcle.ui.profile.ProfileScreen
 import com.github.se.cyrcle.ui.review.ReviewScreen
 
 @Composable
@@ -52,11 +53,20 @@ fun CyrcleNavHost(
     ) {
       composable(Screen.MAP) { MapScreen(navigationActions, parkingViewModel, mapViewModel) }
     }
+
     navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
       composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, mapViewModel) }
       composable(Screen.ATTRIBUTES_PICKER) {
         AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
       }
+    }
+
+    // Add this new navigation block for Profile
+    navigation(
+        startDestination = Screen.PROFILE,
+        route = Route.PROFILE,
+    ) {
+      composable(Screen.PROFILE) { ProfileScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -13,7 +13,7 @@ object Route {
   const val LIST = "List"
   const val MAP = "Map"
   const val ADD_SPOTS = "Add Spots"
-  const val PROFILE = "Profile" // Add this
+  const val PROFILE = "Profile"
 }
 
 object Screen {
@@ -24,11 +24,19 @@ object Screen {
   const val REVIEW = "Review Screen"
   const val LOCATION_PICKER = "Location Picker"
   const val ATTRIBUTES_PICKER = "Attributes Picker"
-  const val PROFILE = "Profile Screen" // Add this
+  const val PROFILE = "Profile Screen"
 }
 
+/**
+ * Data class representing a top level destination in the app.
+ *
+ * @param route The route of the destination
+ * @param icon The icon to display for the destination
+ * @param textId The string resource ID for the text to display for the destination
+ */
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
 
+/** Object containing the top level destinations in the app. */
 object TopLevelDestinations {
   val LIST =
       TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
@@ -39,29 +47,57 @@ object TopLevelDestinations {
           route = Route.PROFILE, icon = Icons.Outlined.Person, textId = Route.PROFILE)
 }
 
+/** List of top level destinations in the app. */
 val LIST_TOP_LEVEL_DESTINATION =
     listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
 
+
+/** Adapter class for navigating between screens in the app. */
 open class NavigationActions(private val navController: NavHostController) {
+
+  /**
+   * Navigate to the specified [TopLevelDestination]
+   *
+   * @param destination The top level destination to navigate to.
+   *
+   * Clear the back stack when navigating to a new destination.
+   */
   open fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
       popUpTo(navController.graph.findStartDestination().id) {
+        // Pop up to the start destination of the graph to
+        // avoid building up a large stack of destinations
+        // on the back stack as users select items
         saveState = true
         inclusive = true
       }
+      // Avoid multiple copies of the same destination when
+      // reselecting the same item
       launchSingleTop = true
+      // Restore state when reselecting a previously selected item
       restoreState = true
     }
   }
 
+  /**
+   * Navigate to the specified screen.
+   *
+   * @param screen The screen to navigate to
+   */
   open fun navigateTo(screen: String) {
     navController.navigate(screen)
   }
 
+  /** Navigate back to the previous screen. */
   open fun goBack() {
     navController.popBackStack()
   }
 
+  /**
+   * Get the current route of the navigation controller.
+   *
+   * @return The current route
+   */
   open fun currentRoute(): String {
     return navController.currentDestination?.route ?: ""
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -51,7 +51,6 @@ object TopLevelDestinations {
 val LIST_TOP_LEVEL_DESTINATION =
     listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
 
-
 /** Adapter class for navigating between screens in the app. */
 open class NavigationActions(private val navController: NavHostController) {
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -3,6 +3,7 @@ package com.github.se.cyrcle.ui.navigation
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -12,6 +13,7 @@ object Route {
   const val LIST = "List"
   const val MAP = "Map"
   const val ADD_SPOTS = "Add Spots"
+  const val PROFILE = "Profile" // Add this
 }
 
 object Screen {
@@ -22,74 +24,44 @@ object Screen {
   const val REVIEW = "Review Screen"
   const val LOCATION_PICKER = "Location Picker"
   const val ATTRIBUTES_PICKER = "Attributes Picker"
+  const val PROFILE = "Profile Screen" // Add this
 }
 
-/**
- * Data class representing a top level destination in the app.
- *
- * @param route The route of the destination
- * @param icon The icon to display for the destination
- * @param textId The string resource ID for the text to display for the destination
- */
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
 
-/** Object containing the top level destinations in the app. */
 object TopLevelDestinations {
   val LIST =
       TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
   val MAP =
       TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.LocationOn, textId = Route.MAP)
+  val PROFILE =
+      TopLevelDestination(
+          route = Route.PROFILE, icon = Icons.Outlined.Person, textId = Route.PROFILE)
 }
 
-/** List of top level destinations in the app. */
-val LIST_TOP_LEVEL_DESTINATION = listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST)
+val LIST_TOP_LEVEL_DESTINATION =
+    listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
 
-/** Adapter class for navigating between screens in the app. */
 open class NavigationActions(private val navController: NavHostController) {
-
-  /**
-   * Navigate to the specified [TopLevelDestination]
-   *
-   * @param destination The top level destination to navigate to.
-   *
-   * Clear the back stack when navigating to a new destination.
-   */
   open fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
-      // Pop up to the start destination of the graph to
-      // avoid building up a large stack of destinations
-      // on the back stack as users select items
       popUpTo(navController.graph.findStartDestination().id) {
         saveState = true
         inclusive = true
       }
-      // Avoid multiple copies of the same destination when
-      // reselecting the same item
       launchSingleTop = true
-      // Restore state when reselecting a previously selected item
       restoreState = true
     }
   }
 
-  /**
-   * Navigate to the specified screen.
-   *
-   * @param screen The screen to navigate to
-   */
   open fun navigateTo(screen: String) {
     navController.navigate(screen)
   }
 
-  /** Navigate back to the previous screen. */
   open fun goBack() {
     navController.popBackStack()
   }
 
-  /**
-   * Get the current route of the navigation controller.
-   *
-   * @return The current route
-   */
   open fun currentRoute(): String {
     return navController.currentDestination?.route ?: ""
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -34,25 +34,20 @@ import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
-// TODO: add some requirements to be able to save changes, such as having a non empty text field.
-
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
-  // Current values
   var isEditing by remember { mutableStateOf(false) }
   var firstName by remember { mutableStateOf("John") }
   var lastName by remember { mutableStateOf("Doe") }
   var username by remember { mutableStateOf("johndoe") }
   var profilePictureUrl by remember { mutableStateOf("") }
-  var favoriteParkings by remember { mutableStateOf(ArrayList<String>()) }
+  var favoriteParkings by remember { mutableStateOf(emptyList<String>()) }
 
-  // Store original values for cancellation
   var originalFirstName by remember { mutableStateOf(firstName) }
   var originalLastName by remember { mutableStateOf(lastName) }
   var originalUsername by remember { mutableStateOf(username) }
   var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
 
-  val context = LocalContext.current
   val imagePickerLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         uri?.let { profilePictureUrl = it.toString() }
@@ -84,7 +79,6 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                     onUsernameChange = { username = it },
                     onImageClick = { imagePickerLauncher.launch("image/*") },
                     onSave = {
-                      // Update original values when saving
                       originalFirstName = firstName
                       originalLastName = lastName
                       originalUsername = username
@@ -92,7 +86,6 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                       isEditing = false
                     },
                     onCancel = {
-                      // Restore original values when canceling
                       firstName = originalFirstName
                       lastName = originalLastName
                       username = originalUsername
@@ -106,7 +99,6 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                     username = username,
                     profilePictureUrl = profilePictureUrl,
                     onEditClick = {
-                      // Store original values when entering edit mode
                       originalFirstName = firstName
                       originalLastName = lastName
                       originalUsername = username
@@ -280,8 +272,8 @@ private fun ProfileImage(
 
 @Composable
 private fun FavoriteParkingsSection(
-    favoriteParkings: ArrayList<String>,
-    onFavoritesUpdated: (ArrayList<String>) -> Unit
+    favoriteParkings: List<String>,
+    onFavoritesUpdated: (List<String>) -> Unit
 ) {
   Text(
       text = "Favorite Parkings",
@@ -304,7 +296,7 @@ private fun FavoriteParkingsSection(
                 parking = parking,
                 index = index,
                 onRemove = {
-                  val updatedList = ArrayList(favoriteParkings)
+                  val updatedList = favoriteParkings.toMutableList()
                   updatedList.removeAt(index)
                   onFavoritesUpdated(updatedList)
                 })

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -34,50 +34,46 @@ import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
-//TODO: add some requirements to be able to save changes, such as having a non empty text field.
-
+// TODO: add some requirements to be able to save changes, such as having a non empty text field.
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
-    // Current values
-    var isEditing by remember { mutableStateOf(false) }
-    var firstName by remember { mutableStateOf("John") }
-    var lastName by remember { mutableStateOf("Doe") }
-    var username by remember { mutableStateOf("johndoe") }
-    var profilePictureUrl by remember { mutableStateOf("") }
-    var favoriteParkings by remember { mutableStateOf(ArrayList<String>()) }
+  // Current values
+  var isEditing by remember { mutableStateOf(false) }
+  var firstName by remember { mutableStateOf("John") }
+  var lastName by remember { mutableStateOf("Doe") }
+  var username by remember { mutableStateOf("johndoe") }
+  var profilePictureUrl by remember { mutableStateOf("") }
+  var favoriteParkings by remember { mutableStateOf(ArrayList<String>()) }
 
-    // Store original values for cancellation
-    var originalFirstName by remember { mutableStateOf(firstName) }
-    var originalLastName by remember { mutableStateOf(lastName) }
-    var originalUsername by remember { mutableStateOf(username) }
-    var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
+  // Store original values for cancellation
+  var originalFirstName by remember { mutableStateOf(firstName) }
+  var originalLastName by remember { mutableStateOf(lastName) }
+  var originalUsername by remember { mutableStateOf(username) }
+  var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
 
-    val context = LocalContext.current
-    val imagePickerLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-            uri?.let { profilePictureUrl = it.toString() }
-        }
+  val context = LocalContext.current
+  val imagePickerLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { profilePictureUrl = it.toString() }
+      }
 
-    Scaffold(
-        modifier = Modifier.testTag("ProfileScreen"),
-        bottomBar = {
-            BottomNavigationBar(
-                navigationActions = navigationActions,
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = Route.PROFILE
-            )
-        }
-    ) { innerPadding ->
+  Scaffold(
+      modifier = Modifier.testTag("ProfileScreen"),
+      bottomBar = {
+        BottomNavigationBar(
+            navigationActions = navigationActions,
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = Route.PROFILE)
+      }) { innerPadding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(16.dp)
-                .testTag("ProfileContent"),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            if (isEditing) {
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp)
+                    .testTag("ProfileContent"),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              if (isEditing) {
                 EditProfileContent(
                     firstName = firstName,
                     lastName = lastName,
@@ -88,46 +84,44 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                     onUsernameChange = { username = it },
                     onImageClick = { imagePickerLauncher.launch("image/*") },
                     onSave = {
-                        // Update original values when saving
-                        originalFirstName = firstName
-                        originalLastName = lastName
-                        originalUsername = username
-                        originalProfilePictureUrl = profilePictureUrl
-                        isEditing = false
+                      // Update original values when saving
+                      originalFirstName = firstName
+                      originalLastName = lastName
+                      originalUsername = username
+                      originalProfilePictureUrl = profilePictureUrl
+                      isEditing = false
                     },
                     onCancel = {
-                        // Restore original values when canceling
-                        firstName = originalFirstName
-                        lastName = originalLastName
-                        username = originalUsername
-                        profilePictureUrl = originalProfilePictureUrl
-                        isEditing = false
-                    }
-                )
-            } else {
+                      // Restore original values when canceling
+                      firstName = originalFirstName
+                      lastName = originalLastName
+                      username = originalUsername
+                      profilePictureUrl = originalProfilePictureUrl
+                      isEditing = false
+                    })
+              } else {
                 DisplayProfileContent(
                     firstName = firstName,
                     lastName = lastName,
                     username = username,
                     profilePictureUrl = profilePictureUrl,
                     onEditClick = {
-                        // Store original values when entering edit mode
-                        originalFirstName = firstName
-                        originalLastName = lastName
-                        originalUsername = username
-                        originalProfilePictureUrl = profilePictureUrl
-                        isEditing = true
-                    }
-                )
-            }
+                      // Store original values when entering edit mode
+                      originalFirstName = firstName
+                      originalLastName = lastName
+                      originalUsername = username
+                      originalProfilePictureUrl = profilePictureUrl
+                      isEditing = true
+                    })
+              }
 
-            Spacer(modifier = Modifier.height(24.dp))
+              Spacer(modifier = Modifier.height(24.dp))
 
-            FavoriteParkingsSection(favoriteParkings) { newFavorites ->
+              FavoriteParkingsSection(favoriteParkings) { newFavorites ->
                 favoriteParkings = newFavorites
+              }
             }
-        }
-    }
+      }
 }
 
 @Composable
@@ -143,57 +137,47 @@ private fun EditProfileContent(
     onSave: () -> Unit,
     onCancel: () -> Unit
 ) {
-    ProfileImage(
-        url = profilePictureUrl,
-        onClick = onImageClick,
-        isEditable = true,
-        modifier = Modifier.testTag("ProfileImage")
-    )
+  ProfileImage(
+      url = profilePictureUrl,
+      onClick = onImageClick,
+      isEditable = true,
+      modifier = Modifier.testTag("ProfileImage"))
 
-    Spacer(modifier = Modifier.height(24.dp))
+  Spacer(modifier = Modifier.height(24.dp))
 
-    InputText(
-        value = firstName,
-        onValueChange = onFirstNameChange,
-        label = "First Name",
-        testTag = "FirstNameField"
-    )
+  InputText(
+      value = firstName,
+      onValueChange = onFirstNameChange,
+      label = "First Name",
+      testTag = "FirstNameField")
 
-    Spacer(modifier = Modifier.height(8.dp))
+  Spacer(modifier = Modifier.height(8.dp))
 
-    InputText(
-        value = lastName,
-        onValueChange = onLastNameChange,
-        label = "Last Name",
-        testTag = "LastNameField"
-    )
+  InputText(
+      value = lastName,
+      onValueChange = onLastNameChange,
+      label = "Last Name",
+      testTag = "LastNameField")
 
-    Spacer(modifier = Modifier.height(8.dp))
+  Spacer(modifier = Modifier.height(8.dp))
 
-    InputText(
-        value = username,
-        onValueChange = onUsernameChange,
-        label = "Username",
-        testTag = "UsernameField"
-    )
+  InputText(
+      value = username,
+      onValueChange = onUsernameChange,
+      label = "Username",
+      testTag = "UsernameField")
 
-    Spacer(modifier = Modifier.height(16.dp))
+  Spacer(modifier = Modifier.height(16.dp))
 
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Button(
-            text = "Save",
-            onClick = onSave,
-            colorLevel = ColorLevel.PRIMARY,
-            testTag = "SaveButton"
-        )
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Button(text = "Save", onClick = onSave, colorLevel = ColorLevel.PRIMARY, testTag = "SaveButton")
 
-        Button(
-            text = "Cancel",
-            onClick = onCancel,
-            colorLevel = ColorLevel.SECONDARY,
-            testTag = "CancelButton"
-        )
-    }
+    Button(
+        text = "Cancel",
+        onClick = onCancel,
+        colorLevel = ColorLevel.SECONDARY,
+        testTag = "CancelButton")
+  }
 }
 
 @Composable
@@ -204,43 +188,38 @@ private fun DisplayProfileContent(
     profilePictureUrl: String,
     onEditClick: () -> Unit
 ) {
-    Text(
-        text = firstName,
-        style = MaterialTheme.typography.headlineMedium,
-        modifier = Modifier.testTag("DisplayFirstName")
-    )
+  Text(
+      text = firstName,
+      style = MaterialTheme.typography.headlineMedium,
+      modifier = Modifier.testTag("DisplayFirstName"))
 
-    Text(
-        text = lastName,
-        style = MaterialTheme.typography.headlineMedium,
-        modifier = Modifier.testTag("DisplayLastName")
-    )
+  Text(
+      text = lastName,
+      style = MaterialTheme.typography.headlineMedium,
+      modifier = Modifier.testTag("DisplayLastName"))
 
-    Spacer(modifier = Modifier.height(16.dp))
+  Spacer(modifier = Modifier.height(16.dp))
 
-    ProfileImage(
-        url = profilePictureUrl,
-        onClick = {},
-        isEditable = false,
-        modifier = Modifier.testTag("ProfileImage")
-    )
+  ProfileImage(
+      url = profilePictureUrl,
+      onClick = {},
+      isEditable = false,
+      modifier = Modifier.testTag("ProfileImage"))
 
-    Spacer(modifier = Modifier.height(8.dp))
+  Spacer(modifier = Modifier.height(8.dp))
 
-    Text(
-        text = "@$username",
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("DisplayUsername")
-    )
+  Text(
+      text = "@$username",
+      style = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.testTag("DisplayUsername"))
 
-    Spacer(modifier = Modifier.height(16.dp))
+  Spacer(modifier = Modifier.height(16.dp))
 
-    Button(
-        text = "Modify Profile",
-        onClick = onEditClick,
-        colorLevel = ColorLevel.TERTIARY,
-        testTag = "EditButton"
-    )
+  Button(
+      text = "Modify Profile",
+      onClick = onEditClick,
+      colorLevel = ColorLevel.TERTIARY,
+      testTag = "EditButton")
 }
 
 @Composable
@@ -250,61 +229,53 @@ private fun ProfileImage(
     isEditable: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val context = LocalContext.current
-    val painter = rememberAsyncImagePainter(
-        ImageRequest.Builder(context)
-            .data(if (url.isNotBlank()) url else null)
-            .apply { transformations(CircleCropTransformation()) }
-            .build()
-    )
+  val context = LocalContext.current
+  val painter =
+      rememberAsyncImagePainter(
+          ImageRequest.Builder(context)
+              .data(if (url.isNotBlank()) url else null)
+              .apply { transformations(CircleCropTransformation()) }
+              .build())
 
-    Box(
-        modifier = modifier
-            .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)
-    ) {
+  Box(
+      modifier =
+          modifier.then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)) {
         if (url.isBlank()) {
-            Box(
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
+          Box(
+              modifier =
+                  Modifier.size(120.dp)
+                      .clip(CircleShape)
+                      .background(MaterialTheme.colorScheme.primaryContainer),
+              contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.Filled.Person,
                     contentDescription = "Default Profile Picture",
                     modifier = Modifier.size(60.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer)
+              }
         } else {
-            Image(
-                painter = painter,
-                contentDescription = "Profile Picture",
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop
-            )
+          Image(
+              painter = painter,
+              contentDescription = "Profile Picture",
+              modifier = Modifier.size(120.dp).clip(CircleShape),
+              contentScale = ContentScale.Crop)
         }
 
         if (isEditable) {
-            Box(
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape)
-                    .background(Color.Black.copy(alpha = 0.3f)),
-                contentAlignment = Alignment.Center
-            ) {
+          Box(
+              modifier =
+                  Modifier.size(120.dp)
+                      .clip(CircleShape)
+                      .background(Color.Black.copy(alpha = 0.3f)),
+              contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.Filled.Edit,
                     contentDescription = "Edit Profile Picture",
                     tint = Color.White,
-                    modifier = Modifier.size(40.dp)
-                )
-            }
+                    modifier = Modifier.size(40.dp))
+              }
         }
-    }
+      }
 }
 
 @Composable
@@ -312,78 +283,58 @@ private fun FavoriteParkingsSection(
     favoriteParkings: ArrayList<String>,
     onFavoritesUpdated: (ArrayList<String>) -> Unit
 ) {
+  Text(
+      text = "Favorite Parkings",
+      style = MaterialTheme.typography.titleLarge,
+      modifier = Modifier.testTag("FavoriteParkingsTitle"))
+
+  Spacer(modifier = Modifier.height(16.dp))
+
+  if (favoriteParkings.isEmpty()) {
     Text(
-        text = "Favorite Parkings",
-        style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.testTag("FavoriteParkingsTitle")
-    )
-
-    Spacer(modifier = Modifier.height(16.dp))
-
-    if (favoriteParkings.isEmpty()) {
-        Text(
-            text = "No favorite parkings yet",
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("NoFavoritesMessage")
-        )
-    } else {
-        LazyRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("FavoriteParkingList"),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            itemsIndexed(favoriteParkings) { index, parking ->
-                FavoriteParkingCard(
-                    parking = parking,
-                    index = index,
-                    onRemove = {
-                        val updatedList = ArrayList(favoriteParkings)
-                        updatedList.removeAt(index)
-                        onFavoritesUpdated(updatedList)
-                    }
-                )
-            }
+        text = "No favorite parkings yet",
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.testTag("NoFavoritesMessage"))
+  } else {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          itemsIndexed(favoriteParkings) { index, parking ->
+            FavoriteParkingCard(
+                parking = parking,
+                index = index,
+                onRemove = {
+                  val updatedList = ArrayList(favoriteParkings)
+                  updatedList.removeAt(index)
+                  onFavoritesUpdated(updatedList)
+                })
+          }
         }
-    }
+  }
 }
 
 @Composable
-private fun FavoriteParkingCard(
-    parking: String,
-    index: Int,
-    onRemove: () -> Unit
-) {
-    Card(
-        modifier = Modifier
-            .size(120.dp)
-            .padding(8.dp),
-        shape = MaterialTheme.shapes.medium,
-    ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Text(
-                text = parking,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(8.dp)
-                    .testTag("ParkingItem_$index")
-            )
+private fun FavoriteParkingCard(parking: String, index: Int, onRemove: () -> Unit) {
+  Card(
+      modifier = Modifier.size(120.dp).padding(8.dp),
+      shape = MaterialTheme.shapes.medium,
+  ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      Text(
+          text = parking,
+          style = MaterialTheme.typography.bodySmall,
+          modifier = Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
 
-            IconButton(
-                onClick = onRemove,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .size(32.dp)
-                    .testTag("FavoriteToggle_$index")
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Star,
-                    contentDescription = "Remove from Favorites",
-                    tint = Color(0xFFFFD700),
-                    modifier = Modifier.size(20.dp)
-                )
-            }
-        }
+      IconButton(
+          onClick = onRemove,
+          modifier =
+              Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = "Remove from Favorites",
+                tint = Color(0xFFFFD700),
+                modifier = Modifier.size(20.dp))
+          }
     }
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -1,0 +1,208 @@
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import coil.transform.CircleCropTransformation
+import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.getButtonColors
+
+@Composable
+fun ProfileScreen(user: User) {
+    // State for editing mode and user details
+    var isEditing by remember { mutableStateOf(false) }
+    var firstName by remember { mutableStateOf(TextFieldValue(user.firstName)) }
+    var lastName by remember { mutableStateOf(TextFieldValue(user.lastName)) }
+    var username by remember { mutableStateOf(TextFieldValue(user.username)) }
+
+    // State for favorite parkings
+    var favoriteParkings by remember { mutableStateOf(user.favoriteParkings.toMutableList()) }
+    val parkingFavorites = remember { mutableStateListOf(*List(user.favoriteParkings.size) { true }.toTypedArray()) }
+
+    // URLs for profile picture and stars
+    var profilePictureUrl by remember { mutableStateOf(user.profilePictureUrl) }
+    val defaultImageUrl = "https://th.bing.com/th/id/R.aee6adef085a77dfa4708f3fd4a1ffb5?rik=nj%2buNqgLIJU0JQ&pid=ImgRaw&r=0"
+    val filledStarImageUrl = "https://th.bing.com/th/id/R.f493b7a899f0c38194622d00ca70a7ff?rik=MvAc4%2fM5MeISxA&pid=ImgRaw&r=0"
+    val emptyStarImageUrl = "https://cdn0.iconfinder.com/data/icons/thin-voting-awards/57/thin-232_star_favorite_add-1024.png"
+
+    // Image picker launcher
+    val context = LocalContext.current
+    val imagePickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let {
+            profilePictureUrl = it.toString()
+        }
+    }
+
+    // Filter non-favorites when leaving the screen
+    DisposableEffect(Unit) {
+        onDispose {
+            favoriteParkings = favoriteParkings.filterIndexed { index, _ -> parkingFavorites[index] }.toMutableList()
+        }
+    }
+
+    Scaffold { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            if (isEditing) {
+                // Editable fields
+                TextField(
+                    value = firstName,
+                    onValueChange = { firstName = it },
+                    label = { Text("First Name") }
+                )
+                TextField(
+                    value = lastName,
+                    onValueChange = { lastName = it },
+                    label = { Text("Last Name") }
+                )
+                TextField(
+                    value = username,
+                    onValueChange = { username = it },
+                    label = { Text("Username") }
+                )
+
+                // Profile picture
+                val painter = rememberAsyncImagePainter(
+                    ImageRequest.Builder(context)
+                        .data(if (profilePictureUrl.isNotBlank()) profilePictureUrl else defaultImageUrl)
+                        .apply {
+                            transformations(CircleCropTransformation())
+                        }
+                        .build()
+                )
+
+                Image(
+                    painter = painter,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(CircleShape)
+                        .clickable { imagePickerLauncher.launch("image/*") },
+                    contentScale = ContentScale.Crop
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Save and Cancel buttons
+                Button(
+                    onClick = { isEditing = false },
+                    colors = getButtonColors(ColorLevel.PRIMARY)
+                ) {
+                    Text("Save Changes")
+                }
+                Button(
+                    onClick = { isEditing = false },
+                    colors = getButtonColors(ColorLevel.SECONDARY)
+                ) {
+                    Text("Cancel")
+                }
+            } else {
+                // Display user information
+                Text(
+                    text = "${user.firstName} ${user.lastName}",
+                    style = MaterialTheme.typography.titleLarge
+                )
+                val painter = rememberAsyncImagePainter(
+                    ImageRequest.Builder(context)
+                        .data(if (user.profilePictureUrl.isNotBlank()) user.profilePictureUrl else defaultImageUrl)
+                        .apply {
+                            transformations(CircleCropTransformation())
+                        }
+                        .build()
+                )
+
+                Image(
+                    painter = painter,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+                Text(
+                    text = "@${user.username}",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+
+                // Modify Profile button
+                Button(
+                    onClick = { isEditing = true },
+                    colors = getButtonColors(ColorLevel.TERTIARY)
+                ) {
+                    Text("Modify Profile")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Favorite Parkings section
+            Text(
+                text = "Favorite Parkings",
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                itemsIndexed(favoriteParkings) { index, parking ->
+                    Card(
+                        modifier = Modifier
+                            .size(120.dp)
+                            .padding(8.dp),
+                        shape = MaterialTheme.shapes.medium
+                    ) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                modifier = Modifier.fillMaxWidth().padding(8.dp)
+                            ) {
+                                Text(
+                                    text = parking,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                                val starPainter = rememberAsyncImagePainter(
+                                    if (parkingFavorites[index]) filledStarImageUrl else emptyStarImageUrl
+                                )
+                                Image(
+                                    painter = starPainter,
+                                    contentDescription = "Toggle Favorite",
+                                    modifier = Modifier
+                                        .size(24.dp)
+                                        .clickable {
+                                            parkingFavorites[index] = !parkingFavorites[index]
+                                        }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -1,47 +1,47 @@
+package com.github.se.cyrcle.ui.profile
+
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
-import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.theme.ColorLevel
-import com.github.se.cyrcle.ui.theme.getButtonColors
+import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.InputText
+import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
 @Composable
-fun ProfileScreen(user: User) {
+fun ProfileScreen(navigationActions: NavigationActions) {
   var isEditing by remember { mutableStateOf(false) }
-  var firstName by remember { mutableStateOf(TextFieldValue(user.firstName)) }
-  var lastName by remember { mutableStateOf(TextFieldValue(user.lastName)) }
-  var username by remember { mutableStateOf(TextFieldValue(user.username)) }
-
-  var favoriteParkings by remember { mutableStateOf(user.favoriteParkings.toMutableList()) }
-  val parkingFavorites = remember {
-    mutableStateListOf(*List(user.favoriteParkings.size) { true }.toTypedArray())
-  }
-
-  var profilePictureUrl by remember { mutableStateOf(user.profilePictureUrl) }
-  val defaultImageUrl =
-      "https://th.bing.com/th/id/R.aee6adef085a77dfa4708f3fd4a1ffb5?rik=nj%2buNqgLIJU0JQ&pid=ImgRaw&r=0"
-  val filledStarImageUrl =
-      "https://th.bing.com/th/id/R.f493b7a899f0c38194622d00ca70a7ff?rik=MvAc4%2fM5MeISxA&pid=ImgRaw&r=0"
-  val emptyStarImageUrl =
-      "https://cdn0.iconfinder.com/data/icons/thin-voting-awards/57/thin-232_star_favorite_add-1024.png"
+  var firstName by remember { mutableStateOf("John") }
+  var lastName by remember { mutableStateOf("Doe") }
+  var username by remember { mutableStateOf("johndoe") }
+  var profilePictureUrl by remember { mutableStateOf("") }
+  var favoriteParkings by remember { mutableStateOf(ArrayList<String>()) }
 
   val context = LocalContext.current
   val imagePickerLauncher =
@@ -49,144 +49,247 @@ fun ProfileScreen(user: User) {
         uri?.let { profilePictureUrl = it.toString() }
       }
 
-  DisposableEffect(Unit) {
-    onDispose {
-      favoriteParkings =
-          favoriteParkings.filterIndexed { index, _ -> parkingFavorites[index] }.toMutableList()
+  Scaffold(
+      modifier = Modifier.testTag("ProfileScreen"),
+      bottomBar = {
+        BottomNavigationBar(
+            navigationActions = navigationActions,
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = Route.PROFILE)
+      }) { innerPadding ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp)
+                    .testTag("ProfileContent"),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              if (isEditing) {
+                EditProfileContent(
+                    firstName = firstName,
+                    lastName = lastName,
+                    username = username,
+                    profilePictureUrl = profilePictureUrl,
+                    onFirstNameChange = { firstName = it },
+                    onLastNameChange = { lastName = it },
+                    onUsernameChange = { username = it },
+                    onImageClick = { imagePickerLauncher.launch("image/*") },
+                    onSave = { isEditing = false },
+                    onCancel = { isEditing = false })
+              } else {
+                DisplayProfileContent(
+                    firstName = firstName,
+                    lastName = lastName,
+                    username = username,
+                    profilePictureUrl = profilePictureUrl,
+                    onEditClick = { isEditing = true })
+              }
+
+              Spacer(modifier = Modifier.height(24.dp))
+
+              FavoriteParkingsSection(favoriteParkings) { newFavorites ->
+                favoriteParkings = newFavorites
+              }
+            }
+      }
+}
+
+@Composable
+private fun EditProfileContent(
+    firstName: String,
+    lastName: String,
+    username: String,
+    profilePictureUrl: String,
+    onFirstNameChange: (String) -> Unit,
+    onLastNameChange: (String) -> Unit,
+    onUsernameChange: (String) -> Unit,
+    onImageClick: () -> Unit,
+    onSave: () -> Unit,
+    onCancel: () -> Unit
+) {
+  ProfileImage(url = profilePictureUrl, onClick = onImageClick, isEditable = true)
+
+  Spacer(modifier = Modifier.height(24.dp))
+
+  InputText(
+      value = firstName,
+      onValueChange = onFirstNameChange,
+      label = "First Name",
+      testTag = "FirstNameInput")
+
+  Spacer(modifier = Modifier.height(8.dp))
+
+  InputText(
+      value = lastName,
+      onValueChange = onLastNameChange,
+      label = "Last Name",
+      testTag = "LastNameInput")
+
+  Spacer(modifier = Modifier.height(8.dp))
+
+  InputText(
+      value = username,
+      onValueChange = onUsernameChange,
+      label = "Username",
+      testTag = "UsernameInput")
+
+  Spacer(modifier = Modifier.height(16.dp))
+
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Button(text = "Save", onClick = onSave, colorLevel = ColorLevel.PRIMARY, testTag = "SaveButton")
+
+    Button(
+        text = "Cancel",
+        onClick = onCancel,
+        colorLevel = ColorLevel.SECONDARY,
+        testTag = "CancelButton")
+  }
+}
+
+@Composable
+private fun DisplayProfileContent(
+    firstName: String,
+    lastName: String,
+    username: String,
+    profilePictureUrl: String,
+    onEditClick: () -> Unit
+) {
+  Text(
+      text = "$firstName $lastName",
+      style = MaterialTheme.typography.headlineMedium,
+      modifier = Modifier.testTag("ProfileName"))
+
+  Spacer(modifier = Modifier.height(16.dp))
+
+  ProfileImage(url = profilePictureUrl, onClick = {}, isEditable = false)
+
+  Spacer(modifier = Modifier.height(8.dp))
+
+  Text(
+      text = "@$username",
+      style = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.testTag("ProfileUsername"))
+
+  Spacer(modifier = Modifier.height(16.dp))
+
+  Button(
+      text = "Modify Profile",
+      onClick = onEditClick,
+      colorLevel = ColorLevel.TERTIARY,
+      testTag = "ModifyProfileButton")
+}
+
+@Composable
+private fun ProfileImage(url: String, onClick: () -> Unit, isEditable: Boolean) {
+  val context = LocalContext.current
+  val painter =
+      rememberAsyncImagePainter(
+          ImageRequest.Builder(context)
+              .data(if (url.isNotBlank()) url else null)
+              .apply { transformations(CircleCropTransformation()) }
+              .build())
+
+  Box(modifier = Modifier.testTag("ProfileImageContainer")) {
+    if (url.isBlank()) {
+      Box(
+          modifier =
+              Modifier.size(120.dp)
+                  .clip(CircleShape)
+                  .background(MaterialTheme.colorScheme.primaryContainer)
+                  .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier),
+          contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Filled.Person,
+                contentDescription = "Default Profile Picture",
+                modifier = Modifier.size(60.dp),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer)
+          }
+    } else {
+      Image(
+          painter = painter,
+          contentDescription = "Profile Picture",
+          modifier =
+              Modifier.size(120.dp)
+                  .clip(CircleShape)
+                  .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier),
+          contentScale = ContentScale.Crop)
+    }
+
+    if (isEditable) {
+      Box(
+          modifier =
+              Modifier.size(120.dp)
+                  .clip(CircleShape)
+                  .background(Color.Black.copy(alpha = 0.3f))
+                  .clickable(onClick = onClick),
+          contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Filled.Edit,
+                contentDescription = "Edit Profile Picture",
+                tint = Color.White,
+                modifier = Modifier.size(40.dp))
+          }
     }
   }
+}
 
-  Scaffold { innerPadding ->
-    Column(
-        modifier = Modifier.fillMaxSize().padding(innerPadding).padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)) {
-          if (isEditing) {
-            TextField(
-                value = firstName,
-                onValueChange = { firstName = it },
-                label = { Text("First Name") },
-                modifier = Modifier.testTag("FirstNameField"))
-            TextField(
-                value = lastName,
-                onValueChange = { lastName = it },
-                label = { Text("Last Name") },
-                modifier = Modifier.testTag("LastNameField"))
-            TextField(
-                value = username,
-                onValueChange = { username = it },
-                label = { Text("Username") },
-                modifier = Modifier.testTag("UsernameField"))
+@Composable
+private fun FavoriteParkingsSection(
+    favoriteParkings: ArrayList<String>,
+    onFavoritesUpdated: (ArrayList<String>) -> Unit
+) {
+  Text(
+      text = "Favorite Parkings",
+      style = MaterialTheme.typography.titleLarge,
+      modifier = Modifier.testTag("FavoriteParkingsTitle"))
 
-            val painter =
-                rememberAsyncImagePainter(
-                    ImageRequest.Builder(context)
-                        .data(
-                            if (profilePictureUrl.isNotBlank()) profilePictureUrl
-                            else defaultImageUrl)
-                        .apply { transformations(CircleCropTransformation()) }
-                        .build())
+  Spacer(modifier = Modifier.height(16.dp))
 
-            Image(
-                painter = painter,
-                contentDescription = "Profile Picture",
-                modifier =
-                    Modifier.size(100.dp)
-                        .clip(CircleShape)
-                        .clickable { imagePickerLauncher.launch("image/*") }
-                        .testTag("ProfilePicture"),
-                contentScale = ContentScale.Crop)
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Button(
-                onClick = { isEditing = false },
-                colors = getButtonColors(ColorLevel.PRIMARY),
-                modifier = Modifier.testTag("SaveButton")) {
-                  Text("Save Changes")
-                }
-            Button(
-                onClick = { isEditing = false },
-                colors = getButtonColors(ColorLevel.SECONDARY),
-                modifier = Modifier.testTag("CancelButton")) {
-                  Text("Cancel")
-                }
-          } else {
-            Text(
-                text = "${firstName.text} ${lastName.text}",
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.testTag("UserNameDisplay"))
-            val painter =
-                rememberAsyncImagePainter(
-                    ImageRequest.Builder(context)
-                        .data(
-                            if (user.profilePictureUrl.isNotBlank()) user.profilePictureUrl
-                            else defaultImageUrl)
-                        .apply { transformations(CircleCropTransformation()) }
-                        .build())
-
-            Image(
-                painter = painter,
-                contentDescription = "Profile Picture",
-                modifier = Modifier.size(100.dp).clip(CircleShape).testTag("ProfilePicture"),
-                contentScale = ContentScale.Crop)
-            Text(
-                text = "@${user.username}",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.testTag("UserHandleDisplay"))
-
-            Button(
-                onClick = { isEditing = true },
-                colors = getButtonColors(ColorLevel.TERTIARY),
-                modifier = Modifier.testTag("ModifyButton")) {
-                  Text("Modify Profile")
-                }
+  if (favoriteParkings.isEmpty()) {
+    Text(
+        text = "No favorite parkings yet",
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.testTag("NoFavoritesMessage"))
+  } else {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          itemsIndexed(favoriteParkings) { index, parking ->
+            FavoriteParkingCard(
+                parking = parking,
+                index = index,
+                onRemove = {
+                  val updatedList = ArrayList(favoriteParkings)
+                  updatedList.removeAt(index)
+                  onFavoritesUpdated(updatedList)
+                })
           }
-
-          Spacer(modifier = Modifier.height(24.dp))
-
-          Text(
-              text = "Favorite Parkings",
-              style = MaterialTheme.typography.titleMedium,
-              modifier = Modifier.testTag("FavoriteParkingsLabel"))
-
-          LazyRow(
-              modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
-              horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                itemsIndexed(favoriteParkings) { index, parking ->
-                  Card(
-                      modifier = Modifier.size(120.dp).padding(8.dp),
-                      shape = MaterialTheme.shapes.medium) {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier.fillMaxSize()) {
-                              Row(
-                                  verticalAlignment = Alignment.CenterVertically,
-                                  horizontalArrangement = Arrangement.SpaceBetween,
-                                  modifier = Modifier.fillMaxWidth().padding(8.dp)) {
-                                    Text(
-                                        text = parking,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        modifier = Modifier.testTag("ParkingItem_$index"))
-                                    val starPainter =
-                                        rememberAsyncImagePainter(
-                                            if (parkingFavorites[index]) filledStarImageUrl
-                                            else emptyStarImageUrl)
-
-                                    Image(
-                                        painter = starPainter,
-                                        contentDescription = "Toggle Favorite",
-                                        modifier =
-                                            Modifier.size(24.dp)
-                                                .clickable {
-                                                  parkingFavorites[index] = !parkingFavorites[index]
-                                                }
-                                                .testTag("FavoriteToggle_$index"))
-                                  }
-                            }
-                      }
-                }
-              }
         }
+  }
+}
+
+@Composable
+private fun FavoriteParkingCard(parking: String, index: Int, onRemove: () -> Unit) {
+  Card(
+      modifier = Modifier.size(120.dp).padding(8.dp),
+      shape = MaterialTheme.shapes.medium,
+  ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      Text(
+          text = parking,
+          style = MaterialTheme.typography.bodySmall,
+          modifier = Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
+
+      IconButton(
+          onClick = onRemove,
+          modifier =
+              Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = "Remove from Favorites",
+                tint = Color(0xFFFFD700),
+                modifier = Modifier.size(20.dp))
+          }
+    }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
@@ -24,185 +25,168 @@ import com.github.se.cyrcle.ui.theme.getButtonColors
 
 @Composable
 fun ProfileScreen(user: User) {
-    // State for editing mode and user details
-    var isEditing by remember { mutableStateOf(false) }
-    var firstName by remember { mutableStateOf(TextFieldValue(user.firstName)) }
-    var lastName by remember { mutableStateOf(TextFieldValue(user.lastName)) }
-    var username by remember { mutableStateOf(TextFieldValue(user.username)) }
+  var isEditing by remember { mutableStateOf(false) }
+  var firstName by remember { mutableStateOf(TextFieldValue(user.firstName)) }
+  var lastName by remember { mutableStateOf(TextFieldValue(user.lastName)) }
+  var username by remember { mutableStateOf(TextFieldValue(user.username)) }
 
-    // State for favorite parkings
-    var favoriteParkings by remember { mutableStateOf(user.favoriteParkings.toMutableList()) }
-    val parkingFavorites = remember { mutableStateListOf(*List(user.favoriteParkings.size) { true }.toTypedArray()) }
+  var favoriteParkings by remember { mutableStateOf(user.favoriteParkings.toMutableList()) }
+  val parkingFavorites = remember {
+    mutableStateListOf(*List(user.favoriteParkings.size) { true }.toTypedArray())
+  }
 
-    // URLs for profile picture and stars
-    var profilePictureUrl by remember { mutableStateOf(user.profilePictureUrl) }
-    val defaultImageUrl = "https://th.bing.com/th/id/R.aee6adef085a77dfa4708f3fd4a1ffb5?rik=nj%2buNqgLIJU0JQ&pid=ImgRaw&r=0"
-    val filledStarImageUrl = "https://th.bing.com/th/id/R.f493b7a899f0c38194622d00ca70a7ff?rik=MvAc4%2fM5MeISxA&pid=ImgRaw&r=0"
-    val emptyStarImageUrl = "https://cdn0.iconfinder.com/data/icons/thin-voting-awards/57/thin-232_star_favorite_add-1024.png"
+  var profilePictureUrl by remember { mutableStateOf(user.profilePictureUrl) }
+  val defaultImageUrl =
+      "https://th.bing.com/th/id/R.aee6adef085a77dfa4708f3fd4a1ffb5?rik=nj%2buNqgLIJU0JQ&pid=ImgRaw&r=0"
+  val filledStarImageUrl =
+      "https://th.bing.com/th/id/R.f493b7a899f0c38194622d00ca70a7ff?rik=MvAc4%2fM5MeISxA&pid=ImgRaw&r=0"
+  val emptyStarImageUrl =
+      "https://cdn0.iconfinder.com/data/icons/thin-voting-awards/57/thin-232_star_favorite_add-1024.png"
 
-    // Image picker launcher
-    val context = LocalContext.current
-    val imagePickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let {
-            profilePictureUrl = it.toString()
-        }
+  val context = LocalContext.current
+  val imagePickerLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { profilePictureUrl = it.toString() }
+      }
+
+  DisposableEffect(Unit) {
+    onDispose {
+      favoriteParkings =
+          favoriteParkings.filterIndexed { index, _ -> parkingFavorites[index] }.toMutableList()
     }
+  }
 
-    // Filter non-favorites when leaving the screen
-    DisposableEffect(Unit) {
-        onDispose {
-            favoriteParkings = favoriteParkings.filterIndexed { index, _ -> parkingFavorites[index] }.toMutableList()
-        }
-    }
+  Scaffold { innerPadding ->
+    Column(
+        modifier = Modifier.fillMaxSize().padding(innerPadding).padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)) {
+          if (isEditing) {
+            TextField(
+                value = firstName,
+                onValueChange = { firstName = it },
+                label = { Text("First Name") },
+                modifier = Modifier.testTag("FirstNameField"))
+            TextField(
+                value = lastName,
+                onValueChange = { lastName = it },
+                label = { Text("Last Name") },
+                modifier = Modifier.testTag("LastNameField"))
+            TextField(
+                value = username,
+                onValueChange = { username = it },
+                label = { Text("Username") },
+                modifier = Modifier.testTag("UsernameField"))
 
-    Scaffold { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            if (isEditing) {
-                // Editable fields
-                TextField(
-                    value = firstName,
-                    onValueChange = { firstName = it },
-                    label = { Text("First Name") }
-                )
-                TextField(
-                    value = lastName,
-                    onValueChange = { lastName = it },
-                    label = { Text("Last Name") }
-                )
-                TextField(
-                    value = username,
-                    onValueChange = { username = it },
-                    label = { Text("Username") }
-                )
-
-                // Profile picture
-                val painter = rememberAsyncImagePainter(
+            val painter =
+                rememberAsyncImagePainter(
                     ImageRequest.Builder(context)
-                        .data(if (profilePictureUrl.isNotBlank()) profilePictureUrl else defaultImageUrl)
-                        .apply {
-                            transformations(CircleCropTransformation())
-                        }
-                        .build()
-                )
+                        .data(
+                            if (profilePictureUrl.isNotBlank()) profilePictureUrl
+                            else defaultImageUrl)
+                        .apply { transformations(CircleCropTransformation()) }
+                        .build())
 
-                Image(
-                    painter = painter,
-                    contentDescription = "Profile Picture",
-                    modifier = Modifier
-                        .size(100.dp)
+            Image(
+                painter = painter,
+                contentDescription = "Profile Picture",
+                modifier =
+                    Modifier.size(100.dp)
                         .clip(CircleShape)
-                        .clickable { imagePickerLauncher.launch("image/*") },
-                    contentScale = ContentScale.Crop
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                // Save and Cancel buttons
-                Button(
-                    onClick = { isEditing = false },
-                    colors = getButtonColors(ColorLevel.PRIMARY)
-                ) {
-                    Text("Save Changes")
-                }
-                Button(
-                    onClick = { isEditing = false },
-                    colors = getButtonColors(ColorLevel.SECONDARY)
-                ) {
-                    Text("Cancel")
-                }
-            } else {
-                // Display user information
-                Text(
-                    text = "${user.firstName} ${user.lastName}",
-                    style = MaterialTheme.typography.titleLarge
-                )
-                val painter = rememberAsyncImagePainter(
-                    ImageRequest.Builder(context)
-                        .data(if (user.profilePictureUrl.isNotBlank()) user.profilePictureUrl else defaultImageUrl)
-                        .apply {
-                            transformations(CircleCropTransformation())
-                        }
-                        .build()
-                )
-
-                Image(
-                    painter = painter,
-                    contentDescription = "Profile Picture",
-                    modifier = Modifier
-                        .size(100.dp)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop
-                )
-                Text(
-                    text = "@${user.username}",
-                    style = MaterialTheme.typography.bodyMedium
-                )
-
-                // Modify Profile button
-                Button(
-                    onClick = { isEditing = true },
-                    colors = getButtonColors(ColorLevel.TERTIARY)
-                ) {
-                    Text("Modify Profile")
-                }
-            }
+                        .clickable { imagePickerLauncher.launch("image/*") }
+                        .testTag("ProfilePicture"),
+                contentScale = ContentScale.Crop)
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Favorite Parkings section
+            Button(
+                onClick = { isEditing = false },
+                colors = getButtonColors(ColorLevel.PRIMARY),
+                modifier = Modifier.testTag("SaveButton")) {
+                  Text("Save Changes")
+                }
+            Button(
+                onClick = { isEditing = false },
+                colors = getButtonColors(ColorLevel.SECONDARY),
+                modifier = Modifier.testTag("CancelButton")) {
+                  Text("Cancel")
+                }
+          } else {
             Text(
-                text = "Favorite Parkings",
-                style = MaterialTheme.typography.titleMedium
-            )
+                text = "${firstName.text} ${lastName.text}",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.testTag("UserNameDisplay"))
+            val painter =
+                rememberAsyncImagePainter(
+                    ImageRequest.Builder(context)
+                        .data(
+                            if (user.profilePictureUrl.isNotBlank()) user.profilePictureUrl
+                            else defaultImageUrl)
+                        .apply { transformations(CircleCropTransformation()) }
+                        .build())
 
-            LazyRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
+            Image(
+                painter = painter,
+                contentDescription = "Profile Picture",
+                modifier = Modifier.size(100.dp).clip(CircleShape).testTag("ProfilePicture"),
+                contentScale = ContentScale.Crop)
+            Text(
+                text = "@${user.username}",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("UserHandleDisplay"))
+
+            Button(
+                onClick = { isEditing = true },
+                colors = getButtonColors(ColorLevel.TERTIARY),
+                modifier = Modifier.testTag("ModifyButton")) {
+                  Text("Modify Profile")
+                }
+          }
+
+          Spacer(modifier = Modifier.height(24.dp))
+
+          Text(
+              text = "Favorite Parkings",
+              style = MaterialTheme.typography.titleMedium,
+              modifier = Modifier.testTag("FavoriteParkingsLabel"))
+
+          LazyRow(
+              modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
+              horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 itemsIndexed(favoriteParkings) { index, parking ->
-                    Card(
-                        modifier = Modifier
-                            .size(120.dp)
-                            .padding(8.dp),
-                        shape = MaterialTheme.shapes.medium
-                    ) {
+                  Card(
+                      modifier = Modifier.size(120.dp).padding(8.dp),
+                      shape = MaterialTheme.shapes.medium) {
                         Box(
                             contentAlignment = Alignment.Center,
-                            modifier = Modifier.fillMaxSize()
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                modifier = Modifier.fillMaxWidth().padding(8.dp)
-                            ) {
-                                Text(
-                                    text = parking,
-                                    style = MaterialTheme.typography.bodySmall
-                                )
-                                val starPainter = rememberAsyncImagePainter(
-                                    if (parkingFavorites[index]) filledStarImageUrl else emptyStarImageUrl
-                                )
-                                Image(
-                                    painter = starPainter,
-                                    contentDescription = "Toggle Favorite",
-                                    modifier = Modifier
-                                        .size(24.dp)
-                                        .clickable {
-                                            parkingFavorites[index] = !parkingFavorites[index]
-                                        }
-                                )
+                            modifier = Modifier.fillMaxSize()) {
+                              Row(
+                                  verticalAlignment = Alignment.CenterVertically,
+                                  horizontalArrangement = Arrangement.SpaceBetween,
+                                  modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                                    Text(
+                                        text = parking,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        modifier = Modifier.testTag("ParkingItem_$index"))
+                                    val starPainter =
+                                        rememberAsyncImagePainter(
+                                            if (parkingFavorites[index]) filledStarImageUrl
+                                            else emptyStarImageUrl)
+
+                                    Image(
+                                        painter = starPainter,
+                                        contentDescription = "Toggle Favorite",
+                                        modifier =
+                                            Modifier.size(24.dp)
+                                                .clickable {
+                                                  parkingFavorites[index] = !parkingFavorites[index]
+                                                }
+                                                .testTag("FavoriteToggle_$index"))
+                                  }
                             }
-                        }
-                    }
+                      }
                 }
-            }
+              }
         }
-    }
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -34,37 +34,50 @@ import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
+//TODO: add some requirements to be able to save changes, such as having a non empty text field.
+
+
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
-  var isEditing by remember { mutableStateOf(false) }
-  var firstName by remember { mutableStateOf("John") }
-  var lastName by remember { mutableStateOf("Doe") }
-  var username by remember { mutableStateOf("johndoe") }
-  var profilePictureUrl by remember { mutableStateOf("") }
-  var favoriteParkings by remember { mutableStateOf(ArrayList<String>()) }
+    // Current values
+    var isEditing by remember { mutableStateOf(false) }
+    var firstName by remember { mutableStateOf("John") }
+    var lastName by remember { mutableStateOf("Doe") }
+    var username by remember { mutableStateOf("johndoe") }
+    var profilePictureUrl by remember { mutableStateOf("") }
+    var favoriteParkings by remember { mutableStateOf(ArrayList<String>()) }
 
-  val context = LocalContext.current
-  val imagePickerLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let { profilePictureUrl = it.toString() }
-      }
+    // Store original values for cancellation
+    var originalFirstName by remember { mutableStateOf(firstName) }
+    var originalLastName by remember { mutableStateOf(lastName) }
+    var originalUsername by remember { mutableStateOf(username) }
+    var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
 
-  Scaffold(
-      modifier = Modifier.testTag("ProfileScreen"),
-      bottomBar = {
-        BottomNavigationBar(
-            navigationActions = navigationActions,
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = Route.PROFILE)
-      }) { innerPadding ->
+    val context = LocalContext.current
+    val imagePickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            uri?.let { profilePictureUrl = it.toString() }
+        }
+
+    Scaffold(
+        modifier = Modifier.testTag("ProfileScreen"),
+        bottomBar = {
+            BottomNavigationBar(
+                navigationActions = navigationActions,
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = Route.PROFILE
+            )
+        }
+    ) { innerPadding ->
         Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(16.dp)
-                    .testTag("ProfileContent"),
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              if (isEditing) {
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+                .testTag("ProfileContent"),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (isEditing) {
                 EditProfileContent(
                     firstName = firstName,
                     lastName = lastName,
@@ -74,24 +87,47 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                     onLastNameChange = { lastName = it },
                     onUsernameChange = { username = it },
                     onImageClick = { imagePickerLauncher.launch("image/*") },
-                    onSave = { isEditing = false },
-                    onCancel = { isEditing = false })
-              } else {
+                    onSave = {
+                        // Update original values when saving
+                        originalFirstName = firstName
+                        originalLastName = lastName
+                        originalUsername = username
+                        originalProfilePictureUrl = profilePictureUrl
+                        isEditing = false
+                    },
+                    onCancel = {
+                        // Restore original values when canceling
+                        firstName = originalFirstName
+                        lastName = originalLastName
+                        username = originalUsername
+                        profilePictureUrl = originalProfilePictureUrl
+                        isEditing = false
+                    }
+                )
+            } else {
                 DisplayProfileContent(
                     firstName = firstName,
                     lastName = lastName,
                     username = username,
                     profilePictureUrl = profilePictureUrl,
-                    onEditClick = { isEditing = true })
-              }
-
-              Spacer(modifier = Modifier.height(24.dp))
-
-              FavoriteParkingsSection(favoriteParkings) { newFavorites ->
-                favoriteParkings = newFavorites
-              }
+                    onEditClick = {
+                        // Store original values when entering edit mode
+                        originalFirstName = firstName
+                        originalLastName = lastName
+                        originalUsername = username
+                        originalProfilePictureUrl = profilePictureUrl
+                        isEditing = true
+                    }
+                )
             }
-      }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            FavoriteParkingsSection(favoriteParkings) { newFavorites ->
+                favoriteParkings = newFavorites
+            }
+        }
+    }
 }
 
 @Composable
@@ -107,43 +143,57 @@ private fun EditProfileContent(
     onSave: () -> Unit,
     onCancel: () -> Unit
 ) {
-  ProfileImage(url = profilePictureUrl, onClick = onImageClick, isEditable = true)
+    ProfileImage(
+        url = profilePictureUrl,
+        onClick = onImageClick,
+        isEditable = true,
+        modifier = Modifier.testTag("ProfileImage")
+    )
 
-  Spacer(modifier = Modifier.height(24.dp))
+    Spacer(modifier = Modifier.height(24.dp))
 
-  InputText(
-      value = firstName,
-      onValueChange = onFirstNameChange,
-      label = "First Name",
-      testTag = "FirstNameInput")
+    InputText(
+        value = firstName,
+        onValueChange = onFirstNameChange,
+        label = "First Name",
+        testTag = "FirstNameField"
+    )
 
-  Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-  InputText(
-      value = lastName,
-      onValueChange = onLastNameChange,
-      label = "Last Name",
-      testTag = "LastNameInput")
+    InputText(
+        value = lastName,
+        onValueChange = onLastNameChange,
+        label = "Last Name",
+        testTag = "LastNameField"
+    )
 
-  Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-  InputText(
-      value = username,
-      onValueChange = onUsernameChange,
-      label = "Username",
-      testTag = "UsernameInput")
+    InputText(
+        value = username,
+        onValueChange = onUsernameChange,
+        label = "Username",
+        testTag = "UsernameField"
+    )
 
-  Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
 
-  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-    Button(text = "Save", onClick = onSave, colorLevel = ColorLevel.PRIMARY, testTag = "SaveButton")
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Button(
+            text = "Save",
+            onClick = onSave,
+            colorLevel = ColorLevel.PRIMARY,
+            testTag = "SaveButton"
+        )
 
-    Button(
-        text = "Cancel",
-        onClick = onCancel,
-        colorLevel = ColorLevel.SECONDARY,
-        testTag = "CancelButton")
-  }
+        Button(
+            text = "Cancel",
+            onClick = onCancel,
+            colorLevel = ColorLevel.SECONDARY,
+            testTag = "CancelButton"
+        )
+    }
 }
 
 @Composable
@@ -154,83 +204,107 @@ private fun DisplayProfileContent(
     profilePictureUrl: String,
     onEditClick: () -> Unit
 ) {
-  Text(
-      text = "$firstName $lastName",
-      style = MaterialTheme.typography.headlineMedium,
-      modifier = Modifier.testTag("ProfileName"))
+    Text(
+        text = firstName,
+        style = MaterialTheme.typography.headlineMedium,
+        modifier = Modifier.testTag("DisplayFirstName")
+    )
 
-  Spacer(modifier = Modifier.height(16.dp))
+    Text(
+        text = lastName,
+        style = MaterialTheme.typography.headlineMedium,
+        modifier = Modifier.testTag("DisplayLastName")
+    )
 
-  ProfileImage(url = profilePictureUrl, onClick = {}, isEditable = false)
+    Spacer(modifier = Modifier.height(16.dp))
 
-  Spacer(modifier = Modifier.height(8.dp))
+    ProfileImage(
+        url = profilePictureUrl,
+        onClick = {},
+        isEditable = false,
+        modifier = Modifier.testTag("ProfileImage")
+    )
 
-  Text(
-      text = "@$username",
-      style = MaterialTheme.typography.bodyMedium,
-      modifier = Modifier.testTag("ProfileUsername"))
+    Spacer(modifier = Modifier.height(8.dp))
 
-  Spacer(modifier = Modifier.height(16.dp))
+    Text(
+        text = "@$username",
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.testTag("DisplayUsername")
+    )
 
-  Button(
-      text = "Modify Profile",
-      onClick = onEditClick,
-      colorLevel = ColorLevel.TERTIARY,
-      testTag = "ModifyProfileButton")
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Button(
+        text = "Modify Profile",
+        onClick = onEditClick,
+        colorLevel = ColorLevel.TERTIARY,
+        testTag = "EditButton"
+    )
 }
 
 @Composable
-private fun ProfileImage(url: String, onClick: () -> Unit, isEditable: Boolean) {
-  val context = LocalContext.current
-  val painter =
-      rememberAsyncImagePainter(
-          ImageRequest.Builder(context)
-              .data(if (url.isNotBlank()) url else null)
-              .apply { transformations(CircleCropTransformation()) }
-              .build())
+private fun ProfileImage(
+    url: String,
+    onClick: () -> Unit,
+    isEditable: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val painter = rememberAsyncImagePainter(
+        ImageRequest.Builder(context)
+            .data(if (url.isNotBlank()) url else null)
+            .apply { transformations(CircleCropTransformation()) }
+            .build()
+    )
 
-  Box(modifier = Modifier.testTag("ProfileImageContainer")) {
-    if (url.isBlank()) {
-      Box(
-          modifier =
-              Modifier.size(120.dp)
-                  .clip(CircleShape)
-                  .background(MaterialTheme.colorScheme.primaryContainer)
-                  .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier),
-          contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = Icons.Filled.Person,
-                contentDescription = "Default Profile Picture",
-                modifier = Modifier.size(60.dp),
-                tint = MaterialTheme.colorScheme.onPrimaryContainer)
-          }
-    } else {
-      Image(
-          painter = painter,
-          contentDescription = "Profile Picture",
-          modifier =
-              Modifier.size(120.dp)
-                  .clip(CircleShape)
-                  .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier),
-          contentScale = ContentScale.Crop)
-    }
+    Box(
+        modifier = modifier
+            .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)
+    ) {
+        if (url.isBlank()) {
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = "Default Profile Picture",
+                    modifier = Modifier.size(60.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        } else {
+            Image(
+                painter = painter,
+                contentDescription = "Profile Picture",
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop
+            )
+        }
 
-    if (isEditable) {
-      Box(
-          modifier =
-              Modifier.size(120.dp)
-                  .clip(CircleShape)
-                  .background(Color.Black.copy(alpha = 0.3f))
-                  .clickable(onClick = onClick),
-          contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = Icons.Filled.Edit,
-                contentDescription = "Edit Profile Picture",
-                tint = Color.White,
-                modifier = Modifier.size(40.dp))
-          }
+        if (isEditable) {
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Edit,
+                    contentDescription = "Edit Profile Picture",
+                    tint = Color.White,
+                    modifier = Modifier.size(40.dp)
+                )
+            }
+        }
     }
-  }
 }
 
 @Composable
@@ -238,58 +312,78 @@ private fun FavoriteParkingsSection(
     favoriteParkings: ArrayList<String>,
     onFavoritesUpdated: (ArrayList<String>) -> Unit
 ) {
-  Text(
-      text = "Favorite Parkings",
-      style = MaterialTheme.typography.titleLarge,
-      modifier = Modifier.testTag("FavoriteParkingsTitle"))
-
-  Spacer(modifier = Modifier.height(16.dp))
-
-  if (favoriteParkings.isEmpty()) {
     Text(
-        text = "No favorite parkings yet",
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("NoFavoritesMessage"))
-  } else {
-    LazyRow(
-        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          itemsIndexed(favoriteParkings) { index, parking ->
-            FavoriteParkingCard(
-                parking = parking,
-                index = index,
-                onRemove = {
-                  val updatedList = ArrayList(favoriteParkings)
-                  updatedList.removeAt(index)
-                  onFavoritesUpdated(updatedList)
-                })
-          }
+        text = "Favorite Parkings",
+        style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.testTag("FavoriteParkingsTitle")
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    if (favoriteParkings.isEmpty()) {
+        Text(
+            text = "No favorite parkings yet",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.testTag("NoFavoritesMessage")
+        )
+    } else {
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("FavoriteParkingList"),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            itemsIndexed(favoriteParkings) { index, parking ->
+                FavoriteParkingCard(
+                    parking = parking,
+                    index = index,
+                    onRemove = {
+                        val updatedList = ArrayList(favoriteParkings)
+                        updatedList.removeAt(index)
+                        onFavoritesUpdated(updatedList)
+                    }
+                )
+            }
         }
-  }
+    }
 }
 
 @Composable
-private fun FavoriteParkingCard(parking: String, index: Int, onRemove: () -> Unit) {
-  Card(
-      modifier = Modifier.size(120.dp).padding(8.dp),
-      shape = MaterialTheme.shapes.medium,
-  ) {
-    Box(modifier = Modifier.fillMaxSize()) {
-      Text(
-          text = parking,
-          style = MaterialTheme.typography.bodySmall,
-          modifier = Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
+private fun FavoriteParkingCard(
+    parking: String,
+    index: Int,
+    onRemove: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .size(120.dp)
+            .padding(8.dp),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = parking,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(8.dp)
+                    .testTag("ParkingItem_$index")
+            )
 
-      IconButton(
-          onClick = onRemove,
-          modifier =
-              Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
-            Icon(
-                imageVector = Icons.Filled.Star,
-                contentDescription = "Remove from Favorites",
-                tint = Color(0xFFFFD700),
-                modifier = Modifier.size(20.dp))
-          }
+            IconButton(
+                onClick = onRemove,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(32.dp)
+                    .testTag("FavoriteToggle_$index")
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Star,
+                    contentDescription = "Remove from Favorites",
+                    tint = Color(0xFFFFD700),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
Content of the PR
This PR adds the user's profile screen where he will be able to see his personal information such as name, username, profile picture, etc. but also his list of favorite parking spots ! The user is also able to modify some of this data .

Why ?
The user might want to see his information, or change his information, or simply have a quick look at his favorite parking spots.

How ?
I added a bunch of buttons, text, and a few images by using their URL. They are clickable and send you to different interfaces. There is an editing mode but I will need to work on this more later so that it actually edits stuff once you click on save changes. For the list of favorite spots there is a clickable yellow-filled star which turns empty to symbolize the parking spot being removed from favorites.

Testing
Pretty trivial tests where I check that everything is shown correctly, everything that i want to click is clickable.