### PR TITLE
Link the markers to the parking view model

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -19,7 +19,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 
-
 @RunWith(AndroidJUnit4::class)
 class MapScreenTest {
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -6,20 +6,19 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.di.mocks.MockImageRepository
+import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.model.map.MapViewModel
-import com.github.se.cyrcle.model.parking.ImageRepositoryCloudStorage
-import com.github.se.cyrcle.model.parking.ParkingRepositoryFirestore
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+
 
 @RunWith(AndroidJUnit4::class)
 class MapScreenTest {
@@ -33,8 +32,8 @@ class MapScreenTest {
   @Before
   fun setUp() {
     mockNavigation = mock(NavigationActions::class.java)
-    val imageRepository = ImageRepositoryCloudStorage(FirebaseAuth.getInstance())
-    val parkingRepository = ParkingRepositoryFirestore(FirebaseFirestore.getInstance())
+    val imageRepository = MockImageRepository()
+    val parkingRepository = MockParkingRepository()
     parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
     mapViewModel = MapViewModel()
     `when`(mockNavigation.currentRoute()).thenReturn(Screen.MAP)

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -86,7 +86,7 @@ fun MapScreen(
   val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.red_marker)
   val resizedBitmap = Bitmap.createScaledBitmap(bitmap, 100, 150, false)
   // Draw markers on the map when the list of parkings changes
-  LaunchedEffect(listOfParkings) {
+  LaunchedEffect(listOfParkings, pointAnnotationManager) {
     drawMarkers(pointAnnotationManager, listOfParkings, resizedBitmap)
   }
 


### PR DESCRIPTION
## Content of the PR 

This PR links the markers with the actual parkings and allow the `ViewAnnotation` to be displayed with relevant info. I also changed the firestore repos in `MapscreenTests.kt` (Image and parking) making future tests for the map more efficient. 

## Why ?

This PR makes the previous feature usable and relevant for users. 

## How ?

I binded to the marker a `JsonElement` (here the parking). I serialize it on creation of the `PointAnnotation` and deserialize on click of one of the marker to extract the infos about the selected parking and display them in the `ViewAnnotation`. 


## Testing 

I have tried many solutions to test the feature implemented with my 2 PR this sprint, unfortunately none works. Markers are rendered on the map as one picture and not as independant UI component. This makes them not recognizable as node during android test. More advanced solutions may require a lot more time (adding advanced framework using image recognition) to be be implemented. This can be done as a future task if someone is willing to give it a try. For now , i recommend doing manual testing to see if it works as intended.  

## Additional resources

![image](https://github.com/user-attachments/assets/7e0bfc1e-7da8-4ef3-a0a5-22d9db12921d)

edit : this PR introduces a quick fix. When reloading the map the markers weren't displayed unless the user dezoom the map. (Thanks @sean-prz)
