### PR TITLE
Bugfix : display newly added spot on the map

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
@@ -92,9 +92,9 @@ class ParkingRepositoryFirestore @Inject constructor(private val db: FirebaseFir
       return
     }
     db.collection(collectionPath)
-        .whereGreaterThanOrEqualTo("location.center.latitude", start.latitude())
+        .whereGreaterThan("location.center.latitude", start.latitude())
         .whereLessThanOrEqualTo("location.center.latitude", end.latitude())
-        .whereGreaterThanOrEqualTo("location.center.longitude", start.longitude())
+        .whereGreaterThan("location.center.longitude", start.longitude())
         .whereLessThanOrEqualTo("location.center.longitude", end.longitude())
         .get()
         .addOnSuccessListener { querySnapshot ->

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -73,7 +73,11 @@ class ParkingViewModel(
     val tile = Tile.getTileFromPoint(parking.location.center)
     tilesToParking.value[tile] = tilesToParking.value[tile]?.plus(parking) ?: listOf(parking)
     parkingRepository.addParking(
-        parking, {}, { Log.e("ParkingViewModel", "Error adding parking", it) })
+        parking,
+        {
+          tilesToParking.value[tile] = tilesToParking.value[tile]?.plus(parking) ?: listOf(parking)
+        },
+        { Log.e("ParkingViewModel", "Error adding parking", it) })
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -70,6 +70,8 @@ class ParkingViewModel(
    * @param parking the parking to add
    */
   fun addParking(parking: Parking) {
+    val tile = Tile.getTileFromPoint(parking.location.center)
+    tilesToParking.value[tile] = tilesToParking.value[tile]?.plus(parking) ?: listOf(parking)
     parkingRepository.addParking(
         parking, {}, { Log.e("ParkingViewModel", "Error adding parking", it) })
   }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -70,11 +70,10 @@ class ParkingViewModel(
    * @param parking the parking to add
    */
   fun addParking(parking: Parking) {
-    val tile = Tile.getTileFromPoint(parking.location.center)
-    tilesToParking.value[tile] = tilesToParking.value[tile]?.plus(parking) ?: listOf(parking)
     parkingRepository.addParking(
         parking,
         {
+          val tile = Tile.getTileFromPoint(parking.location.center)
           tilesToParking.value[tile] = tilesToParking.value[tile]?.plus(parking) ?: listOf(parking)
         },
         { Log.e("ParkingViewModel", "Error adding parking", it) })

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
@@ -52,5 +52,20 @@ data class Tile(val bottomLeft: Point, val topRight: Point) {
       }
       return tiles
     }
+
+    /**
+     * Returns the tile that contains the given point.
+     *
+     * @param point the point to search for
+     * @return the tile that contains the point
+     */
+    fun getTileFromPoint(point: Point): Tile {
+      val x = (point.longitude() / TILE_SIZE).toInt()
+      val y = (point.latitude() / TILE_SIZE).toInt()
+      return roundTiles(
+          Tile(
+              Point.fromLngLat(x * TILE_SIZE, y * TILE_SIZE),
+              Point.fromLngLat((x + 1) * TILE_SIZE, (y + 1) * TILE_SIZE)))
+    }
   }
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
@@ -183,7 +183,7 @@ class ParkingRepositoryFirestoreTest {
     `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockParkingQuerySnapshot))
 
     // Mock the QuerySnapshot to return the expected Parking object
-    `when`(mockCollectionReference.whereGreaterThanOrEqualTo(any<String>(), any()))
+    `when`(mockCollectionReference.whereGreaterThan(any<String>(), any()))
         .thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.whereLessThanOrEqualTo(any<String>(), any()))
         .thenReturn(mockCollectionReference)
@@ -219,14 +219,14 @@ class ParkingRepositoryFirestoreTest {
     `when`(mockParkingQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
 
     // Mock the QuerySnapshot to return the expected Parking object
-    `when`(mockCollectionReference.whereGreaterThanOrEqualTo(any<String>(), any()))
+    `when`(mockCollectionReference.whereGreaterThan(any<String>(), any()))
         .thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.whereLessThanOrEqualTo(any<String>(), any()))
         .thenReturn(mockCollectionReference)
 
     // Call the method under test
     parkingRepositoryFirestore.getKClosestParkings(
-        location = Point.fromLngLat(6.5, 46.5),
+        location = Point.fromLngLat(6.45, 46.45),
         k = 1,
         onSuccess = { parkings ->
           // Assert that the returned list contains the expected Parking object

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/TileManagerTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/TileManagerTest.kt
@@ -21,4 +21,13 @@ class TileManagerTest {
         )
     assert(tiles2.size == 4)
   }
+
+  @Test
+  fun getTileFromPointTest() {
+    val tile =
+        Tile.getTileFromPoint(
+            Point.fromLngLat(6.05, 46.05),
+        )
+    assert(tile == Tile(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(6.1, 46.1)))
+  }
 }


### PR DESCRIPTION
_closes #136_
_closes #143_ 
### What
Fixes a bug introduces by the Tile Manager in which a newly added parking spot, was not displayed on the map as the information about the tile on which it was added was already cached.
Fixes another bug where a spot lying at the intersections of multiple tiles is rendered multiples times
### Why
The user should see the spot that he just added as a confirmation feedback without having to reload the app 
### How
The addParking function of the viewmodel has been changed to add the new parking to the tile parking's list.
The second bug is fixed by going with strict bound instead of non strict bounds for the coordinates
-- -
<img width="548" alt="image" src="https://github.com/user-attachments/assets/4ef464cd-6082-48a4-abf6-088f85a47bda">

