### PR TITLE
Sign the APK

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,9 +55,11 @@ jobs:
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
+          KEYSTORE: ${{ secrets.KEYSTORE }}
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo "$KEYSTORE" | base64 --decode > ./app/keystore.jks
 
       # Cache the Emulator, if the cache does not hit, create the emulator
       - name: AVD cache
@@ -95,6 +97,9 @@ jobs:
         run: |
           # To run the CI with debug information, add --info
           ./gradlew assemble lint --parallel --build-cache
+        env:
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
 
       # Run Unit tests
       - name: Run unit tests

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -36,9 +36,12 @@ jobs:
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
+          KEYSTORE: ${{ secrets.KEYSTORE }}
+
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+          echo "$KEYSTORE" | base64 --decode > ./app/keystore.jks
 
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -47,20 +50,22 @@ jobs:
           java-version: "17"
 
       - name: Build with Gradle
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleRelease
         env:
           VERSION_NAME: ${{ github.event.inputs.version_name }}
           VERSION_CODE: ${{ github.event.inputs.version_code }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
       
       - name: Find APK
         run: find . -name "*.apk" -type f
         
       - name: Rename APK
         run: |
-          mv app/build/outputs/apk/debug/*.apk app/build/outputs/apk/debug/app-release-${{ github.event.inputs.version_name }}-${{ github.event.inputs.version_code }}.apk
+          mv app/build/outputs/apk/release/*.apk app/build/outputs/apk/release/app-release-${{ github.event.inputs.version_name }}-${{ github.event.inputs.version_code }}.apk
   
       - name: Upload renamed APK
         uses: actions/upload-artifact@v3
         with:
           name: app-release-${{ github.event.inputs.version_name }}-${{ github.event.inputs.version_code }}
-          path: app/build/outputs/apk/debug/app-release-${{ github.event.inputs.version_name }}-${{ github.event.inputs.version_code }}.apk
+          path: app/build/outputs/apk/release/app-release-${{ github.event.inputs.version_name }}-${{ github.event.inputs.version_code }}.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,7 +102,23 @@ android {
         res.setSrcDirs(emptyList<File>())
         resources.setSrcDirs(emptyList<File>())
     }
+    signingConfigs {
+        create("release") {
+            // You need to specify either an absolute path or include the
+            // keystore file in the same directory as the build.gradle file.
+            storeFile = file("keystore.jks")
+            storePassword = System.getenv("SIGNING_STORE_PASSWORD")
+            keyAlias = System.getenv("SIGNING_KEY_ALIAS")
+            keyPassword = System.getenv("SIGNING_STORE_PASSWORD")
+        }
+    }
+    buildTypes {
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("release")
+        }
+    }
 }
+
 
 sonar {
     properties {


### PR DESCRIPTION
_Closes #79_


#### What
This PR makes the manual release workflow produce a signed APK.

#### Why 
The current workflow produces a debug APK, that prevents google sign-in.
No google sign-in removes all the community part of the app. 
(Signing the APK is also required to publish the app on the play store)


##### How
This PR follows  the [official guide](https://developer.android.com/build/building-cmdline#gradle_signing) to sign your APK,  but adds encryption and use secrets to hide our signature files as this repo is public. 


#### Test
This was tested on the mock cyrcle repo of the org with success. 
I will still double check after this PR is merged that everything also work on this repo. 
