### PR TITLE
Integrate title suggestion in attribute picker

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.Location
@@ -45,8 +46,16 @@ class AddScreensNavigationTest {
     val parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
     val reviewViewModel: ReviewViewModel = viewModel(factory = ReviewViewModel.Factory)
     val mapViewModel: MapViewModel = viewModel(factory = MapViewModel.Factory)
-    CyrcleNavHost(navigationActions, navController, parkingViewModel, reviewViewModel, mapViewModel)
-    return listOf<Any>(navigationActions, parkingViewModel, reviewViewModel, mapViewModel)
+    val addressViewModel: AddressViewModel = viewModel(factory = AddressViewModel.Factory)
+    CyrcleNavHost(
+        navigationActions,
+        navController,
+        parkingViewModel,
+        reviewViewModel,
+        mapViewModel,
+        addressViewModel)
+    return listOf<Any>(
+        navigationActions, parkingViewModel, reviewViewModel, mapViewModel, addressViewModel)
   }
 
   @OptIn(ExperimentalTestApi::class)
@@ -101,8 +110,9 @@ class AddScreensNavigationTest {
       val navigationActions = list[0] as NavigationActions
       val parkingViewModel = ParkingViewModel(mockedImageRepository, mockedParkingRepository)
       val mapViewModel = list[3] as MapViewModel
+      val addressViewModel = list[4] as AddressViewModel
       mapViewModel.updateLocation(Location(Point.fromLngLat(0.0, 0.0)))
-      AttributesPicker(navigationActions, parkingViewModel, mapViewModel)
+      AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("submitButton"))
     // Perform click on the add button
@@ -120,8 +130,9 @@ class AddScreensNavigationTest {
       val navigationActions = list[0] as NavigationActions
       val parkingViewModel = list[1] as ParkingViewModel
       val mapViewModel = list[3] as MapViewModel
+      val addressViewModel = list[4] as AddressViewModel
       mapViewModel.updateLocation(Location(Point.fromLngLat(0.0, 0.0)))
-      AttributesPicker(navigationActions, parkingViewModel, mapViewModel)
+      AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
     }
 
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("cancelButton"))

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -3,6 +3,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewViewModel
@@ -23,7 +24,8 @@ fun CyrcleNavHost(
     navController: NavHostController,
     parkingViewModel: ParkingViewModel,
     reviewViewModel: ReviewViewModel,
-    mapViewModel: MapViewModel
+    mapViewModel: MapViewModel,
+    addressViewModel: AddressViewModel,
 ) {
   NavHost(navController = navController, startDestination = Route.AUTH) {
     navigation(
@@ -53,7 +55,7 @@ fun CyrcleNavHost(
     navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
       composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, mapViewModel) }
       composable(Screen.ATTRIBUTES_PICKER) {
-        AttributesPicker(navigationActions, parkingViewModel, mapViewModel)
+        AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
       }
     }
   }

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import com.github.se.cyrcle.model.address.AddressRepository
+import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
@@ -40,6 +41,7 @@ class MainActivity : ComponentActivity() {
     val reviewViewModel = ReviewViewModel(reviewRepository)
     val parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
     val mapViewModel = MapViewModel()
+    val addressViewModel = AddressViewModel(addressRepository)
     setContent {
       CyrcleTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
@@ -47,7 +49,12 @@ class MainActivity : ComponentActivity() {
           val navigationActions = NavigationActions(navController)
 
           CyrcleNavHost(
-              navigationActions, navController, parkingViewModel, reviewViewModel, mapViewModel)
+              navigationActions,
+              navController,
+              parkingViewModel,
+              reviewViewModel,
+              mapViewModel,
+              addressViewModel)
         }
       }
     }

--- a/app/src/main/java/com/github/se/cyrcle/model/address/Address.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/address/Address.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.address
 
+import android.util.Log
 import com.google.gson.annotations.SerializedName
 
 /**
@@ -66,15 +67,33 @@ data class Address(
     @SerializedName("continent") val continent: String = ""
 ) {
   /**
-   * Among the fields of the address, we choose the most relevant ones to display.
+   * Among the fields of the address, we choose the most relevant ones to display. The order of the
+   * fields is important. We choose not to display some fields at all, even if they are present.
    *
    * @return The most relevant fields of the address.
    */
   fun displayRelevantFields(): String {
-    // The order of the fields is important. We choose not to display some fields at all, even if
-    // they are present.
     val fieldPriorities =
-        listOf(publicName, house, road, cityBlock, neighbourhood, hamlet, suburb, city)
-    return fieldPriorities.filter { it.isNotEmpty() }.take(3).joinToString(", ")
+        listOf(publicName, road, house, cityBlock, neighbourhood, hamlet, suburb, city)
+    return shortenString(fieldPriorities.filter { it.isNotEmpty() }.take(3).joinToString(", "), 32)
+  }
+
+  /**
+   * If the string is longer than length. Shorten the string by removing everything after the last
+   * comma
+   *
+   * @param string the string to shorten
+   * @param length the maximum length of the string
+   */
+  private fun shortenString(string: String, length: Int): String {
+    Log.d("Address", "Shortening string $string to length $length")
+    if (string.length <= length) {
+      return string
+    }
+    val lastComma = string.lastIndexOf(",")
+    if (lastComma == -1) {
+      return string
+    }
+    return shortenString(string.substring(0, lastComma), length)
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -68,15 +69,17 @@ fun AttributesPicker(
     mapViewModel: MapViewModel,
     addressViewModel: AddressViewModel
 ) {
-  val location = mapViewModel.selectedLocation.collectAsState().value!!
-  addressViewModel.search(location.center)
-  val suggestedAddress = addressViewModel.address.collectAsState().value
-  val title = remember { mutableStateOf(suggestedAddress.displayRelevantFields()) }
+  val title = remember { mutableStateOf("") }
   val description = remember { mutableStateOf("") }
   val rackType = remember { mutableStateOf<ParkingAttribute>(ParkingRackType.TWO_TIER) }
   val capacity = remember { mutableStateOf<ParkingAttribute>(ParkingCapacity.XSMALL) }
   val protection = remember { mutableStateOf<ParkingAttribute>(ParkingProtection.INDOOR) }
   val hasSecurity = remember { mutableStateOf(false) }
+
+  val location = mapViewModel.selectedLocation.collectAsState().value!!
+  LaunchedEffect(location) { addressViewModel.search(location.center) }
+  val suggestedAddress = addressViewModel.address.collectAsState().value
+  LaunchedEffect(suggestedAddress) { title.value = suggestedAddress.displayRelevantFields() }
 
   fun onSubmit() {
     val parking =

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingAttribute
@@ -64,13 +65,13 @@ import com.mapbox.maps.plugin.gestures.generated.GesturesSettings
 fun AttributesPicker(
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel,
-    mapViewModel: MapViewModel
+    mapViewModel: MapViewModel,
+    addressViewModel: AddressViewModel
 ) {
   val location = mapViewModel.selectedLocation.collectAsState().value!!
-  val title = remember {
-    mutableStateOf(
-        "${("%.2f").format(location.center.longitude())}, ${("%.3f").format(location.center.latitude())}")
-  }
+  addressViewModel.search(location.center)
+  val suggestedAddress = addressViewModel.address.collectAsState().value
+  val title = remember { mutableStateOf(suggestedAddress.displayRelevantFields()) }
   val description = remember { mutableStateOf("") }
   val rackType = remember { mutableStateOf<ParkingAttribute>(ParkingRackType.TWO_TIER) }
   val capacity = remember { mutableStateOf<ParkingAttribute>(ParkingCapacity.XSMALL) }

--- a/app/src/test/java/com/github/se/cyrcle/model/address/AddressTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/address/AddressTest.kt
@@ -40,7 +40,8 @@ class AddressTest {
     val address1 =
         Address(
             country = "Switzerland", city = "Lausanne", road = "Avenue de la Gare", house = "14")
-    assertEquals("14, Avenue de la Gare, Lausanne", address1.displayRelevantFields())
+    val expected1 = "Avenue de la Gare, 14, Lausanne"
+    assertEquals(expected1, address1.displayRelevantFields())
 
     val address2 =
         Address(
@@ -48,7 +49,7 @@ class AddressTest {
             city = "Paris",
             road = "Rue du Faubourg Saint-Honoré",
             house = "55")
-    assertEquals(
-        "Palais de L'Élysée, 55, Rue du Faubourg Saint-Honoré", address2.displayRelevantFields())
+    val expected2 = "Palais de L'Élysée"
+    assertEquals(expected2, address2.displayRelevantFields())
   }
 }


### PR DESCRIPTION
Closes #101

This PR integrates feature implemented in PR #84 into the Attribute Picker Screen.
Additional changes are trivial changes (e.g. initialize AddressViewModel and add it to navgraph)

This is what kind of title might be suggested:
![image](https://github.com/user-attachments/assets/36a8380e-9937-4d36-a8e1-af6f69945a8f)

No additional tests (feature is already tested and screen too. This PR doesn't anything that would justify new tests)