### PR TITLE
Refactor getKClosestParkings

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 class MockParkingRepository @Inject constructor() : ParkingRepository {
   private var uid = 0
-  private val parkings = mutableListOf(TestInstancesParking.parkingEnd2End)
+  private val parkings = mutableListOf(TestInstancesParking.parking1)
 
   override fun getNewUid(): String {
     return (uid++).toString()

--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
@@ -4,12 +4,11 @@ import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.mapbox.geojson.Point
-import com.mapbox.turf.TurfMeasurement
 import javax.inject.Inject
 
 class MockParkingRepository @Inject constructor() : ParkingRepository {
   private var uid = 0
-  private val parkings = mutableListOf(TestInstancesParking.parking1)
+  private val parkings = mutableListOf(TestInstancesParking.parkingEnd2End)
 
   override fun getNewUid(): String {
     return (uid++).toString()
@@ -47,22 +46,6 @@ class MockParkingRepository @Inject constructor() : ParkingRepository {
               it.location.center.latitude() in start.latitude()..end.latitude() &&
                   it.location.center.longitude() in start.longitude()..end.longitude()
             })
-  }
-
-  override fun getKClosestParkings(
-      location: Point,
-      k: Int,
-      onSuccess: (List<Parking>) -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    if (k < 0) onFailure(Exception("Error getting parkings"))
-    else
-        onSuccess(
-            parkings
-                .sortedBy {
-                  TurfMeasurement.distance(TestInstancesParking.referencePoint, it.location.center)
-                }
-                .take(k))
   }
 
   override fun addParking(parking: Parking, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -254,7 +254,7 @@ class ListScreenTest {
   @Test
   fun testParkingDetailsScreenListsParkings() {
     val testParking = TestInstancesParking.parking1
-
+    val loc = testParking.location.center
     // Prepare to populate the parking list
     `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
       println(it.getArgument<Point>(0).toString())
@@ -262,16 +262,11 @@ class ListScreenTest {
     }
     `when`(
             mockParkingRepository.getParkingsBetween(
-                eq(Tile.getTileFromPoint(TestInstancesParking.referencePoint).bottomLeft),
-                any(),
-                any(),
-                any()))
+                eq(Tile.getTileFromPoint(loc).bottomLeft), any(), any(), any()))
         .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
 
-    // Force list update
-    parkingViewModel.getParkingsInRadius(TestInstancesParking.referencePoint, 2.0)
-
     composeTestRule.setContent { SpotListScreen(mockNavigationActions, parkingViewModel) }
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
 
     // Check that the list is displayed
     composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
@@ -292,7 +287,7 @@ class ListScreenTest {
         .assertIsDisplayed()
         .assertTextEquals(
             String.format(
-                "%.2f km",
+                "%.0f m",
                 TurfMeasurement.distance(
                     TestInstancesParking.EPFLCenter, testParking.location.center)))
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -25,8 +25,10 @@ import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
+import com.github.se.cyrcle.model.parking.Tile
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
+import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfMeasurement
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -37,6 +39,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -253,12 +256,20 @@ class ListScreenTest {
     val testParking = TestInstancesParking.parking1
 
     // Prepare to populate the parking list
-    `when`(mockParkingRepository.getKClosestParkings(any(), any(), any(), any())).then {
-      it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking))
+    `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
+      println(it.getArgument<Point>(0).toString())
+      it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
     }
+    `when`(
+            mockParkingRepository.getParkingsBetween(
+                eq(Tile.getTileFromPoint(TestInstancesParking.referencePoint).bottomLeft),
+                any(),
+                any(),
+                any()))
+        .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
 
     // Force list update
-    parkingViewModel.getKClosestParkings(TestInstancesParking.referencePoint, 1)
+    parkingViewModel.getParkingsInRadius(TestInstancesParking.referencePoint, 2.0)
 
     composeTestRule.setContent { SpotListScreen(mockNavigationActions, parkingViewModel) }
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -28,7 +28,6 @@ import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.parking.Tile
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
-import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfMeasurement
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -257,7 +256,6 @@ class ListScreenTest {
     val loc = testParking.location.center
     // Prepare to populate the parking list
     `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
-      println(it.getArgument<Point>(0).toString())
       it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
     }
     `when`(

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepository.kt
@@ -48,14 +48,6 @@ interface ParkingRepository {
       onSuccess: (List<Parking>) -> Unit,
       onFailure: (Exception) -> Unit
   )
-
-  fun getKClosestParkings(
-      location: Point,
-      k: Int,
-      onSuccess: (List<Parking>) -> Unit,
-      onFailure: (Exception) -> Unit
-  )
-
   /**
    * Add a parking
    *

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestore.kt
@@ -6,7 +6,6 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.gson.*
 import com.google.gson.reflect.TypeToken
 import com.mapbox.geojson.Point
-import com.mapbox.turf.TurfMeasurement
 import java.lang.reflect.Type
 import javax.inject.Inject
 
@@ -105,49 +104,6 @@ class ParkingRepositoryFirestore @Inject constructor(private val db: FirebaseFir
           onSuccess(parkings)
         }
         .addOnFailureListener { e -> onFailure(e) }
-  }
-
-  override fun getKClosestParkings(
-      location: Point,
-      k: Int,
-      onSuccess: (List<Parking>) -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    // variables for radius search
-    val initialRadius = 0.3
-    val maxRadius = 0.5
-    val step = 0.2
-
-    var currentRadius = initialRadius
-    var parkings = emptyList<Parking>()
-
-    fun getMoreParkings() {
-      getParkingsBetween(
-          Point.fromLngLat(
-              location.longitude() - currentRadius, location.latitude() - currentRadius),
-          Point.fromLngLat(
-              location.longitude() + currentRadius, location.latitude() + currentRadius),
-          { newParkings ->
-            parkings = (parkings + newParkings).distinctBy { it.uid }
-            if (parkings.size < k && currentRadius < maxRadius) {
-              currentRadius += step
-              getMoreParkings()
-            } else {
-              onSuccess(
-                  parkings
-                      .sortedBy {
-                        TurfMeasurement.distance(
-                            location,
-                            Point.fromLngLat(
-                                it.location.center.longitude(), it.location.center.latitude()))
-                      }
-                      .take(k))
-            }
-          },
-          onFailure)
-    }
-
-    getMoreParkings()
   }
 
   override fun addParking(parking: Parking, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -51,7 +51,7 @@ class ParkingViewModel(
         _closestParkings.value =
             parkings
                 .filter { parking ->
-                  TurfMeasurement.distance(_circleCenter.value!!, parking.location.center) <=
+                  TurfMeasurement.distance(_circleCenter.value!!, parking.location.center) * 1000 <=
                       _radius.value
                 }
                 .sortedBy { parking ->

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+const val KMTOMETERS = 1000.0
 /**
  * ViewModel for the Parking feature.
  *
@@ -21,7 +22,6 @@ class ParkingViewModel(
     private val imageRepository: ImageRepository,
     private val parkingRepository: ParkingRepository
 ) : ViewModel() {
-  val kmToMeters = 1000.0
 
   /** List of parkings within the designated area */
   private val _rectParkings = MutableStateFlow<List<Parking>>(emptyList())
@@ -58,7 +58,7 @@ class ParkingViewModel(
             parkings
                 .filter { parking ->
                   TurfMeasurement.distance(_circleCenter.value!!, parking.location.center) *
-                      kmToMeters <= _radius.value
+                      KMTOMETERS <= _radius.value
                 }
                 .sortedBy { parking ->
                   TurfMeasurement.distance(_circleCenter.value!!, parking.location.center)

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -166,9 +166,8 @@ class ParkingViewModel(
   ) {
     _radius.value = radius
     _circleCenter.value = center
-    Tile.getAllTilesInCircle(center, radius).forEach {
-      getParkingsInRect(it.bottomLeft, it.topRight)
-    }
+    val (bottomLeft, topRight) = Tile.getSmallestRectangleEnclosingCircle(center, radius)
+    getParkingsInRect(bottomLeft, topRight)
   }
 
   fun getNewUid(): String {

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -7,6 +7,7 @@ object TestInstancesParking {
   val referencePoint = Point.fromLngLat(6.55, 46.65)
   val EPFLCenter = Point.fromLngLat(6.566397, 46.518467)
 
+  // This parking has to be close to the center point of the map launched by the end2end test
   val parkingEnd2End =
       Parking(
           "E2E",

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -64,4 +64,30 @@ object TestInstancesParking {
           ParkingProtection.COVERED,
           0.0,
           true)
+  val parking4 =
+      Parking(
+          "Test_spot_4",
+          "",
+          null,
+          Location(Point.fromLngLat(7.111, 47.111)),
+          listOf(
+              "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
+          ParkingCapacity.LARGE,
+          ParkingRackType.TWO_TIER,
+          ParkingProtection.COVERED,
+          0.0,
+          true)
+  val parking5 =
+      Parking(
+          "Test_spot_5",
+          "",
+          null,
+          Location(Point.fromLngLat(7.112, 47.112)),
+          listOf(
+              "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
+          ParkingCapacity.LARGE,
+          ParkingRackType.TWO_TIER,
+          ParkingProtection.COVERED,
+          0.0,
+          true)
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -4,9 +4,24 @@ import com.mapbox.geojson.Point
 
 object TestInstancesParking {
 
-  val referencePoint = Point.fromLngLat(6.9, 46.69)
+  val referencePoint = Point.fromLngLat(6.55, 46.65)
   val EPFLCenter = Point.fromLngLat(6.566397, 46.518467)
 
+  val parkingEnd2End =
+      Parking(
+          "E2E",
+          null,
+          null,
+          Location(EPFLCenter),
+          listOf(
+              "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
+          ParkingCapacity.LARGE,
+          ParkingRackType.TWO_TIER,
+          ParkingProtection.COVERED,
+          0.0,
+          true,
+          2,
+          3.0)
   val parking1 =
       Parking(
           "Test_spot_1",

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/TestInstancesParking.kt
@@ -8,27 +8,12 @@ object TestInstancesParking {
   val EPFLCenter = Point.fromLngLat(6.566397, 46.518467)
 
   // This parking has to be close to the center point of the map launched by the end2end test
-  val parkingEnd2End =
-      Parking(
-          "E2E",
-          null,
-          null,
-          Location(EPFLCenter),
-          listOf(
-              "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
-          ParkingCapacity.LARGE,
-          ParkingRackType.TWO_TIER,
-          ParkingProtection.COVERED,
-          0.0,
-          true,
-          2,
-          3.0)
   val parking1 =
       Parking(
           "Test_spot_1",
           "Rue de la paix",
           null,
-          Location(Point.fromLngLat(6.6, 46.2)),
+          Location(EPFLCenter),
           listOf(
               "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
           ParkingCapacity.LARGE,

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
@@ -1,6 +1,7 @@
 package com.github.se.cyrcle.model.parking
 
 import com.mapbox.geojson.Point
+import com.mapbox.turf.TurfMeasurement
 
 const val TILE_SIZE = 0.1
 /**
@@ -66,6 +67,29 @@ data class Tile(val bottomLeft: Point, val topRight: Point) {
           Tile(
               Point.fromLngLat(x * TILE_SIZE, y * TILE_SIZE),
               Point.fromLngLat((x + 1) * TILE_SIZE, (y + 1) * TILE_SIZE)))
+    }
+
+    /**
+     * Return all tiles that are in the circle defined by the center and the radius.
+     *
+     * @param center the center of the circle
+     * @param radius the radius of the circle in meter
+     * @return a set of tiles that are in the circle
+     */
+    fun getAllTilesInCircle(center: Point, radius: Double): Set<Tile> {
+      val leftestPoint = TurfMeasurement.destination(center, radius, -90.0, "meters")
+      val rightestPoint = TurfMeasurement.destination(center, radius, 90.0, "meters")
+      val topPoint = TurfMeasurement.destination(center, radius, 0.0, "meters")
+      val bottomPoint = TurfMeasurement.destination(center, radius, 180.0, "meters")
+      println("Found tiles in circle")
+      println(
+          getAllTilesInRectangle(
+                  Point.fromLngLat(leftestPoint.longitude(), bottomPoint.latitude()),
+                  Point.fromLngLat(rightestPoint.longitude(), topPoint.latitude()))
+              .size)
+      return getAllTilesInRectangle(
+          Point.fromLngLat(leftestPoint.longitude(), bottomPoint.latitude()),
+          Point.fromLngLat(rightestPoint.longitude(), topPoint.latitude()))
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
@@ -98,18 +98,19 @@ data class Tile(val bottomLeft: Point, val topRight: Point) {
     }
 
     /**
-     * Return all tiles that are in the circle defined by the center and the radius.
+     * Return a pair of point representing the bottom left and top right corner of the smallest
+     * rectangle that contains the circle.
      *
      * @param center the center of the circle
      * @param radius the radius of the circle in meter
-     * @return a set of tiles that are in the circle
+     * @return a pair of point representing the bottom left and top right corner of the smallest
      */
-    fun getAllTilesInCircle(center: Point, radius: Double): Set<Tile> {
+    fun getSmallestRectangleEnclosingCircle(center: Point, radius: Double): Pair<Point, Point> {
       val westPoint = TurfMeasurement.destination(center, radius, -90.0, "meters")
       val eastPoint = TurfMeasurement.destination(center, radius, 90.0, "meters")
       val northPoint = TurfMeasurement.destination(center, radius, 0.0, "meters")
       val southPoint = TurfMeasurement.destination(center, radius, 180.0, "meters")
-      return getAllTilesInRectangle(
+      return Pair(
           Point.fromLngLat(westPoint.longitude(), southPoint.latitude()),
           Point.fromLngLat(eastPoint.longitude(), northPoint.latitude()))
     }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Tile.kt
@@ -2,6 +2,8 @@ package com.github.se.cyrcle.model.parking
 
 import com.mapbox.geojson.Point
 import com.mapbox.turf.TurfMeasurement
+import java.math.BigDecimal
+import java.math.RoundingMode
 
 const val TILE_SIZE = 0.1
 /**
@@ -38,17 +40,29 @@ data class Tile(val bottomLeft: Point, val topRight: Point) {
      */
     fun getAllTilesInRectangle(bottomLeft: Point, topRight: Point): Set<Tile> {
       val tiles = mutableSetOf<Tile>()
-      for (x in
-          (bottomLeft.longitude() / TILE_SIZE).toInt()..(topRight.longitude() / TILE_SIZE)
-                  .toInt()) {
-        for (y in
-            (bottomLeft.latitude() / TILE_SIZE).toInt()..(topRight.latitude() / TILE_SIZE)
-                    .toInt()) {
-          val currentTile =
-              Tile(
-                  Point.fromLngLat(x * TILE_SIZE, y * TILE_SIZE),
-                  Point.fromLngLat((x + 1) * TILE_SIZE, (y + 1) * TILE_SIZE))
-          tiles.add(roundTiles(currentTile))
+      // round with a formatter to the 7 digits the bottomLeft and topRight
+
+      /* round down bottomLeft to the nearest TILE_SIZE
+      Note : The BigDecimal is used to avoid floating point errors i.e 7.01 turning into 7.0099999999999998
+      Making the repo look for the tile containing 7.0099999999999998 when not needed
+       */
+      val bottomLeftX =
+          BigDecimal(bottomLeft.longitude() / TILE_SIZE).setScale(7, RoundingMode.HALF_EVEN).toInt()
+      val bottomLeftY =
+          BigDecimal(bottomLeft.latitude() / TILE_SIZE).setScale(7, RoundingMode.HALF_EVEN).toInt()
+      // round up topRight to the nearest TILE_SIZE
+      val topRightX =
+          BigDecimal(topRight.longitude() / TILE_SIZE).setScale(0, RoundingMode.UP).toInt()
+      val topRightY =
+          BigDecimal(topRight.latitude() / TILE_SIZE).setScale(0, RoundingMode.UP).toInt()
+
+      for (x in bottomLeftX until topRightX) {
+        for (y in bottomLeftY until topRightY) {
+          tiles.add(
+              roundTiles(
+                  Tile(
+                      Point.fromLngLat(x * TILE_SIZE, y * TILE_SIZE),
+                      Point.fromLngLat((x + 1) * TILE_SIZE, (y + 1) * TILE_SIZE))))
         }
       }
       return tiles

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -68,9 +68,9 @@ fun SpotListScreen(
 ) {
 
   val referencePoint = TestInstancesParking.EPFLCenter
-  val numberOfNewParkings = 10
+  var radius = 100.0
 
-  val parkingSpots by parkingViewModel.kClosestParkings.collectAsState()
+  val parkingSpots by parkingViewModel.closestParkings.collectAsState()
 
   var selectedProtection by remember { mutableStateOf<Set<ParkingProtection>>(emptySet()) }
   var selectedRackTypes by remember { mutableStateOf<Set<ParkingRackType>>(emptySet()) }
@@ -89,7 +89,7 @@ fun SpotListScreen(
   // Fetch initial parkings if the list is empty
   LaunchedEffect(parkingSpots) {
     if (parkingSpots.isEmpty()) {
-      parkingViewModel.getKClosestParkings(referencePoint, numberOfNewParkings)
+      parkingViewModel.getParkingsInRadius(referencePoint, radius)
     }
   }
 
@@ -133,8 +133,9 @@ fun SpotListScreen(
                   SpotCard(navigationActions, parkingViewModel, parking, distance)
                   Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
                   if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
-                    parkingViewModel.getKClosestParkings(
-                        referencePoint, numberOfNewParkings + filteredParkingSpots.size)
+                    // This incremental solution could be improved to be dynamic and with a limit
+                    radius += 100.0
+                    parkingViewModel.getParkingsInRadius(referencePoint, radius)
                   }
                 }
               }

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -68,7 +69,7 @@ fun SpotListScreen(
 ) {
 
   val referencePoint = TestInstancesParking.EPFLCenter
-  var radius = 100.0
+  val radius = remember { mutableDoubleStateOf(100.0) }
 
   val parkingSpots by parkingViewModel.closestParkings.collectAsState()
 
@@ -89,7 +90,7 @@ fun SpotListScreen(
   // Fetch initial parkings if the list is empty
   LaunchedEffect(parkingSpots) {
     if (parkingSpots.isEmpty()) {
-      parkingViewModel.getParkingsInRadius(referencePoint, radius)
+      parkingViewModel.getParkingsInRadius(referencePoint, radius.doubleValue)
     }
   }
 
@@ -97,7 +98,6 @@ fun SpotListScreen(
     Log.d("ListScreen", "selectedProtection: $selectedProtection")
     Log.d("ListScreen", "selectedRackTypes: $selectedRackTypes")
     Log.d("ListScreen", "selectedCapacities: $selectedCapacities")
-    Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
   }
 
   Scaffold(
@@ -134,8 +134,8 @@ fun SpotListScreen(
                   Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
                   if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
                     // This incremental solution could be improved to be dynamic and with a limit
-                    radius += 100.0
-                    parkingViewModel.getParkingsInRadius(referencePoint, radius)
+                    radius.doubleValue += 100
+                    parkingViewModel.getParkingsInRadius(referencePoint, radius.doubleValue)
                   }
                 }
               }

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -88,16 +88,10 @@ fun SpotListScreen(
       }
 
   // Fetch initial parkings if the list is empty
-  LaunchedEffect(parkingSpots) {
+  LaunchedEffect(Unit) {
     if (parkingSpots.isEmpty()) {
       parkingViewModel.getParkingsInRadius(referencePoint, radius.doubleValue)
     }
-  }
-
-  LaunchedEffect(selectedProtection, selectedProtection, selectedCapacities, onlyWithCCTV) {
-    Log.d("ListScreen", "selectedProtection: $selectedProtection")
-    Log.d("ListScreen", "selectedRackTypes: $selectedRackTypes")
-    Log.d("ListScreen", "selectedCapacities: $selectedCapacities")
   }
 
   Scaffold(
@@ -132,7 +126,8 @@ fun SpotListScreen(
                   val distance = TurfMeasurement.distance(referencePoint, parking.location.center)
                   SpotCard(navigationActions, parkingViewModel, parking, distance)
                   Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
-                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
+                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1 &&
+                      radius.doubleValue < 1000) {
                     // This incremental solution could be improved to be dynamic and with a limit
                     radius.doubleValue += 100
                     parkingViewModel.getParkingsInRadius(referencePoint, radius.doubleValue)

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingRepositoryFirestoreTest.kt
@@ -208,39 +208,6 @@ class ParkingRepositoryFirestoreTest {
   }
 
   @Test
-  fun getKClosesParkings_returnsCorrectValues() {
-    // Mock the DocumentSnapshot to return the expected Parking object
-    `when`(mockDocumentSnapshot.toObject(Parking::class.java)).thenReturn(parking)
-
-    // Ensure that mockParkingQuerySnapshot is properly initialized and mocked
-    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockParkingQuerySnapshot))
-
-    // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
-    `when`(mockParkingQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-
-    // Mock the QuerySnapshot to return the expected Parking object
-    `when`(mockCollectionReference.whereGreaterThan(any<String>(), any()))
-        .thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.whereLessThanOrEqualTo(any<String>(), any()))
-        .thenReturn(mockCollectionReference)
-
-    // Call the method under test
-    parkingRepositoryFirestore.getKClosestParkings(
-        location = Point.fromLngLat(6.45, 46.45),
-        k = 1,
-        onSuccess = { parkings ->
-          // Assert that the returned list contains the expected Parking object
-          assert(parkings.size == 1)
-          assert(parkings[0] == parking)
-        },
-        onFailure = { fail("Expected success but got failure") })
-
-    // Verify that the 'documents' field was accessed
-    verify(timeout(100)) { (mockParkingQuerySnapshot).documents }
-    verify(timeout(100)) { mockDocumentSnapshot.toObject(Parking::class.java) }
-  }
-
-  @Test
   fun addParking_callsFirestoreSet() {
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -84,7 +84,6 @@ class ParkingViewModelTest {
   @Test
   fun getParkingsInRadiusNomainalCaseTest() {
     `when`(parkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
-      println("Called")
       it.getArgument<(List<Parking>) -> Unit>(2)(
           listOf(
               TestInstancesParking.parking4, // at 7.111, 47.111

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -68,34 +68,6 @@ class ParkingViewModelTest {
   }
 
   @Test
-  fun getParkingLocationKIs0() {
-    `when`(parkingRepository.getKClosestParkings(any(), any(), any(), any())).then {
-      it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
-    }
-
-    // Get the two closest parkings to the location
-    parkingViewModel.getKClosestParkings(Point.fromLngLat(7.1, 47.1), 0)
-
-    // Check if the parkings returned are the correct ones
-    assert(parkingViewModel.kClosestParkings.value.isEmpty())
-  }
-
-  @Test
-  fun getParkingLocationKIs1() {
-    `when`(parkingRepository.getKClosestParkings(any(), any(), any(), any())).then {
-      it.getArgument<(List<Parking>) -> Unit>(2)(listOf(TestInstancesParking.parking3))
-    }
-
-    // Get the two closest parkings to the location
-    parkingViewModel.getKClosestParkings(Point.fromLngLat(7.1, 47.1), 1)
-
-    // Check if the parkings returned are the correct ones
-    val parkingsReturned = parkingViewModel.kClosestParkings.value
-    assert(parkingsReturned.size == 1)
-    assert(parkingsReturned[0] == TestInstancesParking.parking3)
-  }
-
-  @Test
   fun updateReviewScoreTest() {
     val parking = TestInstancesParking.parking2
     parkingViewModel.updateReviewScore(5.0, parking)

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -7,9 +7,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
@@ -72,5 +74,39 @@ class ParkingViewModelTest {
     val parking = TestInstancesParking.parking2
     parkingViewModel.updateReviewScore(5.0, parking)
     assert(parking.avgScore == 5.0)
+  }
+  /*
+  This test simulates the repository returning multiple parkings, some out of the radius.
+    The test checks if the parkings returned are correctly sorted and filtered.
+    Note : Parkings have specific coordinates to ensure they are not on the edge of a tile.
+    Otherwise the repo would be called multiple times and the mokkito would each time return the same parkings.
+   */
+  @Test
+  fun getParkingsInRadiusNomainalCaseTest() {
+    `when`(parkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
+      println("Called")
+      it.getArgument<(List<Parking>) -> Unit>(2)(
+          listOf(
+              TestInstancesParking.parking4, // at 7.111, 47.111
+              TestInstancesParking.parking5 // at 7.112, 47.112
+              ))
+    }
+    parkingViewModel.getParkingsInRadius(TestInstancesParking.parking4.location.center, 10.0)
+    assertEquals(1, parkingViewModel.closestParkings.value.size)
+    assert(parkingViewModel.closestParkings.value.contains(TestInstancesParking.parking4))
+  }
+
+  /**
+   * This test simulates a circle overlapping multiples tiles and make sure all tiles are queried.
+   */
+  @Test
+  fun getParkingsInRadiusOverlappingTileTest() {
+    parkingViewModel.getParkingsInRadius(Point.fromLngLat(6.0, 46.0), 100.0)
+    verify(parkingRepository, times(4)).getParkingsBetween(any(), any(), any(), any())
+    // Must use another viewmodel otherwise repo is not called anymore because of the cache
+    val parkingViewModel2 = ParkingViewModel(imageRepository, parkingRepository)
+    clearInvocations(parkingRepository)
+    parkingViewModel2.getParkingsInRadius(Point.fromLngLat(6.05, 46.0), 100.0)
+    verify(parkingRepository, times(2)).getParkingsBetween(any(), any(), any(), any())
   }
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/TileManagerTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/TileManagerTest.kt
@@ -30,4 +30,18 @@ class TileManagerTest {
         )
     assert(tile == Tile(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(6.1, 46.1)))
   }
+  // Note : This Test only works if the tile size is 0.1
+  @Test
+  fun getAllTilesInCircleTest() {
+    val tiles = Tile.getAllTilesInCircle(Point.fromLngLat(6.05, 46.05), 5.0)
+    assert(tiles.size == 1)
+    assert(tiles.contains(Tile(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(6.1, 46.1))))
+
+    val tiles2 = Tile.getAllTilesInCircle(Point.fromLngLat(6.5, 46.5), 5.0)
+    assert(tiles2.size == 4)
+    assert(tiles2.contains(Tile(Point.fromLngLat(6.4, 46.4), Point.fromLngLat(6.5, 46.5))))
+    assert(tiles2.contains(Tile(Point.fromLngLat(6.5, 46.4), Point.fromLngLat(6.6, 46.5))))
+    assert(tiles2.contains(Tile(Point.fromLngLat(6.4, 46.5), Point.fromLngLat(6.5, 46.6))))
+    assert(tiles2.contains(Tile(Point.fromLngLat(6.5, 46.5), Point.fromLngLat(6.6, 46.6))))
+  }
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/TileManagerTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/TileManagerTest.kt
@@ -30,18 +30,21 @@ class TileManagerTest {
         )
     assert(tile == Tile(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(6.1, 46.1)))
   }
-  // Note : This Test only works if the tile size is 0.1
-  @Test
-  fun getAllTilesInCircleTest() {
-    val tiles = Tile.getAllTilesInCircle(Point.fromLngLat(6.05, 46.05), 5.0)
-    assert(tiles.size == 1)
-    assert(tiles.contains(Tile(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(6.1, 46.1))))
 
-    val tiles2 = Tile.getAllTilesInCircle(Point.fromLngLat(6.5, 46.5), 5.0)
-    assert(tiles2.size == 4)
-    assert(tiles2.contains(Tile(Point.fromLngLat(6.4, 46.4), Point.fromLngLat(6.5, 46.5))))
-    assert(tiles2.contains(Tile(Point.fromLngLat(6.5, 46.4), Point.fromLngLat(6.6, 46.5))))
-    assert(tiles2.contains(Tile(Point.fromLngLat(6.4, 46.5), Point.fromLngLat(6.5, 46.6))))
-    assert(tiles2.contains(Tile(Point.fromLngLat(6.5, 46.5), Point.fromLngLat(6.6, 46.6))))
+  /*
+   * Test the smallest rectangle that contains a circle
+   * The circle is centered at 6.05, 46.05 with a radius of 10
+   * The rectangle should have a bottom left corner smaller than 6.05, 46.05
+   * and a top right corner bigger than 6.05, 46.05
+   * This function is pretty simple, so it doesn't need more tests.
+   */
+  @Test
+  fun getSmallestRectangleEnclosingCircleTest() {
+    val (bottomLeft, topRight) =
+        Tile.getSmallestRectangleEnclosingCircle(Point.fromLngLat(6.05, 46.05), 10.0)
+    assert(bottomLeft.longitude() < 6.05)
+    assert(bottomLeft.latitude() < 46.05)
+    assert(topRight.longitude() > 6.05)
+    assert(topRight.latitude() > 46.05)
   }
 }


### PR DESCRIPTION
_Closes #149_
## Changing from `getKClosest` to `getParkingInCircle`

### Why
As agreed with the team in charge of the list screen, It makes more sense for the viewmodel to fix the radius and not the number of parkings returned. 

### How 
The arguments of the function is not the number of parkings to return anymore but the radius to look for.
The function now look in the smallest rectangle containing the circle and then filter and sort the result.

For this to work a new function `getSmallestRectangleEnclosingCircle` has been added in the Tile. 
`getParkingInCircle` just calls `getParkingsInRect` with argument provided by  `getSmallestRectangleEnclosingCircle`

## Optimize the number of call to the database
It was possible to take advantage of the tile Manager introduced by #133 to reduce complexity and the number of calls to the db for this function. 

### How
This new viewmodel function now call another function of the viewmodel `getParkingsInRect` that is already optimized and take advantage of the cache.
It is now this other function of the viewmodel that handles the caching and the call to the db.

The state linked to this function is in fact bind to the state of the `getInRectangle`.


##  Removing `getKClosestParkings` function of the parking Repository .
### Why
This function of the repository was complex with a recursive structure it made **a lot** of unnecessary calls to the database.
Now if the UI needs more parking, it needs to make the circle larger 
### How 
Removing this function involved a lot of deletions in the following files : 
- The interface
- The firestore repo
- The mock repo
- The tests for the repo

**Edit** new codecoverage provided after all the PR merged this week.
<img width="549" alt="image" src="https://github.com/user-attachments/assets/4c488da3-a617-443f-aefe-68ace3124d53">

