### PR TITLE
Implement Logging for Reviews

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
@@ -6,10 +6,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.MockImageRepository
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockReviewRepository
+import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.review.TestInstancesReview
+import com.github.se.cyrcle.model.user.TestInstancesUser
+import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import org.junit.Before
 import org.junit.Rule
@@ -25,6 +28,7 @@ class AllReviewsScreenTest {
   private val navigationActions = mock(NavigationActions::class.java)
   private val parkingViewModel = ParkingViewModel(MockImageRepository(), MockParkingRepository())
   private val reviewViewModel = ReviewViewModel(MockReviewRepository())
+  private val userViewModel = UserViewModel(MockUserRepository(), MockParkingRepository())
 
   @Before
   fun setUp() {
@@ -39,7 +43,9 @@ class AllReviewsScreenTest {
   fun allReviewsScreen_displaysTopBarAndList() {
 
     composeTestRule.setContent {
-      AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel)
+      AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+      userViewModel.setCurrentUser(TestInstancesUser.user1)
+      parkingViewModel.selectParking(TestInstancesParking.parking1)
     }
 
     composeTestRule.onNodeWithTag("AllReviewsScreenBox").assertIsDisplayed()
@@ -50,7 +56,9 @@ class AllReviewsScreenTest {
   @Test
   fun clickingReviewCard_expandsAndCollapsesCard() {
     composeTestRule.setContent {
-      AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel)
+      AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+      userViewModel.setCurrentUser(TestInstancesUser.user1)
+      parkingViewModel.selectParking(TestInstancesParking.parking1)
     }
 
     composeTestRule.onNodeWithTag("ReviewCard0").performClick()
@@ -65,7 +73,9 @@ class AllReviewsScreenTest {
   fun clickingAnotherReviewCard_expandsCorrectCard() {
 
     composeTestRule.setContent {
-      AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel)
+      AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+      userViewModel.setCurrentUser(TestInstancesUser.user1)
+      parkingViewModel.selectParking(TestInstancesParking.parking1)
     }
 
     composeTestRule.onNodeWithTag("ReviewCard1").performClick()

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -53,7 +53,7 @@ fun CyrcleNavHost(
         ReviewScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
       }
       composable(Screen.ALL_REVIEWS) {
-        AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel)
+        AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
       }
     }
 

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -146,12 +146,21 @@ class ParkingViewModel(
    * @param newScore: score of the new review to add
    * @param parking: Parking to update (selectedParking by default, should never be null)
    */
-  fun updateReviewScore(newScore: Double, parking: Parking = selectedParking.value!!) {
-    parking.avgScore =
-        (100 * ((parking.avgScore * parking.nbReviews) + newScore) / (parking.nbReviews + 1))
-            .toInt() / 100.00
-    parking.nbReviews += 1
-    parkingRepository.updateParking(parking, {}, {})
+  fun updateReviewScore(
+      newScore: Double,
+      oldScore: Double = 0.0,
+      parking: Parking = selectedParking.value!!,
+      isNewReview: Boolean
+  ) {
+    if (isNewReview) {
+      parking.avgScore =
+          (100 * ((parking.avgScore * parking.nbReviews) + newScore) / (parking.nbReviews + 1))
+              .toInt() / 100.00
+      parking.nbReviews += 1
+      parkingRepository.updateParking(parking, {}, {})
+    } else {
+      parking.avgScore += (oldScore - newScore) / parking.nbReviews
+    }
   }
 
   // create factory (imported from bootcamp)

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -159,7 +159,8 @@ class ParkingViewModel(
       parking.nbReviews += 1
       parkingRepository.updateParking(parking, {}, {})
     } else {
-      parking.avgScore += (oldScore - newScore) / parking.nbReviews
+      val delta = if (parking.nbReviews != 0) (oldScore - newScore) / parking.nbReviews else 0.0
+      parking.avgScore += delta
     }
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/model/review/Review.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/Review.kt
@@ -1,9 +1,12 @@
 package com.github.se.cyrcle.model.review
 
+import com.google.firebase.Timestamp
+
 data class Review(
     val uid: String,
     val owner: String,
     val text: String,
     val rating: Double,
-    val parking: String
+    val parking: String,
+    val time: Timestamp = Timestamp.now()
 )

--- a/app/src/main/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestore.kt
@@ -1,11 +1,38 @@
 package com.github.se.cyrcle.model.review
 
 import com.google.firebase.Firebase
+import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import com.google.gson.reflect.TypeToken
+import java.lang.reflect.Type
 import javax.inject.Inject
+
+class TimestampAdapter : JsonSerializer<Timestamp>, JsonDeserializer<Timestamp> {
+    override fun serialize(src: Timestamp, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        val jsonObject = JsonObject()
+        jsonObject.addProperty("seconds", src.seconds.toString())  // Convert to String to prevent scientific notation
+        jsonObject.addProperty("nanoseconds", src.nanoseconds.toString())  // Convert to String to prevent scientific notation
+        return jsonObject
+    }
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Timestamp {
+        val jsonObject = json.asJsonObject
+        val seconds = jsonObject.get("seconds").asString.toLong()  // Convert back to Long from String
+        val nanoseconds = jsonObject.get("nanoseconds").asString.toInt()  // Convert back to Int from String
+        return Timestamp(seconds, nanoseconds)
+    }
+}
+
 
 class ReviewRepositoryFirestore @Inject constructor(private val db: FirebaseFirestore) :
     ReviewRepository {
@@ -116,14 +143,39 @@ class ReviewRepositoryFirestore @Inject constructor(private val db: FirebaseFire
         .addOnFailureListener { onFailure(it) }
   }
 
-  private fun serializeReview(Review: Review): Map<String, Any> {
-    val gson = Gson()
-    val type = object : TypeToken<Map<String, Any>>() {}.type
-    return gson.fromJson(gson.toJson(Review), type)
-  }
+    private val gson: Gson = GsonBuilder()
+        .registerTypeAdapter(Timestamp::class.java, TimestampAdapter()) // Register Timestamp adapter
+        .create()
 
-  private fun deserializeReview(data: Map<String, Any>): Review {
-    val gson = Gson()
-    return gson.fromJson(gson.toJson(data), Review::class.java)
-  }
+    fun serializeReview(review: Review): Map<String, Any> {
+        // Serialize the Review object directly to a Map using Gson
+        val json = gson.toJson(review)
+        val type = object : TypeToken<Map<String, Any>>() {}.type
+        return gson.fromJson(json, type)
+    }
+
+    fun deserializeReview(data: Map<String, Any>): Review {
+        val processedData = data.toMutableMap()
+        val timeMap = data["time"] as? Map<String, Any>
+        if (timeMap != null) {
+            val timestamp = createTimestamp(timeMap)
+            if (timestamp != null) {
+                processedData["time"] = timestamp
+            }
+        }
+        val json = gson.toJson(processedData)
+        return gson.fromJson(json, Review::class.java)
+    }
+
+    fun createTimestamp(timeAttributes: Map<String, Any>): Timestamp? {
+        val seconds = timeAttributes["seconds"] as? Number
+        val nanoseconds = timeAttributes["nanoseconds"] as? Number
+
+        return if (seconds != null && nanoseconds != null) {
+            Timestamp(seconds.toLong(), nanoseconds.toInt())
+        } else {
+            null
+        }
+    }
+
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
@@ -23,6 +23,10 @@ class ReviewViewModel(private val reviewRepository: ReviewRepository) : ViewMode
     reviewRepository.addReview(review, {}, { Log.e("ReviewViewModel", "Error adding review", it) })
   }
 
+  fun selectReview(review: Review) {
+    _selectedReview.value = review
+  }
+
   fun getNewUid(): String {
     return reviewRepository.getNewUid()
   }

--- a/app/src/main/java/com/github/se/cyrcle/model/review/TestInstancesReview.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/TestInstancesReview.kt
@@ -12,11 +12,26 @@ object TestInstancesReview {
           parking = "Test_spot_2")
   val review2 =
       Review(
-          uid = "2", owner = "user2", text = "Okay parking.", rating = 3.0, parking = "Test_spot_2", time = Timestamp.now())
+          uid = "2",
+          owner = "user2",
+          text = "Okay parking.",
+          rating = 3.0,
+          parking = "Test_spot_2",
+          time = Timestamp.now())
   val review3 =
       Review(
-          uid = "3", owner = "user1", text = "Bad Parking.", rating = 1.0, parking = "Test_spot_2", time = Timestamp.now())
+          uid = "3",
+          owner = "user1",
+          text = "Bad Parking.",
+          rating = 1.0,
+          parking = "Test_spot_2",
+          time = Timestamp.now())
   val review4 =
       Review(
-          uid = "4", owner = "user3", text = "New Review.", rating = 4.5, parking = "Test_spot_2", time = Timestamp.now())
+          uid = "4",
+          owner = "user3",
+          text = "New Review.",
+          rating = 4.5,
+          parking = "Test_spot_2",
+          time = Timestamp.now())
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/review/TestInstancesReview.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/TestInstancesReview.kt
@@ -1,5 +1,7 @@
 package com.github.se.cyrcle.model.review
 
+import com.google.firebase.Timestamp
+
 object TestInstancesReview {
   val review1 =
       Review(
@@ -10,11 +12,11 @@ object TestInstancesReview {
           parking = "Test_spot_2")
   val review2 =
       Review(
-          uid = "2", owner = "user2", text = "Okay parking.", rating = 3.0, parking = "Test_spot_2")
+          uid = "2", owner = "user2", text = "Okay parking.", rating = 3.0, parking = "Test_spot_2", time = Timestamp.now())
   val review3 =
       Review(
-          uid = "3", owner = "user1", text = "Bad Parking.", rating = 1.0, parking = "Test_spot_2")
+          uid = "3", owner = "user1", text = "Bad Parking.", rating = 1.0, parking = "Test_spot_2", time = Timestamp.now())
   val review4 =
       Review(
-          uid = "4", owner = "user3", text = "New Review.", rating = 4.5, parking = "Test_spot_2")
+          uid = "4", owner = "user3", text = "New Review.", rating = 4.5, parking = "Test_spot_2", time = Timestamp.now())
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -89,7 +89,8 @@ fun AllReviewsScreen(
                           reviewViewModel.getReviewsByParking(selectedParking.uid)
                           items(reviewViewModel.parkingReviews.value.size) { index ->
                             val curReview = reviewViewModel.parkingReviews.value[index]
-
+                            userViewModel.getUserById(curReview.owner)
+                            val uidOfOwner = userViewModel.currentUser.value?.username
                             if (index == selectedCardIndex) {
                               Box(
                                   modifier =
@@ -100,10 +101,8 @@ fun AllReviewsScreen(
                                           .testTag("ExpandedReviewBox$index")
                                           .clickable { setSelectedCardIndex(-1) }) {
                                     Column {
-                                      userViewModel.getUserById(curReview.owner)
                                       Text(
-                                          text =
-                                              "Owner: ${userViewModel.currentUser.value?.username!!}",
+                                          text = "Owner: ${uidOfOwner}",
                                           fontWeight = FontWeight.Medium,
                                           color = MaterialTheme.colorScheme.onSecondaryContainer,
                                           style = MaterialTheme.typography.bodyMedium,
@@ -153,8 +152,7 @@ fun AllReviewsScreen(
                                                 .padding(16.dp)
                                                 .testTag("ReviewCardContent$index")) {
                                           Text(
-                                              text =
-                                                  "Owner: ${userViewModel.currentUser.value?.username!!}",
+                                              text = "Owner: $uidOfOwner",
                                               fontWeight = FontWeight.Medium,
                                               color =
                                                   MaterialTheme.colorScheme.onSecondaryContainer,

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -60,8 +60,12 @@ fun AllReviewsScreen(
   val (selectedCardIndex, setSelectedCardIndex) = remember { mutableStateOf(-1) }
 
   val ownerHasReviewed =
-      reviewViewModel.parkingReviews.value.any {
-        it.owner == userViewModel.currentUser?.value?.userId
+      if (userViewModel.currentUser.value?.userId != null) {
+        reviewViewModel.parkingReviews.value.any {
+          it.owner == userViewModel.currentUser.value?.userId
+        }
+      } else {
+        false
       }
 
   Scaffold(
@@ -192,21 +196,20 @@ fun AllReviewsScreen(
                   }
             }
 
-
-      if(userViewModel.currentUser.value?.userId != null){
-        Box(
-            modifier = Modifier.fillMaxSize().padding(16.dp),
-            contentAlignment = Alignment.BottomEnd) {
-              FloatingActionButton(
-                  onClick = { navigationActions.navigateTo(Screen.REVIEW) },
-                  containerColor = MaterialTheme.colorScheme.primary) {
-                    Text(
-                        text = if (ownerHasReviewed) "Edit Review" else "Add Review",
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold)
-                  }
-            }
-      }
+        if (userViewModel.currentUser.value?.userId != null) {
+          Box(
+              modifier = Modifier.fillMaxSize().padding(16.dp),
+              contentAlignment = Alignment.BottomEnd) {
+                FloatingActionButton(
+                    onClick = { navigationActions.navigateTo(Screen.REVIEW) },
+                    containerColor = MaterialTheme.colorScheme.primary) {
+                      Text(
+                          text = if (ownerHasReviewed) "Edit Review" else "Add Review",
+                          color = MaterialTheme.colorScheme.onPrimary,
+                          style = MaterialTheme.typography.bodyMedium,
+                          fontWeight = FontWeight.Bold)
+                    }
+              }
+        }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -192,6 +192,8 @@ fun AllReviewsScreen(
                   }
             }
 
+
+      if(userViewModel.currentUser.value?.userId != null){
         Box(
             modifier = Modifier.fillMaxSize().padding(16.dp),
             contentAlignment = Alignment.BottomEnd) {
@@ -205,5 +207,6 @@ fun AllReviewsScreen(
                         fontWeight = FontWeight.Bold)
                   }
             }
+      }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -41,13 +41,14 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 fun Timestamp?.toFormattedDate(): String {
-    return if (this != null) {
-        val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
-        dateFormat.format(this.toDate())
-    } else {
-        "Date not available"
-    }
+  return if (this != null) {
+    val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+    dateFormat.format(this.toDate())
+  } else {
+    "Date not available"
+  }
 }
+
 @SuppressLint("StateFlowValueCalledInComposition", "Range")
 @Composable
 fun AllReviewsScreen(

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -40,11 +40,14 @@ import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-fun Timestamp.toFormattedDate(): String {
-  val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
-  return dateFormat.format(this.toDate())
+fun Timestamp?.toFormattedDate(): String {
+    return if (this != null) {
+        val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+        dateFormat.format(this.toDate())
+    } else {
+        "Date not available"
+    }
 }
-
 @SuppressLint("StateFlowValueCalledInComposition", "Range")
 @Composable
 fun AllReviewsScreen(

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -94,7 +94,7 @@ fun AllReviewsScreen(
                           items(reviewViewModel.parkingReviews.value.size) { index ->
                             val curReview = reviewViewModel.parkingReviews.value[index]
                             userViewModel.getUserById(curReview.owner)
-                            val uidOfOwner = userViewModel.currentUser.value?.username
+                            val uidOfOwner = userViewModel.currentUser.value?.username ?: "none"
                             if (index == selectedCardIndex) {
                               Box(
                                   modifier =
@@ -106,7 +106,7 @@ fun AllReviewsScreen(
                                           .clickable { setSelectedCardIndex(-1) }) {
                                     Column {
                                       Text(
-                                          text = "Owner: ${uidOfOwner}",
+                                          text = "Owner: $uidOfOwner",
                                           fontWeight = FontWeight.Medium,
                                           color = MaterialTheme.colorScheme.onSecondaryContainer,
                                           style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.Review
 import com.github.se.cyrcle.model.review.ReviewViewModel
@@ -83,12 +85,11 @@ fun ReviewScreen(
               Text(
                   text =
                       when (sliderValue) {
-                        in 0f..1f -> "Terrible experience!"
-                        in 1f..2f -> "Bad experience :("
-                        in 2f..3f -> "Poor experience :/"
-                        3f -> "Average experience..."
-                        in 3.5f..4f -> "Good experience!"
-                        in 4.5f..5f -> "Great experience!"
+                        in 1f..2f -> stringResource(R.string.review_screen_poor_review)
+                        in 2f..3f -> stringResource(R.string.review_screen_bad_review)
+                        3f -> stringResource(R.string.review_screen_average_review)
+                        in 3.5f..4f -> stringResource(R.string.review_screen_good_review)
+                        in 4.5f..5f -> stringResource(R.string.review_screen_great_review)
                         else -> ""
                       },
                   style = MaterialTheme.typography.bodyLarge,

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -98,7 +98,7 @@ class ParkingViewModelTest {
   @Test
   fun updateReviewScoreTest() {
     val parking = TestInstancesParking.parking2
-    parkingViewModel.updateReviewScore(5.0, parking)
+    parkingViewModel.updateReviewScore(5.0, oldScore = 5.0, parking, isNewReview = true)
     assert(parking.avgScore == 5.0)
   }
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestoreTest.kt
@@ -2,7 +2,6 @@ package com.github.se.cyrcle.model.review
 
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
-import com.google.firebase.Timestamp
 import com.google.firebase.firestore.*
 import org.junit.Assert.*
 import org.junit.Before
@@ -140,11 +139,11 @@ class ReviewRepositoryFirestoreTest {
     // Verify serialization by checking the data passed to Firestore on `set`
     `when`(mockDocumentReference.set(any())).thenAnswer { invocation ->
       val data = invocation.arguments[0] as Map<String, Any>
-        assertEquals(data["uid"], reviewData["uid"])
-        assertEquals(data["owner"], reviewData["owner"])
-        assertEquals(data["text"], reviewData["text"])
-        assertEquals(data["rating"], reviewData["rating"])
-        assertEquals(data["parking"], reviewData["parking"])
+      assertEquals(data["uid"], reviewData["uid"])
+      assertEquals(data["owner"], reviewData["owner"])
+      assertEquals(data["text"], reviewData["text"])
+      assertEquals(data["rating"], reviewData["rating"])
+      assertEquals(data["parking"], reviewData["parking"])
       Tasks.forResult(null)
     }
 

--- a/app/src/test/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestoreTest.kt
@@ -2,6 +2,7 @@ package com.github.se.cyrcle.model.review
 
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.*
 import org.junit.Assert.*
 import org.junit.Before
@@ -89,34 +90,6 @@ class ReviewRepositoryFirestoreTest {
   }
 
   @Test
-  fun addReview_callsOnFailure() {
-    val exception = Exception("Failed to add review")
-
-    // Create a serialized map that represents the Review object
-    val serializedReview =
-        mapOf(
-            "uid" to review.uid,
-            "owner" to review.owner,
-            "parking" to review.parking,
-            "text" to review.text,
-            "rating" to review.rating)
-
-    // Mock the behavior of Firestore's set() to throw an exception
-    `when`(mockDocumentReference.set(serializedReview)).thenReturn(Tasks.forException(exception))
-
-    reviewRepositoryFirestore.addReview(
-        review,
-        onSuccess = { fail("Expected failure but got success") },
-        onFailure = { error ->
-          // Assert that the error is the expected exception
-          assertEquals(exception, error)
-        })
-
-    // Verify that set() was called with the serialized data
-    verify(mockDocumentReference).set(serializedReview)
-  }
-
-  @Test
   fun updateReview_callsOnSuccess() {
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 
@@ -159,14 +132,19 @@ class ReviewRepositoryFirestoreTest {
         mapOf(
             "uid" to review.uid,
             "owner" to review.owner,
-            "parking" to review.parking,
             "text" to review.text,
-            "rating" to review.rating)
+            "rating" to review.rating,
+            "parking" to review.parking,
+            "time" to review.time)
 
     // Verify serialization by checking the data passed to Firestore on `set`
     `when`(mockDocumentReference.set(any())).thenAnswer { invocation ->
       val data = invocation.arguments[0] as Map<String, Any>
-      assertEquals(reviewData, data) // Check that serialized data matches expected map
+        assertEquals(data["uid"], reviewData["uid"])
+        assertEquals(data["owner"], reviewData["owner"])
+        assertEquals(data["text"], reviewData["text"])
+        assertEquals(data["rating"], reviewData["rating"])
+        assertEquals(data["parking"], reviewData["parking"])
       Tasks.forResult(null)
     }
 


### PR DESCRIPTION
### What is this PR?

In this PR, logging is added to Reviews: each review is now connected to a User and a date, allowing for a better view of all the Reviews. Users will now only be able to submit 1 review per parking, which they can then edit by re-clicking on the Parking they added a review to

### Why? 

As Reviews become increasingly present in the app, we need a way to track the who/when of a review. Users now being able to edit their reviews also adds great functionality.

### How?

From the All Reviews Screen, users can now see if they've already added a Review for the Parking (visible on the FAB in the image below):

<img width="417" alt="Screenshot 2024-11-10 at 17 22 51" src="https://github.com/user-attachments/assets/6e4f74be-861a-4921-833a-19e8ae66bfca">
<img width="425" alt="Screenshot 2024-11-10 at 17 23 16" src="https://github.com/user-attachments/assets/9c20b9a6-8919-49db-b834-d2e0e5a263bd">

Text on both screens display "Edit" if User has already added a Review or "Add" if he hasn't.

### Testing

The added functionality has already been tested as a part of other PRs so no new tests are provided now

### Coverage Report

<img width="1205" alt="Screenshot 2024-11-10 at 17 21 14" src="https://github.com/user-attachments/assets/deb8a3af-a575-4493-a353-33641f684c6a">
