### PR TITLE
Rework the UI of the ParkingDetailsScreen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -22,7 +22,6 @@ import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.review.ReviewRepository
 import com.github.se.cyrcle.model.review.ReviewViewModel
-import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -31,11 +30,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 
 @RunWith(AndroidJUnit4::class)
 class ParkingDetailsScreenTest {
@@ -86,7 +83,6 @@ class ParkingDetailsScreenTest {
     // Verify the buttons
     composeTestRule.onNodeWithTag("ButtonsColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ShowInMapButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AddReviewButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ReportButton").assertIsDisplayed()
 
     // Verify the rest of the content
@@ -125,23 +121,6 @@ class ParkingDetailsScreenTest {
   }
 
   @Test
-  fun addReviewButtonBehavesCorrectly() {
-    parkingViewModel.selectParking(TestInstancesParking.parking1)
-    composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
-    }
-
-    composeTestRule.onNodeWithTag("AddReviewButton").assertIsDisplayed().performClick()
-
-    verifyNoInteractions(navigationActions)
-
-    userViewModel.setCurrentUser(TestInstancesUser.user1)
-    composeTestRule.onNodeWithTag("AddReviewButton").assertIsDisplayed().performClick()
-
-    verify(navigationActions).navigateTo(ArgumentMatchers.matches(Screen.REVIEW))
-  }
-
-  @Test
   fun displayTitleAndMultipleImages() {
     parkingViewModel.selectParking(TestInstancesParking.parking2)
     composeTestRule.setContent {
@@ -150,5 +129,17 @@ class ParkingDetailsScreenTest {
 
     composeTestRule.onNodeWithTag("TopAppBarTitle").assertTextContains("Description of Rude épais")
     composeTestRule.onNodeWithTag("ParkingImagesRow").onChildren().assertCountEquals(2)
+  }
+
+  @Test
+  fun seeAllReviewsBehavesCorrectly() {
+    parkingViewModel.selectParking(TestInstancesParking.parking1)
+    composeTestRule.setContent {
+      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("SeeAllReviewsText").performClick()
+
+    verify(navigationActions).navigateTo(Screen.ALL_REVIEWS)
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -1,8 +1,11 @@
 package com.github.se.cyrcle.ui.parkingDetails
 
+import android.util.Log
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildAt
 import androidx.compose.ui.test.onChildren
@@ -65,32 +68,40 @@ class ParkingDetailsScreenTest {
     `when`(navigationActions.currentRoute()).thenReturn(Screen.CARD)
   }
 
+  @OptIn(ExperimentalTestApi::class)
   @Test
   fun displayAllComponents() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
     composeTestRule.setContent {
       ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
     }
-
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ParkingImage0"))
+    Log.w("ParkingDetailsScreenTest", "Checking TopAppBar...")
     // Verify the top app bar
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("TopAppBarTitle").assertIsDisplayed()
-
+    Log.w("ParkingDetailsScreenTest", "TopAppBar checked")
+    Log.w("ParkingDetailsScreenTest", "Checking ParkingImagesRow...")
     // Verify the images
     composeTestRule.onNodeWithTag("ParkingImagesRow").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ParkingImage0").assertIsDisplayed()
+    Log.w("ParkingDetailsScreenTest", "ParkingImagesRow checked")
 
+    Log.w("ParkingDetailsScreenTest", "Checking Buttons..")
     // Verify the buttons
     composeTestRule.onNodeWithTag("ButtonsColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ShowInMapButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ReportButton").assertIsDisplayed()
+    Log.w("ParkingDetailsScreenTest", "Buttons checked")
 
+    Log.w("ParkingDetailsScreenTest", "Checking Rest...")
     // Verify the rest of the content
     composeTestRule.onNodeWithTag("CapacityColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("RackTypeColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ProtectionColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("PriceColumn").assertIsDisplayed()
     composeTestRule.onNodeWithTag("SecurityColumn").assertIsDisplayed()
+    Log.w("ParkingDetailsScreenTest", "Rest checked")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -69,7 +69,6 @@ class MainActivityTest {
       composeTestRule.onNodeWithTag("RowSecurity").assertIsDisplayed()
       composeTestRule.onNodeWithTag("ButtonsColumn").assertIsDisplayed()
       composeTestRule.onNodeWithTag("ShowInMapButton").assertIsDisplayed().assertHasClickAction()
-      composeTestRule.onNodeWithTag("AddReviewButton").assertIsDisplayed().assertHasClickAction()
       composeTestRule.onNodeWithTag("ReportButton").assertIsDisplayed().assertHasClickAction()
     }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -1,9 +1,9 @@
 package com.github.se.cyrcle.ui.parkingDetails
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.background
+import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,16 +13,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AddAPhoto
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.github.se.cyrcle.R
@@ -32,9 +36,9 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.IconButton
 import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
 import com.github.se.cyrcle.ui.theme.atoms.Text
-import com.github.se.cyrcle.ui.theme.bold
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 @SuppressLint("StateFlowValueCalledInComposition")
@@ -49,6 +53,8 @@ fun ParkingDetailsScreen(
           ?: return Text(stringResource(R.string.no_selected_parking_error))
   val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
 
+  val context = LocalContext.current
+
   Scaffold(
       topBar = {
         TopAppBar(
@@ -57,167 +63,194 @@ fun ParkingDetailsScreen(
                 .format(selectedParking.optName ?: stringResource(R.string.default_parking_name)))
       },
       modifier = Modifier.testTag("ParkingDetailsScreen")) { padding ->
-        Box(
+        Column(
             modifier =
                 Modifier.fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
-                    .testTag("ParkingDetailsScreenBox") // Test tag for main container
-            ) {
-              Column(
-                  modifier = Modifier.fillMaxSize().padding(padding),
-                  horizontalAlignment = Alignment.CenterHorizontally,
-                  verticalArrangement = Arrangement.SpaceBetween) {
-                    // Display a row of images using LazyRow
-                    LazyRow(
+                    .padding(padding)
+                    .padding(32.dp)
+                    .testTag("ParkingDetailsColumn")) {
+              // Reviews
+              Row(
+                  modifier =
+                      Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("AverageRatingRow"),
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.SpaceBetween) {
+                    if (selectedParking.nbReviews > 0) {
+                      Row {
+                        ScoreStars(
+                            selectedParking.avgScore,
+                            scale = 0.8f,
+                            text =
+                                pluralStringResource(
+                                        R.plurals.reviews_count, count = selectedParking.nbReviews)
+                                    .format(selectedParking.nbReviews))
+                      }
+                    } else {
+                      Text(
+                          text = stringResource(R.string.no_reviews),
+                          style = MaterialTheme.typography.bodyMedium,
+                          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                          testTag = "ParkingNoReviews")
+                    }
+                    Text(
+                        text = stringResource(R.string.card_screen_see_review),
+                        style =
+                            MaterialTheme.typography.bodyMedium.copy(
+                                textDecoration = TextDecoration.Underline),
+                        color = MaterialTheme.colorScheme.primary,
+                        testTag = "SeeAllReviewsText",
                         modifier =
-                            Modifier.fillMaxWidth()
-                                .padding(8.dp)
-                                .testTag("ParkingImagesRow"), // Test tag for image row
-                        horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                          items(selectedParking.images.size) { index ->
-                            AsyncImage(
-                                model = selectedParking.images[index],
-                                contentDescription = "Image $index",
-                                modifier =
-                                    Modifier.size(170.dp)
-                                        .padding(2.dp)
-                                        .fillMaxWidth()
-                                        .testTag("ParkingImage$index"), // Test tag for each image
-                                contentScale = ContentScale.Crop)
+                            Modifier.clickable { navigationActions.navigateTo(Screen.ALL_REVIEWS) })
+                  }
+
+              Spacer(modifier = Modifier.height(16.dp))
+              // Images
+              Row(
+                  modifier = Modifier.fillMaxWidth().testTag("ImagesRow"),
+                  horizontalArrangement = Arrangement.spacedBy(8.dp),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    if (selectedParking.images.isEmpty()) {
+                      Text(
+                          text = stringResource(R.string.card_screen_no_image),
+                          color = MaterialTheme.colorScheme.onSurface,
+                          style = MaterialTheme.typography.bodyMedium,
+                          testTag = "NoImageText")
+                      IconButton(
+                          icon = Icons.Outlined.AddAPhoto,
+                          contentDescription = "Add Image",
+                          onClick = {
+                            // Temporary toast. Will be replaced by an image picker
+                            Toast.makeText(
+                                    context,
+                                    "A feature to add images will be added later",
+                                    Toast.LENGTH_LONG)
+                                .show()
+                          },
+                          enabled = userSignedIn.value,
+                          testTag = "AddImageIconButton",
+                          modifier = Modifier.padding(start = 8.dp).height(32.dp).fillMaxWidth())
+                    } else {
+                      LazyRow(
+                          modifier = Modifier.fillMaxWidth().testTag("ParkingImagesRow"),
+                          horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            items(selectedParking.images.size) { index ->
+                              AsyncImage(
+                                  model = selectedParking.images[index],
+                                  contentDescription = "Image $index",
+                                  modifier =
+                                      Modifier.size(170.dp)
+                                          .padding(4.dp)
+                                          .testTag("ParkingImage$index"),
+                                  contentScale = ContentScale.Crop)
+                            }
+                          }
+                    }
+                  }
+
+              // Information
+              Column(
+                  modifier =
+                      Modifier.fillMaxWidth().padding(vertical = 32.dp).testTag("InfoColumn"),
+                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().testTag("RowCapacityRack"),
+                        horizontalArrangement = Arrangement.SpaceBetween) {
+                          Column(modifier = Modifier.weight(1f).testTag("CapacityColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_capacity),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text = selectedParking.capacity.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                          Column(modifier = Modifier.weight(1f).testTag("RackTypeColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_rack_type),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text = selectedParking.rackType.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                        }
+                    Row(
+                        modifier = Modifier.fillMaxWidth().testTag("RowProtectionPrice"),
+                        horizontalArrangement = Arrangement.SpaceBetween) {
+                          Column(modifier = Modifier.weight(1f).testTag("ProtectionColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_protection),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text = selectedParking.protection.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                          Column(modifier = Modifier.weight(1f).testTag("PriceColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_price),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            val price = selectedParking.price
+                            Text(
+                                text =
+                                    if (price == 0.0) stringResource(R.string.free) else "$price",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
                           }
                         }
 
-                    // Column for parking info such as capacity, rack type, protection, etc.
-                    Column(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                                .testTag("InfoColumn"), // Test tag for info column
-                        verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                          // Row for displaying capacity and rack type
-                          Row(
-                              modifier = Modifier.fillMaxWidth().testTag("RowCapacityRack"),
-                              horizontalArrangement = Arrangement.SpaceBetween) {
-                                Column(modifier = Modifier.weight(1f).testTag("CapacityColumn")) {
-                                  Text(
-                                      text = stringResource(R.string.card_screen_capacity),
-                                      style = bold)
-                                  Text(
-                                      text = selectedParking.capacity.description,
-                                      color = Color.Gray)
-                                }
-                                Column(modifier = Modifier.weight(1f).testTag("RackTypeColumn")) {
-                                  Text(
-                                      text = stringResource(R.string.card_screen_rack_type),
-                                      style = bold)
-                                  Text(
-                                      text = selectedParking.rackType.description,
-                                      color = Color.Gray)
-                                }
-                              }
-
-                          // Row for displaying protection and price
-                          Row(
-                              modifier = Modifier.fillMaxWidth().testTag("RowProtectionPrice"),
-                              horizontalArrangement = Arrangement.SpaceBetween) {
-                                Column(modifier = Modifier.weight(1f).testTag("ProtectionColumn")) {
-                                  Text(
-                                      text = stringResource(R.string.card_screen_protection),
-                                      style = bold)
-                                  Text(
-                                      text = selectedParking.protection.description,
-                                      color = Color.Gray)
-                                }
-                                Column(modifier = Modifier.weight(1f).testTag("PriceColumn")) {
-                                  Text(
-                                      text = stringResource(R.string.card_screen_price),
-                                      style = bold)
-                                  val price = selectedParking.price
-                                  Text(
-                                      text = if (price == 0.0) "Free" else "$price",
-                                      color = Color.Gray)
-                                }
-                              }
-
-                          // Row for displaying if security is present
-                          Row(
-                              modifier = Modifier.fillMaxWidth().testTag("RowSecurity"),
-                              horizontalArrangement = Arrangement.SpaceBetween) {
-                                Column(modifier = Modifier.weight(1f).testTag("SecurityColumn")) {
-                                  Text(
-                                      text = stringResource(R.string.card_screen_surveillance),
-                                      style = bold)
-                                  Text(
-                                      text =
-                                          if (selectedParking.hasSecurity)
-                                              stringResource(R.string.yes)
-                                          else stringResource(R.string.no),
-                                      color = Color.Gray)
-                                }
-                                Column(
-                                    modifier = Modifier.weight(1f).testTag("AverageRatingColumn")) {
-                                      Text(
-                                          text = stringResource(R.string.card_screen_rating),
-                                          style = bold)
-                                      if (selectedParking.nbReviews == 0) {
-                                        Text(text = stringResource(R.string.no_reviews))
-                                      } else
-                                          ScoreStars(
-                                              selectedParking.avgScore,
-                                              scale = 0.8f,
-                                              text = "(${selectedParking.nbReviews})")
-
-                                      Spacer(
-                                          modifier =
-                                              Modifier.height(
-                                                  8.dp)) // Space between rating and button
-
-                                      Button(
-                                          text = stringResource(R.string.card_screen_see_review),
-                                          onClick = {
-                                            navigationActions.navigateTo(Screen.ALL_REVIEWS)
-                                          },
-                                          modifier =
-                                              Modifier.fillMaxWidth()
-                                                  .testTag(
-                                                      "SeeAllReviewsButton"), // Test tag for See
-                                          // All Reviews button
-                                          colorLevel = ColorLevel.PRIMARY)
-                                    }
-                              }
+                    Row(
+                        modifier = Modifier.fillMaxWidth().testTag("RowSecurity"),
+                        horizontalArrangement = Arrangement.SpaceBetween) {
+                          Column(modifier = Modifier.weight(1f).testTag("SecurityColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_surveillance),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text =
+                                    if (selectedParking.hasSecurity) stringResource(R.string.yes)
+                                    else stringResource(R.string.no),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
                         }
+                  }
 
-                    // Column for action buttons like "Show in Map", "Add A Review", and "Report"
-                    Column(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                                .testTag("ButtonsColumn"), // Test tag for buttons column
-                        verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                          Button(
-                              text = stringResource(R.string.card_screen_show_map),
-                              onClick = { /* Handle Return to Map */},
-                              modifier = Modifier.fillMaxWidth().height(40.dp),
-                              colorLevel = ColorLevel.PRIMARY,
-                              testTag = "ShowInMapButton")
+              Column(
+                  modifier = Modifier.fillMaxWidth().testTag("ButtonsColumn"),
+                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Button(
+                        text = stringResource(R.string.card_screen_show_map),
+                        onClick = {
+                          // Temporary toast. Will redirect to the map screen later
+                          Toast.makeText(
+                                  context,
+                                  "A feature to show the parking on the map will be added later",
+                                  Toast.LENGTH_LONG)
+                              .show()
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colorLevel = ColorLevel.PRIMARY,
+                        testTag = "ShowInMapButton")
 
-                          Button(
-                              text = stringResource(R.string.card_screen_add_review),
-                              onClick = { navigationActions.navigateTo(Screen.REVIEW) },
-                              modifier = Modifier.fillMaxWidth().height(40.dp),
-                              colorLevel = ColorLevel.PRIMARY,
-                              enabled = userSignedIn,
-                              testTag = "AddReviewButton")
-
-                          Button(
-                              text = stringResource(R.string.card_screen_report),
-                              onClick = {},
-                              modifier = Modifier.height(40.dp),
-                              colorLevel = ColorLevel.ERROR,
-                              testTag = "ReportButton")
-                        }
-
-                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(
+                        text = stringResource(R.string.card_screen_report),
+                        onClick = {
+                          // Temporary toast. Will be replaced by a report system
+                          Toast.makeText(
+                                  context,
+                                  "A report system will be added to the app later",
+                                  Toast.LENGTH_LONG)
+                              .show()
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colorLevel = ColorLevel.ERROR,
+                        testTag = "ReportButton")
                   }
             }
       }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -276,6 +277,7 @@ fun ScoreStars(
   val hasHalfStar = (roundedScore - fullStars) >= 0.5
 
   Row(
+      verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(0.dp) // Smaller spacing between stars
       ) {
         for (i in 1..maxStars) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="card_screen_show_map">Show in Map</string>
     <string name="card_screen_add_review">Add A Review</string>
     <string name="card_screen_report">Report</string>
+    <string name="card_screen_no_image">No images for this parking yet</string>
+    <string name="free">Free</string>
 
     <!-- List Screen -->
     <string name="list_screen_protection">Protection</string>


### PR DESCRIPTION
## This PR is a duplicate of #157. It was meant to fix a problem, but is not needed anymore

### New UI
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8bfce507-e0b3-4269-9b3e-d929c19f119f">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/877fe64b-0280-4f95-88f3-dd36ae821b6b">

### Key changes
- Remove "Add Review" button
> This button does not really fit in this screen, and is better in the All Reviews Screen

- Display text when there are no images (and button to add one, currently displays toast)

- Rework paddings of different elements of the UI

- Replace "See all reviews" button by clickable text to make UI lighter


### Coverage
![image](https://github.com/user-attachments/assets/1a4d283c-8db1-471f-a897-a8920ce8cec9)

