### PR TITLE
fix: solve issue 167

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -12,7 +12,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-const val KMTOMETERS = 1000.0
+const val KM_TO_METERS = 1000.0
+const val DEFAULT_RADIUS = 100.0
+const val MAX_RADIUS = 1000.0
+const val RADIUS_INCREMENT = 100.0
 /**
  * ViewModel for the Parking feature.
  *
@@ -35,8 +38,18 @@ class ParkingViewModel(
   private val _selectedParking = MutableStateFlow<Parking?>(null)
   val selectedParking: StateFlow<Parking?> = _selectedParking
 
-  // Circle center and radius for the circle search for the list screen
-  private val _radius = MutableStateFlow(0.0)
+  /**
+   * Radius of the circle around the center to display parkings With a public getter to display the
+   * radius in the TopBar of the ListScreen The default value is DEFAULT_RADIUS stored in meters
+   */
+  private val _radius = MutableStateFlow(DEFAULT_RADIUS)
+  val radius: StateFlow<Double> = _radius
+
+  /**
+   * Center of the circle, normally corresponding to the user's location. When this is null, the
+   * filtering and sorting of parkings is not computing. Hence, we should make sure that this is
+   * null when in the map screen.
+   */
   private val _circleCenter = MutableStateFlow<Point?>(null)
   // List of tiles to display
   private var tilesToDisplay: Set<Tile> = emptySet()
@@ -44,28 +57,6 @@ class ParkingViewModel(
   private val tilesToParking =
       MutableStateFlow<LinkedHashMap<Tile, List<Parking>>>(LinkedHashMap(10, 1f, true))
 
-  init {
-    viewModelScope.launch {
-      /*
-         * When the list of parkings in the rectangle changes, update the list of closest parkings
-         * For this it uses the two states _circleCenter and _radius to filter the parkings
-
-      */
-      _rectParkings.collect { parkings ->
-        Log.d("ListScreen", "Updating closest Parkings:s")
-        if (_circleCenter.value == null) return@collect // Don't compute if the circle is not set
-        _closestParkings.value =
-            parkings
-                .filter { parking ->
-                  TurfMeasurement.distance(_circleCenter.value!!, parking.location.center) *
-                      KMTOMETERS <= _radius.value
-                }
-                .sortedBy { parking ->
-                  TurfMeasurement.distance(_circleCenter.value!!, parking.location.center)
-                }
-      }
-    }
-  }
   /**
    * Fetches the image URL from the cloud storage, This function as to be called after retrieving
    * the path from the Firestore database.
@@ -134,9 +125,12 @@ class ParkingViewModel(
             maxOf(startPos.latitude(), endPos.latitude()))
     // Get all tiles that are in the rectangle
     tilesToDisplay = Tile.getAllTilesInRectangle(bottomLeft, topRight)
+    // Used to keep track of when the last request has finished.
+    var nbRequestLeft = tilesToDisplay.size
     tilesToDisplay.forEach { tile ->
       if (tilesToParking.value.containsKey(tile)) {
         _rectParkings.value += tilesToParking.value[tile]!!
+        updateClosestParkings(--nbRequestLeft)
         return@forEach // Skip to the next tile if already fetched
       }
       tilesToParking.value[tile] = emptyList() // Avoid querying the same tile multiple times
@@ -146,21 +140,22 @@ class ParkingViewModel(
           { parkings ->
             tilesToParking.value[tile] = parkings
             _rectParkings.value += parkings
+            updateClosestParkings(--nbRequestLeft)
           },
           { Log.e("ParkingViewModel", "-- Error getting parkings: $it") })
     }
   }
 
   /**
-   * Get all parkings in a radius of k meters around a location. Uses the Haversine formula to
+   * Get all parkings in a radius of radius meters around a location. Uses the Haversine formula to
    * calculate the distance between two points on the Earth's surface. and make use of the
-   * getParkingBetween function to get all parkings in the circle.* The result is stored in the
+   * getParkingBetween function to get all parkings in the circle. The result is stored in the
    * closestParkings state.
    *
    * @param center: center of the circle
    * @param radius: radius of the circle in meter.
    */
-  fun getParkingsInRadius(
+  private fun getParkingsInRadius(
       center: Point,
       radius: Double,
   ) {
@@ -168,6 +163,23 @@ class ParkingViewModel(
     _circleCenter.value = center
     val (bottomLeft, topRight) = Tile.getSmallestRectangleEnclosingCircle(center, radius)
     getParkingsInRect(bottomLeft, topRight)
+  }
+
+  /**
+   * Increments the radius of the circle by RADIUS_INCREMENT if the new radius is less than
+   * MAX_RADIUS.
+   */
+  fun incrementRadius() {
+    if (_circleCenter.value == null || _radius.value == MAX_RADIUS) return
+    _radius.value += RADIUS_INCREMENT
+    getParkingsInRadius(_circleCenter.value!!, _radius.value)
+  }
+
+  /** set the center of the circle, and reset the radius to DEFAULT_RADIUS */
+  fun setCircleCenter(center: Point) {
+    _circleCenter.value = center
+    _radius.value = DEFAULT_RADIUS
+    getParkingsInRadius(center, DEFAULT_RADIUS)
   }
 
   fun getNewUid(): String {
@@ -187,6 +199,29 @@ class ParkingViewModel(
             .toInt() / 100.00
     parking.nbReviews += 1
     parkingRepository.updateParking(parking, {}, {})
+  }
+
+  /**
+   * Updates the list of closest parkings.
+   *
+   * @param nbRequestLeft: number of tiles left to fetch the parkings from. If nbRequestLeft is 0,
+   *   the function will update the closest parkings and if the result is empty, it will increment
+   *   the radius.
+   */
+  private fun updateClosestParkings(nbRequestLeft: Int) {
+    if (_circleCenter.value == null || nbRequestLeft != 0) return // avoid updating if not ready
+    _closestParkings.value =
+        _rectParkings.value
+            .filter { parking ->
+              TurfMeasurement.distance(_circleCenter.value!!, parking.location.center) *
+                  KM_TO_METERS <= _radius.value
+            }
+            .sortedBy { parking ->
+              TurfMeasurement.distance(_circleCenter.value!!, parking.location.center)
+            }
+    if (_closestParkings.value.isEmpty() || _radius.value == MAX_RADIUS) {
+      incrementRadius()
+    }
   }
 
   // create factory (imported from bootcamp)

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -16,6 +16,7 @@ const val KM_TO_METERS = 1000.0
 const val DEFAULT_RADIUS = 100.0
 const val MAX_RADIUS = 1000.0
 const val RADIUS_INCREMENT = 100.0
+const val MIN_NB_PARKINGS = 10
 /**
  * ViewModel for the Parking feature.
  *
@@ -261,7 +262,7 @@ class ParkingViewModel(
                       _selectedCapacities.value.contains(parking.capacity)) &&
                   (!_onlyWithCCTV.value || parking.hasSecurity)
             }
-    if (_closestParkings.value.size < 5 || _radius.value == MAX_RADIUS) {
+    if (_closestParkings.value.size < MIN_NB_PARKINGS || _radius.value == MAX_RADIUS) {
       incrementRadius()
     }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -147,7 +147,7 @@ fun FilterHeader(
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
           Text(
-              "All parkings in a radius of \n ${radius.value} m",
+              text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
               modifier = Modifier.weight(1f),
               style = MaterialTheme.typography.headlineMedium,
               color = MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -68,21 +68,12 @@ fun SpotListScreen(
 
   val referencePoint = TestInstancesParking.EPFLCenter
 
-  val parkingSpots by parkingViewModel.closestParkings.collectAsState()
+  val filteredParkingSpots by parkingViewModel.closestParkings.collectAsState()
 
-  var selectedProtection by remember { mutableStateOf<Set<ParkingProtection>>(emptySet()) }
-  var selectedRackTypes by remember { mutableStateOf<Set<ParkingRackType>>(emptySet()) }
-  var selectedCapacities by remember { mutableStateOf<Set<ParkingCapacity>>(emptySet()) }
-  var onlyWithCCTV by remember { mutableStateOf(false) }
-
-  // Filter the parking spots based on the selected attributes
-  val filteredParkingSpots =
-      parkingSpots.filter { parking ->
-        (selectedProtection.isEmpty() || selectedProtection.contains(parking.protection)) &&
-            (selectedRackTypes.isEmpty() || selectedRackTypes.contains(parking.rackType)) &&
-            (selectedCapacities.isEmpty() || selectedCapacities.contains(parking.capacity)) &&
-            (!onlyWithCCTV || parking.hasSecurity)
-      }
+  val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
+  val selectedRackTypes by parkingViewModel.selectedRackTypes.collectAsState()
+  val selectedCapacities by parkingViewModel.selectedCapacities.collectAsState()
+  val onlyWithCCTV by parkingViewModel.onlyWithCCTV.collectAsState()
 
   /**
    * Set the center of the circle in the ViewModel when the screen is launched. This should be
@@ -102,15 +93,18 @@ fun SpotListScreen(
               onAttributeSelected = { attribute ->
                 when (attribute) {
                   is ParkingProtection ->
-                      selectedProtection = toggleSelection(selectedProtection, attribute)
+                      parkingViewModel.setSelectedProtection(
+                          toggleSelection(selectedProtection, attribute))
                   is ParkingRackType ->
-                      selectedRackTypes = toggleSelection(selectedRackTypes, attribute)
+                      parkingViewModel.setSelectedRackTypes(
+                          toggleSelection(selectedRackTypes, attribute))
                   is ParkingCapacity ->
-                      selectedCapacities = toggleSelection(selectedCapacities, attribute)
+                      parkingViewModel.setSelectedCapacities(
+                          toggleSelection(selectedCapacities, attribute))
                 }
               },
               onlyWithCCTV = onlyWithCCTV,
-              onCCTVCheckedChange = { onlyWithCCTV = it },
+              onCCTVCheckedChange = { parkingViewModel.setOnlyWithCCTV(it) },
               parkingViewModel = parkingViewModel)
 
           val listState = rememberLazyListState()

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.ui.list
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -32,7 +31,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -69,7 +67,6 @@ fun SpotListScreen(
 ) {
 
   val referencePoint = TestInstancesParking.EPFLCenter
-  val radius = remember { mutableDoubleStateOf(100.0) }
 
   val parkingSpots by parkingViewModel.closestParkings.collectAsState()
 
@@ -87,12 +84,11 @@ fun SpotListScreen(
             (!onlyWithCCTV || parking.hasSecurity)
       }
 
-  // Fetch initial parkings if the list is empty
-  LaunchedEffect(Unit) {
-    if (parkingSpots.isEmpty()) {
-      parkingViewModel.getParkingsInRadius(referencePoint, radius.doubleValue)
-    }
-  }
+  /**
+   * Set the center of the circle in the ViewModel when the screen is launched. This should be
+   * linked to the user's location in the future.
+   */
+  LaunchedEffect(Unit) { parkingViewModel.setCircleCenter(referencePoint) }
 
   Scaffold(
       modifier = Modifier.testTag("SpotListScreen"),
@@ -114,7 +110,8 @@ fun SpotListScreen(
                 }
               },
               onlyWithCCTV = onlyWithCCTV,
-              onCCTVCheckedChange = { onlyWithCCTV = it })
+              onCCTVCheckedChange = { onlyWithCCTV = it },
+              parkingViewModel = parkingViewModel)
 
           val listState = rememberLazyListState()
           LazyColumn(
@@ -125,12 +122,9 @@ fun SpotListScreen(
                 items(items = filteredParkingSpots) { parking ->
                   val distance = TurfMeasurement.distance(referencePoint, parking.location.center)
                   SpotCard(navigationActions, parkingViewModel, parking, distance)
-                  Log.d("ListScreen", "Filtered parking spots: $filteredParkingSpots")
-                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1 &&
-                      radius.doubleValue < 1000) {
-                    // This incremental solution could be improved to be dynamic and with a limit
-                    radius.doubleValue += 100
-                    parkingViewModel.getParkingsInRadius(referencePoint, radius.doubleValue)
+                  // Increment the radius when the last parking spot is reached
+                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
+                    parkingViewModel.incrementRadius()
                   }
                 }
               }
@@ -145,21 +139,31 @@ fun FilterHeader(
     selectedCapacities: Set<ParkingCapacity>,
     onAttributeSelected: (ParkingAttribute) -> Unit,
     onlyWithCCTV: Boolean,
-    onCCTVCheckedChange: (Boolean) -> Unit
+    onCCTVCheckedChange: (Boolean) -> Unit,
+    parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
 ) {
   var showProtectionOptions by remember { mutableStateOf(false) }
   var showRackTypeOptions by remember { mutableStateOf(false) }
   var showCapacityOptions by remember { mutableStateOf(false) }
   var showFilters by remember { mutableStateOf(false) }
-
+  val radius = parkingViewModel.radius.collectAsState()
   Column(modifier = Modifier.padding(16.dp)) {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-      SmallFloatingActionButton(
-          onClick = { showFilters = !showFilters },
-          icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
-          contentDescription = "Filter",
-          testTag = "ShowFiltersButton")
-    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically) {
+          Text(
+              "All parkings in a radius of \n ${radius.value} m",
+              modifier = Modifier.weight(1f),
+              style = MaterialTheme.typography.headlineMedium,
+              color = MaterialTheme.colorScheme.onSurface)
+
+          SmallFloatingActionButton(
+              onClick = { showFilters = !showFilters },
+              icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
+              contentDescription = "Filter",
+              testTag = "ShowFiltersButton")
+        }
 
     if (showFilters) {
       FilterSection(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     <string name="list_screen_price">%.2f $</string>
     <string name="list_screen_rating">Rating: %.1f</string>
     <string name="list_screen_display_only_cctv">Only display parkings with CCTV camera</string>
+    <string name="all_parkings_radius">All parkings in a radius of \n %1$d m</string>
+
 
     <!-- Zoom Controls -->
     <string name="zoom_in">Zoom In</string>

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -11,7 +11,6 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
@@ -74,38 +73,5 @@ class ParkingViewModelTest {
     val parking = TestInstancesParking.parking2
     parkingViewModel.updateReviewScore(5.0, parking)
     assert(parking.avgScore == 5.0)
-  }
-  /*
-  This test simulates the repository returning multiple parkings, some out of the radius.
-    The test checks if the parkings returned are correctly sorted and filtered.
-    Note : Parkings have specific coordinates to ensure they are not on the edge of a tile.
-    Otherwise the repo would be called multiple times and the mokkito would each time return the same parkings.
-   */
-  @Test
-  fun getParkingsInRadiusNomainalCaseTest() {
-    `when`(parkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
-      it.getArgument<(List<Parking>) -> Unit>(2)(
-          listOf(
-              TestInstancesParking.parking4, // at 7.111, 47.111
-              TestInstancesParking.parking5 // at 7.112, 47.112
-              ))
-    }
-    parkingViewModel.getParkingsInRadius(TestInstancesParking.parking4.location.center, 10.0)
-    assertEquals(1, parkingViewModel.closestParkings.value.size)
-    assert(parkingViewModel.closestParkings.value.contains(TestInstancesParking.parking4))
-  }
-
-  /**
-   * This test simulates a circle overlapping multiples tiles and make sure all tiles are queried.
-   */
-  @Test
-  fun getParkingsInRadiusOverlappingTileTest() {
-    parkingViewModel.getParkingsInRadius(Point.fromLngLat(6.0, 46.0), 100.0)
-    verify(parkingRepository, times(4)).getParkingsBetween(any(), any(), any(), any())
-    // Must use another viewmodel otherwise repo is not called anymore because of the cache
-    val parkingViewModel2 = ParkingViewModel(imageRepository, parkingRepository)
-    clearInvocations(parkingRepository)
-    parkingViewModel2.getParkingsInRadius(Point.fromLngLat(6.05, 46.0), 100.0)
-    verify(parkingRepository, times(2)).getParkingsBetween(any(), any(), any(), any())
   }
 }


### PR DESCRIPTION
_Closes #167_

## Making the filter settings permanent 
By moving the states related to the filter selection in the viewmodel, the filter is now permanent.
That means if the user leaves and come back to the list Screen the filter is still in place

## Refactoring the way the parkings are fetched in ListScreen.
To address this bug and ensure the list screen is working in all cases, the interaction between the ListScreen (UI) and the Viewmodel has been re-thinked.
 
### Making `getParkingsInRadius` private 
It is not the role of the UI anymore to call `getParkingsInRadius`, instead the UI can performs two actions to change the list of parking it receives from the Viewmodel :
1. It can set the circle center with `setCircleCenter`. This has to be called when the screen is composed
2. It can request more parking when the user scrolled to the end with `incrementRadius`.

The role of increasing the radius if no parkings has been found has shifted from the UI to the viewmodel
-- -

### Changing the viewmodel internally
How the viewmodel gets the parking for the state `closestParkings` has been modified to resolve bug #167. 
This refactor also prevents spam requests from the UI to increase the radius multiple times without having the result of the first call. (Wanting to go from a radius 100m to 300m without having the result of radius 200m) 

#### How
- The hard to read `init {}` block has been removed and instead its functionality has been moved inside `updateClosestParkings`
- An argument `nbRequestLeft` has been added to the viewmodel to keep track of when there are currently request still loading
- `nbRequestLeft`. is used in `updateClosestParkings` to avoid useless computation. 


## Global summary of the process 
This graph shows the process of getting parkings, handled by the viewmodel, when the UI request more Parkings.
<img width="961" alt="image" src="https://github.com/user-attachments/assets/b95ab928-3548-4df0-8a0c-e44e71ffcbf3">

This graph shows the same process when the user loads the listScreen.
<img width="961" alt="image" src="https://github.com/user-attachments/assets/2779bde4-2605-4da0-9ace-60110321e78d">




-- -
### Displaying on the ListScreen the current radius 
Finally this PR adds a UI element to inform the user the radius of search. 
<img width="241" alt="image" src="https://github.com/user-attachments/assets/0f1932a8-9092-4f53-a5f9-1b7a76a4d354">
 
-- -



-- -
#### Code coverage
<img width="400" alt="image" src="https://github.com/user-attachments/assets/76ecf1a7-996c-4876-85f1-5cc63dafc2ba">

-- -
Known issue : 
- Switching to the list screen instantly when launching the app, increase the radius to its maximum. 



