### PR TITLE
Feature toggle button

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
@@ -57,7 +57,8 @@ class ButtonTest {
     val value = mutableStateOf(true)
     composeTestRule.setContent {
       ToggleButton("Button", value)
-      ToggleButton("Button", value, Modifier, ColorLevel.PRIMARY, tag1)
+      ToggleButton(
+          "Button", value, Modifier, { value.value = !value.value }, ColorLevel.PRIMARY, tag1)
     }
 
     composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
@@ -35,12 +35,18 @@ class ButtonTest {
     composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()
     composeTestRule.onNodeWithTag("${tagD}Text", true).assertIsDisplayed()
     composeTestRule.onNodeWithTag(tagD).performClick()
-    assertEquals(a, 2)
+    assertEquals(2, a)
+    disabled.value = true
+    composeTestRule.onNodeWithTag(tagD).performClick() // Shouldn't trigger onClick
+    assertEquals(2, a)
 
     composeTestRule.onNodeWithTag(tag1).assertIsDisplayed()
     composeTestRule.onNodeWithTag("${tag1}Text", true).assertIsDisplayed()
     composeTestRule.onNodeWithTag(tag1).performClick()
-    assertEquals(a, 3)
+    assertEquals(3, a)
+    disabled.value = true
+    composeTestRule.onNodeWithTag(tag1).performClick() // Shouldn't trigger onClick
+    assertEquals(3, a)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
@@ -40,6 +40,7 @@ class ButtonTest {
     composeTestRule.onNodeWithTag(tagD).performClick() // Shouldn't trigger onClick
     assertEquals(2, a)
 
+    disabled.value = false
     composeTestRule.onNodeWithTag(tag1).assertIsDisplayed()
     composeTestRule.onNodeWithTag("${tag1}Text", true).assertIsDisplayed()
     composeTestRule.onNodeWithTag(tag1).performClick()
@@ -47,6 +48,31 @@ class ButtonTest {
     disabled.value = true
     composeTestRule.onNodeWithTag(tag1).performClick() // Shouldn't trigger onClick
     assertEquals(3, a)
+  }
+
+  @Test
+  fun displayToggleButton() {
+    val tagD = "ToggleButton"
+    val tag1 = "ToggleButton1"
+    val value = mutableStateOf(true)
+    composeTestRule.setContent {
+      ToggleButton("Button", value)
+      ToggleButton("Button", value, Modifier, ColorLevel.PRIMARY, tag1)
+    }
+
+    composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${tagD}Text", true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(tagD).performClick() // Turn to false
+    assertEquals(false, value.value)
+    composeTestRule.onNodeWithTag(tagD).performClick() // Turn back to true
+    assertEquals(true, value.value)
+
+    composeTestRule.onNodeWithTag(tag1).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${tag1}Text", true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(tag1).performClick() // Turn to false
+    assertEquals(false, value.value)
+    composeTestRule.onNodeWithTag(tag1).performClick() // Turn back to true
+    assertEquals(true, value.value)
   }
 
   @Test

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/Color.kt
@@ -125,5 +125,8 @@ fun getOnContainerColor(colorLevel: ColorLevel): Color {
 @Composable
 fun getButtonColors(colorLevel: ColorLevel): ButtonColors {
   return ButtonDefaults.buttonColors(
-      containerColor = getColor(colorLevel), contentColor = getOnColor(colorLevel))
+      containerColor = getColor(colorLevel),
+      contentColor = getOnColor(colorLevel),
+      disabledContainerColor = disabledColor(),
+      disabledContentColor = onDisabledColor())
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/Theme.kt
@@ -129,13 +129,23 @@ val DarkColorScheme =
         )
 
 /**
- * Return a themed color, depending on the system theme.
+ * Return a themed disabledColor, depending on the system theme.
  *
  * @return A themed color.
  */
 @Composable
 fun disabledColor(): Color {
   return if (isSystemInDarkTheme()) Color.DarkGray else Color.LightGray
+}
+
+/**
+ * Return a themed onDisabled color, depending on the system theme.
+ *
+ * @return A themed color.
+ */
+@Composable
+fun onDisabledColor(): Color {
+  return if (isSystemInDarkTheme()) Color.LightGray else Color.DarkGray
 }
 
 /** Generate the theme of the application. */

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -1,6 +1,7 @@
 package com.github.se.cyrcle.ui.theme.atoms
 
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -19,6 +20,7 @@ import com.github.se.cyrcle.ui.theme.disabledColor
 import com.github.se.cyrcle.ui.theme.getButtonColors
 import com.github.se.cyrcle.ui.theme.getColor
 import com.github.se.cyrcle.ui.theme.getOnColor
+import com.github.se.cyrcle.ui.theme.onDisabledColor
 
 /**
  * Create a themed small floating action button, with simplified arguments.
@@ -158,6 +160,34 @@ fun Button(
       modifier = modifier.testTag(testTag),
       colors = getButtonColors(colorLevel),
       enabled = !disabled.value) {
+        Text(text, Modifier.testTag("${testTag}Text"))
+      }
+}
+
+/**
+ * Create a themed toggle button, with simplified arguments.
+ *
+ * @param value The mutable boolean that this toggle represent and modify.
+ * @param modifier Chained modifier. `.testTag` will be overwritten, use the `testTag` for this.
+ * @param colorLevel The color scheme of the object.
+ * @param testTag The test tag of the object.
+ */
+@Composable
+fun ToggleButton(
+    text: String,
+    value: MutableState<Boolean>,
+    modifier: Modifier = Modifier,
+    colorLevel: ColorLevel = ColorLevel.PRIMARY,
+    testTag: String = "ToggleButton"
+) {
+  Button(
+      onClick = { value.value = !value.value },
+      modifier = modifier.testTag(testTag),
+      colors =
+          if (value.value) getButtonColors(colorLevel)
+          else
+              ButtonDefaults.buttonColors(
+                  containerColor = disabledColor(), contentColor = onDisabledColor())) {
         Text(text, Modifier.testTag("${testTag}Text"))
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -156,7 +156,8 @@ fun Button(
   Button(
       onClick = { if (!disabled.value) onClick() },
       modifier = modifier.testTag(testTag),
-      colors = getButtonColors(colorLevel)) {
+      colors = getButtonColors(colorLevel),
+      enabled = !disabled.value) {
         Text(text, Modifier.testTag("${testTag}Text"))
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -177,11 +177,12 @@ fun ToggleButton(
     text: String,
     value: MutableState<Boolean>,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit = { value.value = !value.value },
     colorLevel: ColorLevel = ColorLevel.PRIMARY,
     testTag: String = "ToggleButton"
 ) {
   Button(
-      onClick = { value.value = !value.value },
+      onClick = onClick,
       modifier = modifier.testTag(testTag),
       colors =
           if (value.value) getButtonColors(colorLevel)


### PR DESCRIPTION
Add a new Atom : ToggleButton (here with the two states displayed on top of one another)
![image](https://github.com/user-attachments/assets/cfed80ae-6a1d-4a2a-9d82-1f201d78e882)

It can be use to display a filter, or anything that has to be toggle on an off.

This PR also solve the Button (base one) not being turned gray when disabled.

![image](https://github.com/user-attachments/assets/1665a6c8-7179-4c52-8a95-fb5753fb0021)


Close #135 