### PR TITLE
User profile favorite parkings

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -163,4 +163,53 @@ class ProfileScreenTest {
     // Verify profile image is clickable in edit mode
     composeTestRule.onNodeWithTag("ProfileImage").assertHasClickAction()
   }
+
+  @Test
+  fun testRemoveFavoriteParking() {
+    // Wait for favorite parkings to be displayed
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FavoriteToggle_0").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Click remove favorite button
+    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+
+    // Verify dialog appears
+    composeTestRule.onNodeWithText("Remove favorite").assertExists()
+    composeTestRule.onNodeWithText("Remove").assertExists()
+    composeTestRule.onNodeWithText("Cancel").assertExists()
+
+    // Confirm removal
+    composeTestRule.onNodeWithText("Remove").performClick()
+
+    // Verify parking was removed
+    composeTestRule.onNodeWithText("Parking Central").assertDoesNotExist()
+  }
+
+  @Test
+  fun testInputFieldValidation() {
+    // Enter edit mode
+    composeTestRule.onNodeWithTag("EditButton").performClick()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule.onAllNodesWithTag("FirstNameField").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Test empty fields
+    composeTestRule.onNodeWithTag("FirstNameField").performTextClearance()
+    composeTestRule.onNodeWithTag("LastNameField").performTextClearance()
+    composeTestRule.onNodeWithTag("UsernameField").performTextClearance()
+
+    // Test maximum length inputs
+    val longInput = "a".repeat(50)
+    composeTestRule.onNodeWithTag("FirstNameField").performTextInput(longInput)
+    composeTestRule.onNodeWithTag("LastNameField").performTextInput(longInput)
+    composeTestRule.onNodeWithTag("UsernameField").performTextInput(longInput)
+
+    // Save changes
+    composeTestRule.onNodeWithTag("SaveButton").performClick()
+
+    // Verify the values were saved (or validation messages appeared if implemented)
+    composeTestRule.onNodeWithTag("DisplayFirstName").assertExists()
+  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -128,7 +128,7 @@ class ProfileScreenTest {
   }
 
   @Test
-  fun testFavoriteParkingsSection() {
+  fun testFavoriteParkingsSectionWithHardcodedParkings() {
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule.onAllNodesWithTag("FavoriteParkingsTitle").fetchSemanticsNodes().isNotEmpty()
     }
@@ -136,8 +136,12 @@ class ProfileScreenTest {
     // Check favorite parkings section exists
     composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertExists()
 
-    // If no favorites, verify empty state message
-    composeTestRule.onNodeWithTag("NoFavoritesMessage").assertExists()
+    // Verify the favorite parking items
+    composeTestRule.onNodeWithTag("FavoriteParkingList").assertExists()
+    composeTestRule
+        .onAllNodesWithTag("ParkingItem_")
+        .assertAll(hasTextExactly("Parking Central", "Parking Station", "Parking Mall"))
+    composeTestRule.onAllNodesWithTag("FavoriteToggle_").assertAll(isToggleable())
   }
 
   @Test

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -277,7 +277,7 @@ private fun ProfileImage(
 }
 
 @Composable
-fun FavoriteParkingsSection(
+private fun FavoriteParkingsSection(
     favoriteParkings: List<Parking>,
     onFavoritesUpdated: (List<Parking>) -> Unit
 ) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -36,39 +36,52 @@ import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
-  var isEditing by remember { mutableStateOf(false) }
-  var firstName by remember { mutableStateOf("John") }
-  var lastName by remember { mutableStateOf("Doe") }
-  var username by remember { mutableStateOf("johndoe") }
-  var profilePictureUrl by remember { mutableStateOf("") }
-  var favoriteParkings by remember { mutableStateOf(emptyList<String>()) }
+    var isEditing by remember { mutableStateOf(false) }
+    var firstName by remember { mutableStateOf("John") }
+    var lastName by remember { mutableStateOf("Doe") }
+    var username by remember { mutableStateOf("johndoe") }
+    var profilePictureUrl by remember { mutableStateOf("") }
+    var favoriteParkings by remember {
+        mutableStateOf(
+            listOf(
+                "Parking Central",
+                "Parking Station",
+                "Parking Mall",
+                "Parking Airport",
+                "Parking Downtown"
+            )
+        )
+    }
 
-  var originalFirstName by remember { mutableStateOf(firstName) }
-  var originalLastName by remember { mutableStateOf(lastName) }
-  var originalUsername by remember { mutableStateOf(username) }
-  var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
+    var originalFirstName by remember { mutableStateOf(firstName) }
+    var originalLastName by remember { mutableStateOf(lastName) }
+    var originalUsername by remember { mutableStateOf(username) }
+    var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
 
-  val imagePickerLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let { profilePictureUrl = it.toString() }
-      }
+    val imagePickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            uri?.let { profilePictureUrl = it.toString() }
+        }
 
-  Scaffold(
-      modifier = Modifier.testTag("ProfileScreen"),
-      bottomBar = {
-        BottomNavigationBar(
-            navigationActions = navigationActions,
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = Route.PROFILE)
-      }) { innerPadding ->
+    Scaffold(
+        modifier = Modifier.testTag("ProfileScreen"),
+        bottomBar = {
+            BottomNavigationBar(
+                navigationActions = navigationActions,
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = Route.PROFILE
+            )
+        }
+    ) { innerPadding ->
         Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(16.dp)
-                    .testTag("ProfileContent"),
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              if (isEditing) {
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+                .testTag("ProfileContent"),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (isEditing) {
                 EditProfileContent(
                     firstName = firstName,
                     lastName = lastName,
@@ -79,41 +92,43 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                     onUsernameChange = { username = it },
                     onImageClick = { imagePickerLauncher.launch("image/*") },
                     onSave = {
-                      originalFirstName = firstName
-                      originalLastName = lastName
-                      originalUsername = username
-                      originalProfilePictureUrl = profilePictureUrl
-                      isEditing = false
+                        originalFirstName = firstName
+                        originalLastName = lastName
+                        originalUsername = username
+                        originalProfilePictureUrl = profilePictureUrl
+                        isEditing = false
                     },
                     onCancel = {
-                      firstName = originalFirstName
-                      lastName = originalLastName
-                      username = originalUsername
-                      profilePictureUrl = originalProfilePictureUrl
-                      isEditing = false
-                    })
-              } else {
+                        firstName = originalFirstName
+                        lastName = originalLastName
+                        username = originalUsername
+                        profilePictureUrl = originalProfilePictureUrl
+                        isEditing = false
+                    }
+                )
+            } else {
                 DisplayProfileContent(
                     firstName = firstName,
                     lastName = lastName,
                     username = username,
                     profilePictureUrl = profilePictureUrl,
                     onEditClick = {
-                      originalFirstName = firstName
-                      originalLastName = lastName
-                      originalUsername = username
-                      originalProfilePictureUrl = profilePictureUrl
-                      isEditing = true
-                    })
-              }
+                        originalFirstName = firstName
+                        originalLastName = lastName
+                        originalUsername = username
+                        originalProfilePictureUrl = profilePictureUrl
+                        isEditing = true
+                    }
+                )
 
-              Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(24.dp))
 
-              FavoriteParkingsSection(favoriteParkings) { newFavorites ->
-                favoriteParkings = newFavorites
-              }
+                FavoriteParkingsSection(favoriteParkings) { newFavorites ->
+                    favoriteParkings = newFavorites
+                }
             }
-      }
+        }
+    }
 }
 
 @Composable
@@ -129,47 +144,57 @@ private fun EditProfileContent(
     onSave: () -> Unit,
     onCancel: () -> Unit
 ) {
-  ProfileImage(
-      url = profilePictureUrl,
-      onClick = onImageClick,
-      isEditable = true,
-      modifier = Modifier.testTag("ProfileImage"))
+    ProfileImage(
+        url = profilePictureUrl,
+        onClick = onImageClick,
+        isEditable = true,
+        modifier = Modifier.testTag("ProfileImage")
+    )
 
-  Spacer(modifier = Modifier.height(24.dp))
+    Spacer(modifier = Modifier.height(24.dp))
 
-  InputText(
-      value = firstName,
-      onValueChange = onFirstNameChange,
-      label = "First Name",
-      testTag = "FirstNameField")
+    InputText(
+        value = firstName,
+        onValueChange = onFirstNameChange,
+        label = "First Name",
+        testTag = "FirstNameField"
+    )
 
-  Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-  InputText(
-      value = lastName,
-      onValueChange = onLastNameChange,
-      label = "Last Name",
-      testTag = "LastNameField")
+    InputText(
+        value = lastName,
+        onValueChange = onLastNameChange,
+        label = "Last Name",
+        testTag = "LastNameField"
+    )
 
-  Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-  InputText(
-      value = username,
-      onValueChange = onUsernameChange,
-      label = "Username",
-      testTag = "UsernameField")
+    InputText(
+        value = username,
+        onValueChange = onUsernameChange,
+        label = "Username",
+        testTag = "UsernameField"
+    )
 
-  Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
 
-  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-    Button(text = "Save", onClick = onSave, colorLevel = ColorLevel.PRIMARY, testTag = "SaveButton")
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Button(
+            text = "Save",
+            onClick = onSave,
+            colorLevel = ColorLevel.PRIMARY,
+            testTag = "SaveButton"
+        )
 
-    Button(
-        text = "Cancel",
-        onClick = onCancel,
-        colorLevel = ColorLevel.SECONDARY,
-        testTag = "CancelButton")
-  }
+        Button(
+            text = "Cancel",
+            onClick = onCancel,
+            colorLevel = ColorLevel.SECONDARY,
+            testTag = "CancelButton"
+        )
+    }
 }
 
 @Composable
@@ -180,38 +205,43 @@ private fun DisplayProfileContent(
     profilePictureUrl: String,
     onEditClick: () -> Unit
 ) {
-  Text(
-      text = firstName,
-      style = MaterialTheme.typography.headlineMedium,
-      modifier = Modifier.testTag("DisplayFirstName"))
+    Text(
+        text = firstName,
+        style = MaterialTheme.typography.headlineMedium,
+        modifier = Modifier.testTag("DisplayFirstName")
+    )
 
-  Text(
-      text = lastName,
-      style = MaterialTheme.typography.headlineMedium,
-      modifier = Modifier.testTag("DisplayLastName"))
+    Text(
+        text = lastName,
+        style = MaterialTheme.typography.headlineMedium,
+        modifier = Modifier.testTag("DisplayLastName")
+    )
 
-  Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
 
-  ProfileImage(
-      url = profilePictureUrl,
-      onClick = {},
-      isEditable = false,
-      modifier = Modifier.testTag("ProfileImage"))
+    ProfileImage(
+        url = profilePictureUrl,
+        onClick = {},
+        isEditable = false,
+        modifier = Modifier.testTag("ProfileImage")
+    )
 
-  Spacer(modifier = Modifier.height(8.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
-  Text(
-      text = "@$username",
-      style = MaterialTheme.typography.bodyMedium,
-      modifier = Modifier.testTag("DisplayUsername"))
+    Text(
+        text = "@$username",
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.testTag("DisplayUsername")
+    )
 
-  Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
 
-  Button(
-      text = "Modify Profile",
-      onClick = onEditClick,
-      colorLevel = ColorLevel.TERTIARY,
-      testTag = "EditButton")
+    Button(
+        text = "Modify Profile",
+        onClick = onEditClick,
+        colorLevel = ColorLevel.TERTIARY,
+        testTag = "EditButton"
+    )
 }
 
 @Composable
@@ -221,53 +251,57 @@ private fun ProfileImage(
     isEditable: Boolean,
     modifier: Modifier = Modifier
 ) {
-  val context = LocalContext.current
-  val painter =
-      rememberAsyncImagePainter(
-          ImageRequest.Builder(context)
-              .data(if (url.isNotBlank()) url else null)
-              .apply { transformations(CircleCropTransformation()) }
-              .build())
-
-  Box(
-      modifier =
-          modifier.then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)) {
+    Box(
+        modifier = modifier.then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)
+    ) {
         if (url.isBlank()) {
-          Box(
-              modifier =
-                  Modifier.size(120.dp)
-                      .clip(CircleShape)
-                      .background(MaterialTheme.colorScheme.primaryContainer),
-              contentAlignment = Alignment.Center) {
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Person,
                     contentDescription = "Default Profile Picture",
                     modifier = Modifier.size(60.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer)
-              }
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
         } else {
-          Image(
-              painter = painter,
-              contentDescription = "Profile Picture",
-              modifier = Modifier.size(120.dp).clip(CircleShape),
-              contentScale = ContentScale.Crop)
+            Image(
+                painter = rememberAsyncImagePainter(
+                    ImageRequest.Builder(LocalContext.current)
+                        .data(url)
+                        .apply { transformations(CircleCropTransformation()) }
+                        .build()
+                ),
+                contentDescription = "Profile Picture",
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop
+            )
         }
 
         if (isEditable) {
-          Box(
-              modifier =
-                  Modifier.size(120.dp)
-                      .clip(CircleShape)
-                      .background(Color.Black.copy(alpha = 0.3f)),
-              contentAlignment = Alignment.Center) {
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Edit,
                     contentDescription = "Edit Profile Picture",
                     tint = Color.White,
-                    modifier = Modifier.size(40.dp))
-              }
+                    modifier = Modifier.size(40.dp)
+                )
+            }
         }
-      }
+    }
 }
 
 @Composable
@@ -275,58 +309,105 @@ private fun FavoriteParkingsSection(
     favoriteParkings: List<String>,
     onFavoritesUpdated: (List<String>) -> Unit
 ) {
-  Text(
-      text = "Favorite Parkings",
-      style = MaterialTheme.typography.titleLarge,
-      modifier = Modifier.testTag("FavoriteParkingsTitle"))
-
-  Spacer(modifier = Modifier.height(16.dp))
-
-  if (favoriteParkings.isEmpty()) {
     Text(
-        text = "No favorite parkings yet",
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("NoFavoritesMessage"))
-  } else {
-    LazyRow(
-        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          itemsIndexed(favoriteParkings) { index, parking ->
-            FavoriteParkingCard(
-                parking = parking,
-                index = index,
-                onRemove = {
-                  val updatedList = favoriteParkings.toMutableList()
-                  updatedList.removeAt(index)
-                  onFavoritesUpdated(updatedList)
-                })
-          }
+        text = "Favorite Parkings",
+        style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.testTag("FavoriteParkingsTitle")
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    if (favoriteParkings.isEmpty()) {
+        Text(
+            text = "No favorite parkings yet",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.testTag("NoFavoritesMessage")
+        )
+    } else {
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("FavoriteParkingList"),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            itemsIndexed(favoriteParkings) { index, parking ->
+                FavoriteParkingCard(
+                    parking = parking,
+                    index = index,
+                    onRemove = {
+                        val updatedList = favoriteParkings.toMutableList()
+                        updatedList.removeAt(index)
+                        onFavoritesUpdated(updatedList)
+                    }
+                )
+            }
         }
-  }
+    }
 }
 
 @Composable
-private fun FavoriteParkingCard(parking: String, index: Int, onRemove: () -> Unit) {
-  Card(
-      modifier = Modifier.size(120.dp).padding(8.dp),
-      shape = MaterialTheme.shapes.medium,
-  ) {
-    Box(modifier = Modifier.fillMaxSize()) {
-      Text(
-          text = parking,
-          style = MaterialTheme.typography.bodySmall,
-          modifier = Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
+private fun FavoriteParkingCard(
+    parking: String,
+    index: Int,
+    onRemove: () -> Unit
+) {
+    var showConfirmDialog by remember { mutableStateOf(false) }
 
-      IconButton(
-          onClick = onRemove,
-          modifier =
-              Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
-            Icon(
-                imageVector = Icons.Filled.Star,
-                contentDescription = "Remove from Favorites",
-                tint = Color(0xFFFFD700),
-                modifier = Modifier.size(20.dp))
-          }
+    Card(
+        modifier = Modifier
+            .size(120.dp)
+            .padding(8.dp),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = parking,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(8.dp)
+                    .testTag("ParkingItem_$index")
+            )
+
+            IconButton(
+                onClick = { showConfirmDialog = true },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(32.dp)
+                    .testTag("FavoriteToggle_$index")
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Star,
+                    contentDescription = "Remove from Favorites",
+                    tint = Color(0xFFFFD700),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
     }
-  }
+
+    if (showConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showConfirmDialog = false },
+            title = { Text("Remove favorite") },
+            text = { Text("Are you sure you want to remove $parking from your favorites?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onRemove()
+                        showConfirmDialog = false
+                    }
+                ) {
+                    Text("Remove")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showConfirmDialog = false }
+                ) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -26,6 +26,12 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
+import com.github.se.cyrcle.ui.card.Location
+import com.github.se.cyrcle.ui.card.Parking
+import com.github.se.cyrcle.ui.card.ParkingCapacity
+import com.github.se.cyrcle.ui.card.ParkingProtection
+import com.github.se.cyrcle.ui.card.ParkingRackType
+import com.github.se.cyrcle.ui.card.Point
 import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
@@ -33,6 +39,8 @@ import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
+
+
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
@@ -44,11 +52,42 @@ fun ProfileScreen(navigationActions: NavigationActions) {
     var favoriteParkings by remember {
         mutableStateOf(
             listOf(
-                "Parking Central",
-                "Parking Station",
-                "Parking Mall",
-                "Parking Airport",
-                "Parking Downtown"
+                Parking(
+                    uid = "1",
+                    optName = "Parking Central",
+                    optDescription = null,
+                    location = Location(Point(1.0, 1.0)),
+                    images = emptyList(),
+                    capacity = ParkingCapacity.MEDIUM,
+                    rackType = ParkingRackType.U_RACK,
+                    protection = ParkingProtection.NONE,
+                    price = 0.0,
+                    hasSecurity = false
+                ),
+                Parking(
+                    uid = "2",
+                    optName = "Parking Station",
+                    optDescription = null,
+                    location = Location(Point(2.0, 2.0)),
+                    images = emptyList(),
+                    capacity = ParkingCapacity.SMALL,
+                    rackType = ParkingRackType.WALL_BUTTERFLY,
+                    protection = ParkingProtection.COVERED,
+                    price = 2.5,
+                    hasSecurity = true
+                ),
+                Parking(
+                    uid = "3",
+                    optName = "Parking Mall",
+                    optDescription = null,
+                    location = Location(Point(3.0, 3.0)),
+                    images = emptyList(),
+                    capacity = ParkingCapacity.LARGE,
+                    rackType = ParkingRackType.GRID,
+                    protection = ParkingProtection.INDOOR,
+                    price = 1.0,
+                    hasSecurity = true
+                )
             )
         )
     }
@@ -123,8 +162,10 @@ fun ProfileScreen(navigationActions: NavigationActions) {
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                FavoriteParkingsSection(favoriteParkings) { newFavorites ->
-                    favoriteParkings = newFavorites
+                FavoriteParkingsSection(favoriteParkings.map { it.optName ?: "" }) { newFavorites ->
+                    favoriteParkings = favoriteParkings.filter { parking ->
+                        newFavorites.contains(parking.optName)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -41,86 +41,76 @@ import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
 @Composable
-fun ProfileScreen(
-    navigationActions: NavigationActions
-) {
-    var isEditing by remember { mutableStateOf(false) }
-    var firstName by remember { mutableStateOf("John") }
-    var lastName by remember { mutableStateOf("Doe") }
-    var username by remember { mutableStateOf("johndoe") }
-    var profilePictureUrl by remember { mutableStateOf("") }
-    var favoriteParkings by remember {
-        mutableStateOf(
-            listOf(
-                Parking(
-                    uid = "1",
-                    optName = "Parking Central",
-                    optDescription = null,
-                    location = Location(Point(1.0, 1.0)),
-                    images = emptyList(),
-                    capacity = ParkingCapacity.MEDIUM,
-                    rackType = ParkingRackType.U_RACK,
-                    protection = ParkingProtection.NONE,
-                    price = 0.0,
-                    hasSecurity = false
-                ),
-                Parking(
-                    uid = "2",
-                    optName = "Parking Station",
-                    optDescription = null,
-                    location = Location(Point(2.0, 2.0)),
-                    images = emptyList(),
-                    capacity = ParkingCapacity.SMALL,
-                    rackType = ParkingRackType.WALL_BUTTERFLY,
-                    protection = ParkingProtection.COVERED,
-                    price = 2.5,
-                    hasSecurity = true
-                ),
-                Parking(
-                    uid = "3",
-                    optName = "Parking Mall",
-                    optDescription = null,
-                    location = Location(Point(3.0, 3.0)),
-                    images = emptyList(),
-                    capacity = ParkingCapacity.LARGE,
-                    rackType = ParkingRackType.GRID,
-                    protection = ParkingProtection.INDOOR,
-                    price = 1.0,
-                    hasSecurity = true
-                )
-            )
-        )
-    }
+fun ProfileScreen(navigationActions: NavigationActions) {
+  var isEditing by remember { mutableStateOf(false) }
+  var firstName by remember { mutableStateOf("John") }
+  var lastName by remember { mutableStateOf("Doe") }
+  var username by remember { mutableStateOf("johndoe") }
+  var profilePictureUrl by remember { mutableStateOf("") }
+  var favoriteParkings by remember {
+    mutableStateOf(
+        listOf(
+            Parking(
+                uid = "1",
+                optName = "Parking Central",
+                optDescription = null,
+                location = Location(Point(1.0, 1.0)),
+                images = emptyList(),
+                capacity = ParkingCapacity.MEDIUM,
+                rackType = ParkingRackType.U_RACK,
+                protection = ParkingProtection.NONE,
+                price = 0.0,
+                hasSecurity = false),
+            Parking(
+                uid = "2",
+                optName = "Parking Station",
+                optDescription = null,
+                location = Location(Point(2.0, 2.0)),
+                images = emptyList(),
+                capacity = ParkingCapacity.SMALL,
+                rackType = ParkingRackType.WALL_BUTTERFLY,
+                protection = ParkingProtection.COVERED,
+                price = 2.5,
+                hasSecurity = true),
+            Parking(
+                uid = "3",
+                optName = "Parking Mall",
+                optDescription = null,
+                location = Location(Point(3.0, 3.0)),
+                images = emptyList(),
+                capacity = ParkingCapacity.LARGE,
+                rackType = ParkingRackType.GRID,
+                protection = ParkingProtection.INDOOR,
+                price = 1.0,
+                hasSecurity = true)))
+  }
 
-    var originalFirstName by remember { mutableStateOf(firstName) }
-    var originalLastName by remember { mutableStateOf(lastName) }
-    var originalUsername by remember { mutableStateOf(username) }
-    var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
+  var originalFirstName by remember { mutableStateOf(firstName) }
+  var originalLastName by remember { mutableStateOf(lastName) }
+  var originalUsername by remember { mutableStateOf(username) }
+  var originalProfilePictureUrl by remember { mutableStateOf(profilePictureUrl) }
 
-    val imagePickerLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-            uri?.let { profilePictureUrl = it.toString() }
-        }
+  val imagePickerLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { profilePictureUrl = it.toString() }
+      }
 
-    Scaffold(
-        modifier = Modifier.testTag("ProfileScreen"),
-        bottomBar = {
-            BottomNavigationBar(
-                navigationActions = navigationActions,
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = Route.PROFILE
-            )
-        }
-    ) { innerPadding ->
+  Scaffold(
+      modifier = Modifier.testTag("ProfileScreen"),
+      bottomBar = {
+        BottomNavigationBar(
+            navigationActions = navigationActions,
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = Route.PROFILE)
+      }) { innerPadding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(16.dp)
-                .testTag("ProfileContent"),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            if (isEditing) {
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp)
+                    .testTag("ProfileContent"),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              if (isEditing) {
                 EditProfileContent(
                     firstName = firstName,
                     lastName = lastName,
@@ -131,46 +121,41 @@ fun ProfileScreen(
                     onUsernameChange = { username = it },
                     onImageClick = { imagePickerLauncher.launch("image/*") },
                     onSave = {
-                        originalFirstName = firstName
-                        originalLastName = lastName
-                        originalUsername = username
-                        originalProfilePictureUrl = profilePictureUrl
-                        isEditing = false
+                      originalFirstName = firstName
+                      originalLastName = lastName
+                      originalUsername = username
+                      originalProfilePictureUrl = profilePictureUrl
+                      isEditing = false
                     },
                     onCancel = {
-                        firstName = originalFirstName
-                        lastName = originalLastName
-                        username = originalUsername
-                        profilePictureUrl = originalProfilePictureUrl
-                        isEditing = false
-                    }
-                )
-            } else {
+                      firstName = originalFirstName
+                      lastName = originalLastName
+                      username = originalUsername
+                      profilePictureUrl = originalProfilePictureUrl
+                      isEditing = false
+                    })
+              } else {
                 DisplayProfileContent(
                     firstName = firstName,
                     lastName = lastName,
                     username = username,
                     profilePictureUrl = profilePictureUrl,
                     onEditClick = {
-                        originalFirstName = firstName
-                        originalLastName = lastName
-                        originalUsername = username
-                        originalProfilePictureUrl = profilePictureUrl
-                        isEditing = true
-                    }
-                )
+                      originalFirstName = firstName
+                      originalLastName = lastName
+                      originalUsername = username
+                      originalProfilePictureUrl = profilePictureUrl
+                      isEditing = true
+                    })
 
                 Spacer(modifier = Modifier.height(24.dp))
 
                 FavoriteParkingsSection(
                     favoriteParkings = favoriteParkings,
-                    onFavoritesUpdated = { newFavorites ->
-                        favoriteParkings = newFavorites
-                    }
-                )
+                    onFavoritesUpdated = { newFavorites -> favoriteParkings = newFavorites })
+              }
             }
-        }
-    }
+      }
 }
 
 @Composable
@@ -186,57 +171,47 @@ private fun EditProfileContent(
     onSave: () -> Unit,
     onCancel: () -> Unit
 ) {
-    ProfileImage(
-        url = profilePictureUrl,
-        onClick = onImageClick,
-        isEditable = true,
-        modifier = Modifier.testTag("ProfileImage")
-    )
+  ProfileImage(
+      url = profilePictureUrl,
+      onClick = onImageClick,
+      isEditable = true,
+      modifier = Modifier.testTag("ProfileImage"))
 
-    Spacer(modifier = Modifier.height(24.dp))
+  Spacer(modifier = Modifier.height(24.dp))
 
-    InputText(
-        value = firstName,
-        onValueChange = onFirstNameChange,
-        label = "First Name",
-        testTag = "FirstNameField"
-    )
+  InputText(
+      value = firstName,
+      onValueChange = onFirstNameChange,
+      label = "First Name",
+      testTag = "FirstNameField")
 
-    Spacer(modifier = Modifier.height(8.dp))
+  Spacer(modifier = Modifier.height(8.dp))
 
-    InputText(
-        value = lastName,
-        onValueChange = onLastNameChange,
-        label = "Last Name",
-        testTag = "LastNameField"
-    )
+  InputText(
+      value = lastName,
+      onValueChange = onLastNameChange,
+      label = "Last Name",
+      testTag = "LastNameField")
 
-    Spacer(modifier = Modifier.height(8.dp))
+  Spacer(modifier = Modifier.height(8.dp))
 
-    InputText(
-        value = username,
-        onValueChange = onUsernameChange,
-        label = "Username",
-        testTag = "UsernameField"
-    )
+  InputText(
+      value = username,
+      onValueChange = onUsernameChange,
+      label = "Username",
+      testTag = "UsernameField")
 
-    Spacer(modifier = Modifier.height(16.dp))
+  Spacer(modifier = Modifier.height(16.dp))
 
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Button(
-            text = "Save",
-            onClick = onSave,
-            colorLevel = ColorLevel.PRIMARY,
-            testTag = "SaveButton"
-        )
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Button(text = "Save", onClick = onSave, colorLevel = ColorLevel.PRIMARY, testTag = "SaveButton")
 
-        Button(
-            text = "Cancel",
-            onClick = onCancel,
-            colorLevel = ColorLevel.SECONDARY,
-            testTag = "CancelButton"
-        )
-    }
+    Button(
+        text = "Cancel",
+        onClick = onCancel,
+        colorLevel = ColorLevel.SECONDARY,
+        testTag = "CancelButton")
+  }
 }
 
 @Composable
@@ -247,43 +222,38 @@ private fun DisplayProfileContent(
     profilePictureUrl: String,
     onEditClick: () -> Unit
 ) {
-    Text(
-        text = firstName,
-        style = MaterialTheme.typography.headlineMedium,
-        modifier = Modifier.testTag("DisplayFirstName")
-    )
+  Text(
+      text = firstName,
+      style = MaterialTheme.typography.headlineMedium,
+      modifier = Modifier.testTag("DisplayFirstName"))
 
-    Text(
-        text = lastName,
-        style = MaterialTheme.typography.headlineMedium,
-        modifier = Modifier.testTag("DisplayLastName")
-    )
+  Text(
+      text = lastName,
+      style = MaterialTheme.typography.headlineMedium,
+      modifier = Modifier.testTag("DisplayLastName"))
 
-    Spacer(modifier = Modifier.height(16.dp))
+  Spacer(modifier = Modifier.height(16.dp))
 
-    ProfileImage(
-        url = profilePictureUrl,
-        onClick = {},
-        isEditable = false,
-        modifier = Modifier.testTag("ProfileImage")
-    )
+  ProfileImage(
+      url = profilePictureUrl,
+      onClick = {},
+      isEditable = false,
+      modifier = Modifier.testTag("ProfileImage"))
 
-    Spacer(modifier = Modifier.height(8.dp))
+  Spacer(modifier = Modifier.height(8.dp))
 
-    Text(
-        text = "@$username",
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("DisplayUsername")
-    )
+  Text(
+      text = "@$username",
+      style = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.testTag("DisplayUsername"))
 
-    Spacer(modifier = Modifier.height(16.dp))
+  Spacer(modifier = Modifier.height(16.dp))
 
-    Button(
-        text = "Modify Profile",
-        onClick = onEditClick,
-        colorLevel = ColorLevel.TERTIARY,
-        testTag = "EditButton"
-    )
+  Button(
+      text = "Modify Profile",
+      onClick = onEditClick,
+      colorLevel = ColorLevel.TERTIARY,
+      testTag = "EditButton")
 }
 
 @Composable
@@ -293,163 +263,128 @@ private fun ProfileImage(
     isEditable: Boolean,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier = modifier.then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)
-    ) {
+  Box(
+      modifier =
+          modifier.then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)) {
         if (url.isBlank()) {
-            Box(
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
+          Box(
+              modifier =
+                  Modifier.size(120.dp)
+                      .clip(CircleShape)
+                      .background(MaterialTheme.colorScheme.primaryContainer),
+              contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.Filled.Person,
                     contentDescription = "Default Profile Picture",
                     modifier = Modifier.size(60.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer)
+              }
         } else {
-            Image(
-                painter = rememberAsyncImagePainter(
-                    ImageRequest.Builder(LocalContext.current)
-                        .data(url)
-                        .apply { transformations(CircleCropTransformation()) }
-                        .build()
-                ),
-                contentDescription = "Profile Picture",
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop
-            )
+          Image(
+              painter =
+                  rememberAsyncImagePainter(
+                      ImageRequest.Builder(LocalContext.current)
+                          .data(url)
+                          .apply { transformations(CircleCropTransformation()) }
+                          .build()),
+              contentDescription = "Profile Picture",
+              modifier = Modifier.size(120.dp).clip(CircleShape),
+              contentScale = ContentScale.Crop)
         }
 
         if (isEditable) {
-            Box(
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(CircleShape)
-                    .background(Color.Black.copy(alpha = 0.3f)),
-                contentAlignment = Alignment.Center
-            ) {
+          Box(
+              modifier =
+                  Modifier.size(120.dp)
+                      .clip(CircleShape)
+                      .background(Color.Black.copy(alpha = 0.3f)),
+              contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = Icons.Filled.Edit,
                     contentDescription = "Edit Profile Picture",
                     tint = Color.White,
-                    modifier = Modifier.size(40.dp)
-                )
-            }
+                    modifier = Modifier.size(40.dp))
+              }
         }
-    }
+      }
 }
 
 @Composable
-private fun FavoriteParkingsSection(
+fun FavoriteParkingsSection(
     favoriteParkings: List<Parking>,
     onFavoritesUpdated: (List<Parking>) -> Unit
 ) {
+  Text(
+      text = "Favorite Parkings",
+      style = MaterialTheme.typography.titleLarge,
+      modifier = Modifier.testTag("FavoriteParkingsTitle"))
+
+  Spacer(modifier = Modifier.height(16.dp))
+
+  if (favoriteParkings.isEmpty()) {
     Text(
-        text = "Favorite Parkings",
-        style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.testTag("FavoriteParkingsTitle")
-    )
-
-    Spacer(modifier = Modifier.height(16.dp))
-
-    if (favoriteParkings.isEmpty()) {
-        Text(
-            text = "No favorite parkings yet",
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("NoFavoritesMessage")
-        )
-    } else {
-        LazyRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("FavoriteParkingList"),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            itemsIndexed(favoriteParkings) { index, parking ->
-                FavoriteParkingCard(
-                    parking = parking,
-                    index = index,
-                    onRemove = {
-                        val updatedList = favoriteParkings.toMutableList()
-                        updatedList.removeAt(index)
-                        onFavoritesUpdated(updatedList)
-                    }
-                )
-            }
+        text = "No favorite parkings yet",
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.testTag("NoFavoritesMessage"))
+  } else {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          itemsIndexed(favoriteParkings) { index, parking ->
+            FavoriteParkingCard(
+                parking = parking,
+                index = index,
+                onRemove = {
+                  val updatedList = favoriteParkings.toMutableList()
+                  updatedList.removeAt(index)
+                  onFavoritesUpdated(updatedList)
+                })
+          }
         }
-    }
+  }
 }
 
 @Composable
-private fun FavoriteParkingCard(
-    parking: Parking,
-    index: Int,
-    onRemove: () -> Unit
-) {
-    var showConfirmDialog by remember { mutableStateOf(false) }
+private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Unit) {
+  var showConfirmDialog by remember { mutableStateOf(false) }
 
-    Card(
-        modifier = Modifier
-            .size(120.dp)
-            .padding(8.dp),
-        shape = MaterialTheme.shapes.medium,
-    ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Text(
-                text = parking.optName ?: "", // Display only the optName property
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(8.dp)
-                    .testTag("ParkingItem_$index")
-            )
+  Card(
+      modifier = Modifier.size(120.dp).padding(8.dp),
+      shape = MaterialTheme.shapes.medium,
+  ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      Text(
+          text = parking.optName ?: "", // Display only the optName property
+          style = MaterialTheme.typography.bodySmall,
+          modifier = Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
 
-            IconButton(
-                onClick = { showConfirmDialog = true },
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .size(32.dp)
-                    .testTag("FavoriteToggle_$index")
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Star,
-                    contentDescription = "Remove from Favorites",
-                    tint = Color(0xFFFFD700),
-                    modifier = Modifier.size(20.dp)
-                )
-            }
-        }
+      IconButton(
+          onClick = { showConfirmDialog = true },
+          modifier =
+              Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = "Remove from Favorites",
+                tint = Color(0xFFFFD700),
+                modifier = Modifier.size(20.dp))
+          }
     }
+  }
 
-    if (showConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { showConfirmDialog = false },
-            title = { Text("Remove favorite") },
-            text = { Text("Are you sure you want to remove ${parking.optName} from your favorites?") },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        onRemove()
-                        showConfirmDialog = false
-                    }
-                ) {
-                    Text("Remove")
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showConfirmDialog = false }
-                ) {
-                    Text("Cancel")
-                }
-            }
-        )
-    }
+  if (showConfirmDialog) {
+    AlertDialog(
+        onDismissRequest = { showConfirmDialog = false },
+        title = { Text("Remove favorite") },
+        text = { Text("Are you sure you want to remove ${parking.optName} from your favorites?") },
+        confirmButton = {
+          TextButton(
+              onClick = {
+                onRemove()
+                showConfirmDialog = false
+              }) {
+                Text("Remove")
+              }
+        },
+        dismissButton = { TextButton(onClick = { showConfirmDialog = false }) { Text("Cancel") } })
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -40,10 +40,10 @@ import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
-
-
 @Composable
-fun ProfileScreen(navigationActions: NavigationActions) {
+fun ProfileScreen(
+    navigationActions: NavigationActions
+) {
     var isEditing by remember { mutableStateOf(false) }
     var firstName by remember { mutableStateOf("John") }
     var lastName by remember { mutableStateOf("Doe") }
@@ -162,11 +162,12 @@ fun ProfileScreen(navigationActions: NavigationActions) {
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                FavoriteParkingsSection(favoriteParkings.map { it.optName ?: "" }) { newFavorites ->
-                    favoriteParkings = favoriteParkings.filter { parking ->
-                        newFavorites.contains(parking.optName)
+                FavoriteParkingsSection(
+                    favoriteParkings = favoriteParkings,
+                    onFavoritesUpdated = { newFavorites ->
+                        favoriteParkings = newFavorites
                     }
-                }
+                )
             }
         }
     }
@@ -347,8 +348,8 @@ private fun ProfileImage(
 
 @Composable
 private fun FavoriteParkingsSection(
-    favoriteParkings: List<String>,
-    onFavoritesUpdated: (List<String>) -> Unit
+    favoriteParkings: List<Parking>,
+    onFavoritesUpdated: (List<Parking>) -> Unit
 ) {
     Text(
         text = "Favorite Parkings",
@@ -388,7 +389,7 @@ private fun FavoriteParkingsSection(
 
 @Composable
 private fun FavoriteParkingCard(
-    parking: String,
+    parking: Parking,
     index: Int,
     onRemove: () -> Unit
 ) {
@@ -402,7 +403,7 @@ private fun FavoriteParkingCard(
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Text(
-                text = parking,
+                text = parking.optName ?: "", // Display only the optName property
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier
                     .align(Alignment.Center)
@@ -431,7 +432,7 @@ private fun FavoriteParkingCard(
         AlertDialog(
             onDismissRequest = { showConfirmDialog = false },
             title = { Text("Remove favorite") },
-            text = { Text("Are you sure you want to remove $parking from your favorites?") },
+            text = { Text("Are you sure you want to remove ${parking.optName} from your favorites?") },
             confirmButton = {
                 TextButton(
                     onClick = {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -26,12 +26,11 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
-import com.github.se.cyrcle.ui.card.Location
-import com.github.se.cyrcle.ui.card.Parking
-import com.github.se.cyrcle.ui.card.ParkingCapacity
-import com.github.se.cyrcle.ui.card.ParkingProtection
-import com.github.se.cyrcle.ui.card.ParkingRackType
-import com.github.se.cyrcle.ui.card.Point
+import com.github.se.cyrcle.model.parking.Location
+import com.github.se.cyrcle.model.parking.Parking
+import com.github.se.cyrcle.model.parking.ParkingCapacity
+import com.github.se.cyrcle.model.parking.ParkingProtection
+import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
@@ -39,9 +38,11 @@ import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
+import com.mapbox.geojson.Point
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
+
   var isEditing by remember { mutableStateOf(false) }
   var firstName by remember { mutableStateOf("John") }
   var lastName by remember { mutableStateOf("Doe") }
@@ -54,7 +55,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                 uid = "1",
                 optName = "Parking Central",
                 optDescription = null,
-                location = Location(Point(1.0, 1.0)),
+                location = Location(Point.fromLngLat(1.0, 1.0)),
                 images = emptyList(),
                 capacity = ParkingCapacity.MEDIUM,
                 rackType = ParkingRackType.U_RACK,
@@ -65,7 +66,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                 uid = "2",
                 optName = "Parking Station",
                 optDescription = null,
-                location = Location(Point(2.0, 2.0)),
+                location = Location(Point.fromLngLat(1.1, 1.1)),
                 images = emptyList(),
                 capacity = ParkingCapacity.SMALL,
                 rackType = ParkingRackType.WALL_BUTTERFLY,
@@ -76,7 +77,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
                 uid = "3",
                 optName = "Parking Mall",
                 optDescription = null,
-                location = Location(Point(3.0, 3.0)),
+                location = Location(Point.fromLngLat(1.2, 1.2)),
                 images = emptyList(),
                 capacity = ParkingCapacity.LARGE,
                 rackType = ParkingRackType.GRID,

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -26,11 +26,8 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
-import com.github.se.cyrcle.model.parking.Location
 import com.github.se.cyrcle.model.parking.Parking
-import com.github.se.cyrcle.model.parking.ParkingCapacity
-import com.github.se.cyrcle.model.parking.ParkingProtection
-import com.github.se.cyrcle.model.parking.ParkingRackType
+import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
@@ -38,7 +35,6 @@ import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.InputText
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
-import com.mapbox.geojson.Point
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
@@ -51,39 +47,9 @@ fun ProfileScreen(navigationActions: NavigationActions) {
   var favoriteParkings by remember {
     mutableStateOf(
         listOf(
-            Parking(
-                uid = "1",
-                optName = "Parking Central",
-                optDescription = null,
-                location = Location(Point.fromLngLat(1.0, 1.0)),
-                images = emptyList(),
-                capacity = ParkingCapacity.MEDIUM,
-                rackType = ParkingRackType.U_RACK,
-                protection = ParkingProtection.NONE,
-                price = 0.0,
-                hasSecurity = false),
-            Parking(
-                uid = "2",
-                optName = "Parking Station",
-                optDescription = null,
-                location = Location(Point.fromLngLat(1.1, 1.1)),
-                images = emptyList(),
-                capacity = ParkingCapacity.SMALL,
-                rackType = ParkingRackType.WALL_BUTTERFLY,
-                protection = ParkingProtection.COVERED,
-                price = 2.5,
-                hasSecurity = true),
-            Parking(
-                uid = "3",
-                optName = "Parking Mall",
-                optDescription = null,
-                location = Location(Point.fromLngLat(1.2, 1.2)),
-                images = emptyList(),
-                capacity = ParkingCapacity.LARGE,
-                rackType = ParkingRackType.GRID,
-                protection = ParkingProtection.INDOOR,
-                price = 1.0,
-                hasSecurity = true)))
+            TestInstancesParking.parking1,
+            TestInstancesParking.parking2,
+            TestInstancesParking.parking3))
   }
 
   var originalFirstName by remember { mutableStateOf(firstName) }


### PR DESCRIPTION
What is this PR?
This PR enhances the favorite parkings feature of the user profile screen.
It also prepares for future viewmodel implementations.

Why?
Users should be able to remove some obsolete favorite parkings, but not fear accidentally removing one they still like.

How?
I added a second step to deleting a favorite spot by asking for confirmation.
I removed the possibility to modify parking cards from the edit mode.

Additional ressources?
![image](https://github.com/user-attachments/assets/774ba5ab-b864-4175-b21a-690b77209c0b)


