### PR TITLE
Rework list screen UI and add infinite scroll

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/MainActivityTest.kt
@@ -92,7 +92,7 @@ class MainActivityTest {
       composeTestRule.onNodeWithTag("SpotListColumn").performScrollToIndex(index)
       composeTestRule
           .onNodeWithTag("SpotListColumn")
-          .onChildAt(index + 1)
+          .onChildAt(index)
           .assertIsDisplayed()
           .assertHasClickAction()
           .performClick()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
@@ -57,8 +57,7 @@ class ButtonTest {
     val value = mutableStateOf(true)
     composeTestRule.setContent {
       ToggleButton("Button", value)
-      ToggleButton(
-          "Button", value, Modifier, { value.value = !value.value }, ColorLevel.PRIMARY, tag1)
+      ToggleButton("Button", value, Modifier, ColorLevel.PRIMARY, tag1)
     }
 
     composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()
@@ -74,6 +73,32 @@ class ButtonTest {
     assertEquals(false, value.value)
     composeTestRule.onNodeWithTag(tag1).performClick() // Turn back to true
     assertEquals(true, value.value)
+  }
+
+  @Test
+  fun displayToggleButtonOverload() {
+    val tagD = "ToggleButton"
+    val tag1 = "ToggleButton1"
+    val mutableState = mutableStateOf(true)
+    val function = { mutableState.value = !mutableState.value }
+    composeTestRule.setContent {
+      ToggleButton("Button", mutableState.value, function)
+      ToggleButton("Button", mutableState.value, function, Modifier, ColorLevel.PRIMARY, tag1)
+    }
+
+    composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${tagD}Text", true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(tagD).performClick() // Turn to false
+    assertEquals(false, mutableState.value)
+    composeTestRule.onNodeWithTag(tagD).performClick() // Turn back to true
+    assertEquals(true, mutableState.value)
+
+    composeTestRule.onNodeWithTag(tag1).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${tag1}Text", true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(tag1).performClick() // Turn to false
+    assertEquals(false, mutableState.value)
+    composeTestRule.onNodeWithTag(tag1).performClick() // Turn back to true
+    assertEquals(true, mutableState.value)
   }
 
   @Test

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -19,7 +19,9 @@ object TestInstancesParking {
           ParkingRackType.TWO_TIER,
           ParkingProtection.COVERED,
           0.0,
-          true)
+          true,
+          2,
+          3.0)
   val parking2 =
       Parking(
           "Test_spot_2",

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -5,6 +5,7 @@ import com.mapbox.geojson.Point
 object TestInstancesParking {
 
   val referencePoint = Point.fromLngLat(6.9, 46.69)
+  val EPFLCenter = Point.fromLngLat(6.566397, 46.518467)
 
   val parking1 =
       Parking(

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -1,6 +1,8 @@
 package com.github.se.cyrcle.ui.list
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,11 +14,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -27,12 +35,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.cyrcle.model.parking.Parking
+import com.github.se.cyrcle.model.parking.ParkingAttribute
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
@@ -43,6 +52,7 @@ import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.turf.TurfMeasurement
@@ -52,90 +62,60 @@ fun SpotListScreen(
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory),
 ) {
+
+  val referencePoint = TestInstancesParking.EPFLCenter
+
   val parkingSpots by parkingViewModel.kClosestParkings.collectAsState()
 
   var selectedProtection by remember { mutableStateOf<Set<ParkingProtection>>(emptySet()) }
   var selectedRackTypes by remember { mutableStateOf<Set<ParkingRackType>>(emptySet()) }
   var selectedCapacities by remember { mutableStateOf<Set<ParkingCapacity>>(emptySet()) }
+  var onlyWithCCTV by remember { mutableStateOf(false) }
 
-  val sortedFilteredParkingSpots =
-      parkingSpots
-          .map { parking ->
-            // TODO: Use the user's location instead of a hardcoded reference point
-            parking to
-                TurfMeasurement.distance(
-                    TestInstancesParking.referencePoint, parking.location.center)
-          }
-          .sortedWith(
-              compareByDescending<Pair<Parking, Double>> { (parking, _) ->
-                    listOf(
-                            selectedProtection.contains(parking.protection),
-                            selectedRackTypes.contains(parking.rackType),
-                            selectedCapacities.contains(parking.capacity))
-                        .count { it }
-                  }
-                  .thenBy { (_, distance) -> distance })
+  // Filter the parking spots based on the selected attributes
+  val filteredParkingSpots =
+      parkingSpots.filter { parking ->
+        (selectedProtection.isEmpty() || selectedProtection.contains(parking.protection)) &&
+            (selectedRackTypes.isEmpty() || selectedRackTypes.contains(parking.rackType)) &&
+            (selectedCapacities.isEmpty() || selectedCapacities.contains(parking.capacity)) &&
+            (!onlyWithCCTV || parking.hasSecurity)
+      }
 
   Scaffold(
       modifier = Modifier.testTag("SpotListScreen"),
       bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.LIST) }) {
           innerPadding ->
-        LazyColumn(
+        Column(
             modifier =
                 Modifier.fillMaxSize()
                     .padding(innerPadding)
                     .padding(bottom = 16.dp)
-                    .testTag("SpotListColumn"),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)) {
-              item {
-                FilterHeader(
-                    selectedProtection = selectedProtection,
-                    onProtectionSelected = { protection ->
-                      selectedProtection =
-                          if (selectedProtection.contains(protection)) {
-                            selectedProtection - protection
-                          } else {
-                            selectedProtection + protection
-                          }
-                    },
-                    selectedRackTypes = selectedRackTypes,
-                    onRackTypeSelected = { rackType ->
-                      selectedRackTypes =
-                          if (selectedRackTypes.contains(rackType)) {
-                            selectedRackTypes - rackType
-                          } else {
-                            selectedRackTypes + rackType
-                          }
-                    },
-                    selectedCapacities = selectedCapacities,
-                    onCapacitySelected = { capacity ->
-                      selectedCapacities =
-                          if (selectedCapacities.contains(capacity)) {
-                            selectedCapacities - capacity
-                          } else {
-                            selectedCapacities + capacity
-                          }
-                    })
-              }
-              items(sortedFilteredParkingSpots) { (parking, distance) ->
-                val matchedCriteria = mutableListOf<String>()
-
-                if (selectedProtection.isNotEmpty() &&
-                    selectedProtection.contains(parking.protection)) {
-                  matchedCriteria.add("Protection: ${parking.protection.description}")
-                }
-                if (selectedRackTypes.isNotEmpty() &&
-                    selectedRackTypes.contains(parking.rackType)) {
-                  matchedCriteria.add("Rack Type: ${parking.rackType.description}")
-                }
-                if (selectedCapacities.isNotEmpty() &&
-                    selectedCapacities.contains(parking.capacity)) {
-                  matchedCriteria.add("Capacity: ${parking.capacity.description}")
-                }
-
-                SpotCard(navigationActions, parkingViewModel, parking, distance, matchedCriteria)
-              }
+                    .testTag("SpotListColumn")) {
+              FilterHeader(
+                  selectedProtection = selectedProtection,
+                  selectedRackTypes = selectedRackTypes,
+                  selectedCapacities = selectedCapacities,
+                  onAttributeSelected = { attribute ->
+                    when (attribute) {
+                      is ParkingProtection ->
+                          selectedProtection = toggleSelection(selectedProtection, attribute)
+                      is ParkingRackType ->
+                          selectedRackTypes = toggleSelection(selectedRackTypes, attribute)
+                      is ParkingCapacity ->
+                          selectedCapacities = toggleSelection(selectedCapacities, attribute)
+                    }
+                  },
+                  onlyWithCCTV = onlyWithCCTV,
+                  onCCTVCheckedChange = { onlyWithCCTV = it })
+              LazyColumn(
+                  contentPadding = PaddingValues(16.dp),
+                  verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(items = filteredParkingSpots) { parking ->
+                      val distance =
+                          TurfMeasurement.distance(referencePoint, parking.location.center)
+                      SpotCard(navigationActions, parkingViewModel, parking, distance)
+                    }
+                  }
             }
       }
 }
@@ -143,11 +123,11 @@ fun SpotListScreen(
 @Composable
 fun FilterHeader(
     selectedProtection: Set<ParkingProtection>,
-    onProtectionSelected: (ParkingProtection) -> Unit,
     selectedRackTypes: Set<ParkingRackType>,
-    onRackTypeSelected: (ParkingRackType) -> Unit,
     selectedCapacities: Set<ParkingCapacity>,
-    onCapacitySelected: (ParkingCapacity) -> Unit
+    onAttributeSelected: (ParkingAttribute) -> Unit,
+    onlyWithCCTV: Boolean,
+    onCCTVCheckedChange: (Boolean) -> Unit
 ) {
   var showProtectionOptions by remember { mutableStateOf(false) }
   var showRackTypeOptions by remember { mutableStateOf(false) }
@@ -155,78 +135,61 @@ fun FilterHeader(
   var showFilters by remember { mutableStateOf(false) }
 
   Column(modifier = Modifier.padding(16.dp)) {
-    Button(
-        text = if (showFilters) "Hide Filters" else "Show Filters",
-        onClick = { showFilters = !showFilters },
-        modifier = Modifier.fillMaxWidth(),
-        colorLevel = ColorLevel.PRIMARY,
-        testTag = "ShowFiltersButton")
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+      SmallFloatingActionButton(
+          onClick = { showFilters = !showFilters },
+          icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
+          contentDescription = "Filter",
+      )
+    }
 
     if (showFilters) {
-      Spacer(modifier = Modifier.height(8.dp))
-
       FilterSection(
           title = "Protection",
           isExpanded = showProtectionOptions,
           onToggle = { showProtectionOptions = !showProtectionOptions }) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth().testTag("ProtectionFilter"),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                  items(ParkingProtection.entries) { protection ->
-                    Button(
-                        text = protection.name,
-                        onClick = { onProtectionSelected(protection) },
-                        modifier = Modifier.padding(2.dp),
-                        colorLevel = ColorLevel.PRIMARY,
-                        disabled =
-                            remember { mutableStateOf(selectedProtection.contains(protection)) },
-                        testTag = "ProtectionFilterItem")
-                  }
-                }
+            FilterOptions(
+                options = ParkingProtection.entries.toTypedArray(),
+                onOptionSelected = onAttributeSelected,
+                selectedOptions = selectedProtection,
+                getDescription = { it.description },
+                testTag = "ProtectionFilter")
           }
-
-      Spacer(modifier = Modifier.height(8.dp))
-
       FilterSection(
           title = "Rack Type",
           isExpanded = showRackTypeOptions,
           onToggle = { showRackTypeOptions = !showRackTypeOptions }) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth().testTag("RackTypeFilter"),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                  items(ParkingRackType.entries) { rackType ->
-                    Button(
-                        text = rackType.name,
-                        onClick = { onRackTypeSelected(rackType) },
-                        modifier = Modifier.padding(2.dp),
-                        colorLevel = ColorLevel.PRIMARY,
-                        disabled =
-                            remember { mutableStateOf(selectedRackTypes.contains(rackType)) },
-                        testTag = "RackTypeFilterItem")
-                  }
-                }
+            FilterOptions(
+                options = ParkingRackType.entries.toTypedArray(),
+                onOptionSelected = onAttributeSelected,
+                selectedOptions = selectedRackTypes,
+                getDescription = { it.description },
+                testTag = "RackTypeFilter")
           }
-
-      Spacer(modifier = Modifier.height(8.dp))
-
       FilterSection(
           title = "Capacity",
           isExpanded = showCapacityOptions,
           onToggle = { showCapacityOptions = !showCapacityOptions }) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth().testTag("CapacityFilter"),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                  items(ParkingCapacity.entries) { capacity ->
-                    Button(
-                        text = capacity.name,
-                        onClick = { onCapacitySelected(capacity) },
-                        modifier = Modifier.padding(2.dp),
-                        colorLevel = ColorLevel.PRIMARY,
-                        disabled =
-                            remember { mutableStateOf(selectedCapacities.contains(capacity)) },
-                        testTag = "CapacityFilterItem")
-                  }
-                }
+            FilterOptions(
+                options = ParkingCapacity.entries.toTypedArray(),
+                onOptionSelected = onAttributeSelected,
+                selectedOptions = selectedCapacities,
+                getDescription = { it.description },
+                testTag = "CapacityFilter")
+          }
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(8.dp),
+          verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = onlyWithCCTV,
+                onCheckedChange = onCCTVCheckedChange,
+                modifier = Modifier.testTag("CCTVCheckbox"))
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = "Only display parkings with CCTV camera",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.testTag("CCTVCheckboxLabel"))
           }
     }
   }
@@ -239,37 +202,62 @@ fun FilterSection(
     onToggle: () -> Unit,
     content: @Composable () -> Unit
 ) {
-  Column {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleMedium,
-        modifier =
-            Modifier.clickable(onClick = onToggle)
-                .padding(8.dp)
-                .background(Color.LightGray)
-                .fillMaxWidth(),
-        color = MaterialTheme.colorScheme.tertiary,
-        testTag = title)
+  Column(
+      modifier =
+          Modifier.padding(8.dp)
+              .border(1.dp, Color.Gray, shape = MaterialTheme.shapes.medium)
+              .background(MaterialTheme.colorScheme.surface, shape = MaterialTheme.shapes.medium)
+              .padding(8.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.clickable(onClick = onToggle).padding(8.dp).fillMaxWidth(),
+            color = MaterialTheme.colorScheme.primary,
+            testTag = title)
 
-    if (isExpanded) {
-      content()
-    }
-  }
+        if (isExpanded) {
+          content()
+        }
+      }
 }
 
+@Composable
+fun <T : Enum<T>> FilterOptions(
+    options: Array<T>,
+    onOptionSelected: (T) -> Unit,
+    selectedOptions: Set<T>,
+    getDescription: (T) -> String,
+    testTag: String
+) {
+  LazyRow(
+      modifier = Modifier.fillMaxWidth().testTag(testTag),
+      horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        items(options) { option ->
+          Button(
+              text = getDescription(option),
+              onClick = { onOptionSelected(option) },
+              modifier = Modifier.padding(2.dp),
+              colorLevel = ColorLevel.PRIMARY,
+              disabled = remember { mutableStateOf(selectedOptions.contains(option)) },
+              testTag = "${testTag}Item")
+        }
+      }
+}
+
+@SuppressLint("DefaultLocale")
 @Composable
 fun SpotCard(
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel,
     parking: Parking,
-    distance: Double,
-    matchedCriteria: List<String>
+    distance: Double
 ) {
+  // make a line between the card and the next one
+  HorizontalDivider(modifier = Modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface)
   Card(
       modifier =
           Modifier.fillMaxWidth()
               .height(120.dp)
-              .shadow(8.dp, shape = MaterialTheme.shapes.medium)
               .padding(4.dp)
               .clickable(
                   onClick = {
@@ -277,36 +265,54 @@ fun SpotCard(
                     navigationActions.navigateTo(Screen.CARD)
                   })
               .testTag("SpotListItem"),
-      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
-      shape = MaterialTheme.shapes.medium,
-      elevation = CardDefaults.cardElevation(8.dp)) {
+      colors = CardDefaults.cardColors(containerColor = Color.Transparent)) {
         Box(modifier = Modifier.fillMaxSize()) {
           Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag("SpotCardContent")) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween) {
-                  Text(
+                  androidx.compose.material3.Text(
                       text = parking.optName ?: "Unnamed Parking",
-                      style = MaterialTheme.typography.titleLarge,
-                      color = MaterialTheme.colorScheme.secondary,
-                      testTag = "ParkingName")
+                      style = MaterialTheme.typography.bodyLarge,
+                      color = MaterialTheme.colorScheme.onSurface,
+                      maxLines = 1,
+                      overflow = TextOverflow.Ellipsis,
+                      modifier = Modifier.testTag("ParkingName"),
+                  )
                   Text(
-                      text = String.format("%.2f km", distance),
+                      text =
+                          if (distance < 1) String.format("%.0f m", distance * 1000)
+                          else String.format("%.2f km", distance),
                       style = MaterialTheme.typography.bodySmall,
-                      color = MaterialTheme.colorScheme.secondary,
+                      color = MaterialTheme.colorScheme.onSurface,
                       testTag = "ParkingDistance")
                 }
 
-            if (matchedCriteria.isNotEmpty()) {
-              Spacer(modifier = Modifier.height(4.dp))
-              matchedCriteria.forEach { criterion ->
+            // Rating
+            Spacer(modifier = Modifier.height(4.dp))
+            if (parking.nbReviews > 0) {
+              Row {
                 Text(
-                    text = criterion,
+                    text = "Rating: ${parking.avgScore}", // TODO: Replace with star composable
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
-                    testTag = "MatchedCriterionItem")
+                    color = MaterialTheme.colorScheme.onSurface,
+                    testTag = "ParkingRating")
+                // Number of reviews
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text =
+                        "(${parking.nbReviews} review" + if (parking.nbReviews > 1) "s)" else ")",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                    testTag = "ParkingNbReviews")
               }
+            } else {
+              Text(
+                  text = "No reviews yet",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                  testTag = "ParkingNoReviews")
             }
           }
 
@@ -318,4 +324,12 @@ fun SpotCard(
               testTag = "ParkingPrice")
         }
       }
+}
+
+private fun <T> toggleSelection(set: Set<T>, item: T): Set<T> {
+  return if (set.contains(item)) {
+    set - item
+  } else {
+    set + item
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.ui.list
 
-import android.annotation.SuppressLint
 import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -57,6 +56,7 @@ import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.turf.TurfMeasurement
+import java.util.Locale
 
 @Composable
 fun SpotListScreen(
@@ -262,7 +262,6 @@ fun FilterSection(
       }
 }
 
-@SuppressLint("DefaultLocale")
 @Composable
 fun SpotCard(
     navigationActions: NavigationActions,
@@ -299,8 +298,9 @@ fun SpotCard(
                       testTag = "ParkingName")
                   Text(
                       text =
-                          if (distance < 1) String.format("%.0f m", distance * 1000)
-                          else String.format("%.2f km", distance),
+                          if (distance < 1)
+                              String.format(Locale.getDefault(), "%.0f m", distance * 1000)
+                          else String.format(Locale.getDefault(), "%.2f km", distance),
                       style = MaterialTheme.typography.bodySmall,
                       color = MaterialTheme.colorScheme.onSurface,
                       testTag = "ParkingDistance")

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -108,7 +108,7 @@ fun SpotListScreen(
                 Modifier.fillMaxSize()
                     .padding(innerPadding)
                     .padding(bottom = 16.dp)
-                    .testTag("SpotListColumn")) {
+                    ) {
               FilterHeader(
                   selectedProtection = selectedProtection,
                   selectedRackTypes = selectedRackTypes,
@@ -130,7 +130,9 @@ fun SpotListScreen(
               LazyColumn(
                   state = listState,
                   contentPadding = PaddingValues(16.dp),
-                  verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                  verticalArrangement = Arrangement.spacedBy(8.dp),
+                  modifier = Modifier.testTag("SpotListColumn")
+                ) {
                     items(items = filteredParkingSpots) { parking ->
                       val distance =
                           TurfMeasurement.distance(referencePoint, parking.location.center)

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FilterList
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
@@ -53,10 +52,9 @@ import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
-import com.github.se.cyrcle.ui.theme.Cerulean
-import com.github.se.cyrcle.ui.theme.White
 import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.turf.TurfMeasurement
 
@@ -103,48 +101,41 @@ fun SpotListScreen(
       modifier = Modifier.testTag("SpotListScreen"),
       bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.LIST) }) {
           innerPadding ->
-        Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(bottom = 16.dp)
-                    ) {
-              FilterHeader(
-                  selectedProtection = selectedProtection,
-                  selectedRackTypes = selectedRackTypes,
-                  selectedCapacities = selectedCapacities,
-                  onAttributeSelected = { attribute ->
-                    when (attribute) {
-                      is ParkingProtection ->
-                          selectedProtection = toggleSelection(selectedProtection, attribute)
-                      is ParkingRackType ->
-                          selectedRackTypes = toggleSelection(selectedRackTypes, attribute)
-                      is ParkingCapacity ->
-                          selectedCapacities = toggleSelection(selectedCapacities, attribute)
-                    }
-                  },
-                  onlyWithCCTV = onlyWithCCTV,
-                  onCCTVCheckedChange = { onlyWithCCTV = it })
+        Column(modifier = Modifier.fillMaxSize().padding(innerPadding).padding(bottom = 16.dp)) {
+          FilterHeader(
+              selectedProtection = selectedProtection,
+              selectedRackTypes = selectedRackTypes,
+              selectedCapacities = selectedCapacities,
+              onAttributeSelected = { attribute ->
+                when (attribute) {
+                  is ParkingProtection ->
+                      selectedProtection = toggleSelection(selectedProtection, attribute)
+                  is ParkingRackType ->
+                      selectedRackTypes = toggleSelection(selectedRackTypes, attribute)
+                  is ParkingCapacity ->
+                      selectedCapacities = toggleSelection(selectedCapacities, attribute)
+                }
+              },
+              onlyWithCCTV = onlyWithCCTV,
+              onCCTVCheckedChange = { onlyWithCCTV = it })
 
-              val listState = rememberLazyListState()
-              LazyColumn(
-                  state = listState,
-                  contentPadding = PaddingValues(16.dp),
-                  verticalArrangement = Arrangement.spacedBy(8.dp),
-                  modifier = Modifier.testTag("SpotListColumn")
-                ) {
-                    items(items = filteredParkingSpots) { parking ->
-                      val distance =
-                          TurfMeasurement.distance(referencePoint, parking.location.center)
-                      SpotCard(navigationActions, parkingViewModel, parking, distance)
-                      Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
-                      if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
-                        parkingViewModel.getKClosestParkings(
-                            referencePoint, numberOfNewParkings + filteredParkingSpots.size)
-                      }
-                    }
+          val listState = rememberLazyListState()
+          LazyColumn(
+              state = listState,
+              contentPadding = PaddingValues(16.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+              modifier = Modifier.testTag("SpotListColumn")) {
+                items(items = filteredParkingSpots) { parking ->
+                  val distance = TurfMeasurement.distance(referencePoint, parking.location.center)
+                  SpotCard(navigationActions, parkingViewModel, parking, distance)
+                  Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
+                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
+                    parkingViewModel.getKClosestParkings(
+                        referencePoint, numberOfNewParkings + filteredParkingSpots.size)
                   }
-            }
+                }
+              }
+        }
       }
 }
 
@@ -182,8 +173,8 @@ fun FilterHeader(
                   items(ParkingProtection.entries.toTypedArray()) { option ->
                     ToggleButton(
                         text = option.description,
-                        onclick = { onAttributeSelected(option) },
-                        activated = selectedProtection.contains(option),
+                        onClick = { onAttributeSelected(option) },
+                        value = selectedProtection.contains(option),
                         modifier = Modifier.padding(2.dp),
                         testTag = "ProtectionFilterItem")
                   }
@@ -200,8 +191,8 @@ fun FilterHeader(
                   items(ParkingRackType.entries.toTypedArray()) { option ->
                     ToggleButton(
                         text = option.description,
-                        onclick = { onAttributeSelected(option) },
-                        activated = selectedRackTypes.contains(option),
+                        onClick = { onAttributeSelected(option) },
+                        value = selectedRackTypes.contains(option),
                         modifier = Modifier.padding(2.dp),
                         testTag = "RackTypeFilterItem")
                   }
@@ -218,8 +209,8 @@ fun FilterHeader(
                   items(ParkingCapacity.entries.toTypedArray()) { option ->
                     ToggleButton(
                         text = option.description,
-                        onclick = { onAttributeSelected(option) },
-                        activated = selectedCapacities.contains(option),
+                        onClick = { onAttributeSelected(option) },
+                        value = selectedCapacities.contains(option),
                         modifier = Modifier.padding(2.dp),
                         testTag = "CapacityFilterItem")
                   }
@@ -351,24 +342,4 @@ private fun <T> toggleSelection(set: Set<T>, item: T): Set<T> {
   } else {
     set + item
   }
-}
-
-// Hardcoded. To be deleted and usages replaced with corresponding atom
-@Composable
-fun ToggleButton(
-    text: String,
-    onclick: () -> Unit = {},
-    activated: Boolean = true,
-    modifier: Modifier,
-    testTag: String = "ToggleButton"
-) {
-  androidx.compose.material3.Button(
-      onClick = onclick,
-      modifier = modifier.testTag(testTag),
-      colors =
-          if (activated)
-              ButtonDefaults.buttonColors(containerColor = Cerulean, contentColor = White)
-          else ButtonDefaults.buttonColors(containerColor = Color.Gray, contentColor = White)) {
-        Text(text, Modifier.testTag("${testTag}Text"))
-      }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -165,7 +165,9 @@ fun Button(
 }
 
 /**
- * Create a themed toggle button, with simplified arguments.
+ * Create a themed toggle button, with simplified arguments. This button will change the value of
+ * the mutable boolean when clicked. Also, the color of the button will change based on the value of
+ * the boolean (true = enabled, false = disabled).
  *
  * @param value The mutable boolean that this toggle represent and modify.
  * @param modifier Chained modifier. `.testTag` will be overwritten, use the `testTag` for this.
@@ -195,6 +197,7 @@ fun ToggleButton(
 /**
  * Create a themed toggle button. This overload offers more flexibility.
  *
+ * @param text The text to display.
  * @param value The boolean that this toggle represent.
  * @param onClick The function describing what should happen on click.
  * @param modifier Chained modifier. `.testTag` will be overwritten, use the `testTag` for this.

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -177,7 +177,36 @@ fun ToggleButton(
     text: String,
     value: MutableState<Boolean>,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit = { value.value = !value.value },
+    colorLevel: ColorLevel = ColorLevel.PRIMARY,
+    testTag: String = "ToggleButton"
+) {
+  Button(
+      onClick = { value.value = !value.value },
+      modifier = modifier.testTag(testTag),
+      colors =
+          if (value.value) getButtonColors(colorLevel)
+          else
+              ButtonDefaults.buttonColors(
+                  containerColor = disabledColor(), contentColor = onDisabledColor())) {
+        Text(text, Modifier.testTag("${testTag}Text"))
+      }
+}
+
+/**
+ * Create a themed toggle button. This overload offers more flexibility.
+ *
+ * @param value The boolean that this toggle represent.
+ * @param onClick The function describing what should happen on click.
+ * @param modifier Chained modifier. `.testTag` will be overwritten, use the `testTag` for this.
+ * @param colorLevel The color scheme of the object.
+ * @param testTag The test tag of the object.
+ */
+@Composable
+fun ToggleButton(
+    text: String,
+    value: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     colorLevel: ColorLevel = ColorLevel.PRIMARY,
     testTag: String = "ToggleButton"
 ) {
@@ -185,7 +214,7 @@ fun ToggleButton(
       onClick = onClick,
       modifier = modifier.testTag(testTag),
       colors =
-          if (value.value) getButtonColors(colorLevel)
+          if (value) getButtonColors(colorLevel)
           else
               ButtonDefaults.buttonColors(
                   containerColor = disabledColor(), contentColor = onDisabledColor())) {


### PR DESCRIPTION
Closes #100 

### What
This PR does two things:
1. Rework the UI of the list screen, here is a preview
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ce72bda4-16f1-456d-bb89-b9bf52bceb22">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/047dff2f-9191-44fb-a037-58bc550fdad7">

2. Make the list screen infinite scroll

### Key changes
For consistency while scrolling, the filtering system had to be changed. We are back to a classic filtering system, as the smart filtering system and the infinite scroll are not compatible. (Previously, the parkings were first sorted by number of matched criterion and then by distance. This would mean that while scrolling down, when we would reach the bottom, parkings that were further but had more matched criterion would get propulsed to the top of the list.)

### Coverage 
![image](https://github.com/user-attachments/assets/0750fc4f-3ba8-4f85-989c-ba146258d468)

### Tests
Tests have been adapted to cope with the new UI.

### Future work:
Once the StarReview molecule is done, it shall be added in place of the text "Rating:"
Once the logic for the image database is done, we can add an image to preview the parking
