### PR TITLE
BugFix Preview Card don't display after adding a review

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -81,6 +81,7 @@ fun MapScreen(
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
   var removeViewAnnotation = remember { true }
   var cancelables = remember<Cancelable> { Cancelable({}) }
+  var listener: MapIdleCallback? = null
   var pointAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
 
   val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.red_marker)
@@ -133,7 +134,9 @@ fun MapScreen(
 
                   val pointAnnotation = it
 
-                  val listener = MapIdleCallback {
+                  listener = null
+
+                  listener = MapIdleCallback {
 
                     // Add the new view annotation
                     val viewAnnotation =
@@ -164,7 +167,7 @@ fun MapScreen(
                     removeViewAnnotation = true
                   }
                   cancelables.cancel()
-                  cancelables = mapView.mapboxMap.subscribeMapIdle(listener)
+                  cancelables = mapView.mapboxMap.subscribeMapIdle(listener!!)
                   true
                 })
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -83,11 +83,12 @@ fun MapScreen(
   var cancelables = remember<Cancelable> { Cancelable({}) }
   var listener = remember<MapIdleCallback?> { null }
   var pointAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
+  val selectedParking = parkingViewModel.selectedParking.collectAsState().value
 
   val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.red_marker)
   val resizedBitmap = Bitmap.createScaledBitmap(bitmap, 100, 150, false)
   // Draw markers on the map when the list of parkings changes
-  LaunchedEffect(listOfParkings, pointAnnotationManager) {
+  LaunchedEffect(listOfParkings, pointAnnotationManager, selectedParking?.nbReviews) {
     drawMarkers(pointAnnotationManager, listOfParkings, resizedBitmap)
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -81,7 +81,7 @@ fun MapScreen(
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
   var removeViewAnnotation = remember { true }
   var cancelables = remember<Cancelable> { Cancelable({}) }
-  var listener: MapIdleCallback? = null
+  var listener = remember<MapIdleCallback?> { null }
   var pointAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
 
   val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.red_marker)
@@ -133,8 +133,6 @@ fun MapScreen(
                   val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
 
                   val pointAnnotation = it
-
-                  listener = null
 
                   listener = MapIdleCallback {
 


### PR DESCRIPTION
Close #131 

## What is the content of the PR

This PR fixes the following bug : 
When a user add a review , comes back to the Map and select a marker , the preview card isn't displaying anymore. 

## How ? 

The problem came from the val `listener` inside the clickListener. Adding a review seems to influence the listeners inside the `MapScreen`. The fix was to define `listener` as a var outside other listeners.

edit: the problem seems to come from the fact that the map doesn't update when a parking is modified(review is added). So we need to add `selectedParking.nbreviews` to the arguments of the `LaunchedEffect` which will redraw the markers and update the `PointAnnotationManager` when the number of review changes. 

## Testing

Since it is Map-related i advise you to test manually the map by checking preview cards are displaying, adding a review then checking that the preview card still display. 

## Code Coverage 
![image](https://github.com/user-attachments/assets/f685d05a-7c4a-40f4-84c7-9f8b248e4300)

