### PR TITLE
Divide the user information into a public and a private part 

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
@@ -21,18 +21,18 @@ class MockUserRepository @Inject constructor() : UserRepository {
       onSuccess: (User) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (userId == "" || users.none { it.userId == userId })
+    if (userId == "" || users.none { it.public.userId == userId })
         onFailure(Exception("Error getting user"))
-    else onSuccess(users.find { it.userId == userId }!!)
+    else onSuccess(users.find { it.public.userId == userId }!!)
   }
 
   override fun getAllUsers(onSuccess: (List<User>) -> Unit, onFailure: (Exception) -> Unit) {
-    if (users.none { it.userId == "" }) onSuccess(users)
+    if (users.none { it.public.userId == "" }) onSuccess(users)
     else onFailure(Exception("Error getting users"))
   }
 
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    if (user.userId == "") onFailure(Exception("Error adding user"))
+    if (user.public.userId == "") onFailure(Exception("Error adding user"))
     else {
       users.add(user)
       onSuccess()
@@ -40,10 +40,10 @@ class MockUserRepository @Inject constructor() : UserRepository {
   }
 
   override fun updateUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    if (user.userId == "" || users.none { it.userId == user.userId })
+    if (user.public.userId == "" || users.none { it.public.userId == user.public.userId })
         onFailure(Exception("Error updating user"))
     else {
-      users.remove(users.find { it.userId == user.userId })
+      users.remove(users.find { it.public.userId == user.public.userId })
       users.add(user)
       onSuccess()
     }
@@ -54,10 +54,10 @@ class MockUserRepository @Inject constructor() : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (userId == "" || users.none { it.userId == userId })
+    if (userId == "" || users.none { it.public.userId == userId })
         onFailure(Exception("Error deleting user"))
     else {
-      users.remove(users.find { it.userId == userId })
+      users.remove(users.find { it.public.userId == userId })
       onSuccess()
     }
   }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
@@ -24,6 +24,7 @@ import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.addParking.attributes.AttributesPicker
 import com.github.se.cyrcle.ui.addParking.location.LocationPicker
@@ -87,7 +88,7 @@ class AddScreensNavigationTest {
       val userViewModel = list[3] as UserViewModel
       val mapViewModel = list[4] as MapViewModel
 
-      userViewModel.setCurrentUser(User(userId = "default", username = "sayMyName", email = ""))
+      userViewModel.setCurrentUser(User(UserPublic("default", "sayMyName", ""), null))
       MapScreen(navigationActions, parkingViewModel, userViewModel, mapViewModel)
     }
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("addButton"))

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -15,6 +15,8 @@ import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.model.user.UserDetails
+import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
@@ -48,12 +50,8 @@ class ViewProfileScreenTest {
 
     val user =
         User(
-            userId = "1",
-            username = "janesmith",
-            firstName = "Jane",
-            lastName = "Smith",
-            email = "jane.smith@example.com",
-            profilePictureUrl = "http://example.com/jane.jpg")
+            UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
+            UserDetails("Jane", "Smith", ""))
 
     userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -51,7 +51,7 @@ class ViewProfileScreenTest {
     val user =
         User(
             UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
-            UserDetails("Jane", "Smith", ""))
+            UserDetails("Jane", "Smith", "jane.smith@example.com"))
 
     userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)

--- a/app/src/main/java/com/github/se/cyrcle/model/user/TestInstancesUser.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/TestInstancesUser.kt
@@ -4,46 +4,39 @@ object TestInstancesUser {
 
   val user1 =
       User(
-          userId = "user1",
-          username = "john_doe",
-          firstName = "John",
-          lastName = "Doe",
-          email = "john.doe@example.com",
-          profilePictureUrl = "https://example.com/profile/john_doe.jpg",
-          favoriteParkings = listOf("Test_spot_1", "Test_spot_2"),
-          // homeAddress = "123 Main St, New York, NY",
-          // lastLoginTime = Timestamp(0,0), // Now using Timestamp
-          // accountCreationDate = Timestamp(0,0),
-          // numberOfContributedSpots = 5,
-          // userReputationScore = 120
-      )
+          public =
+              UserPublic(
+                  userId = "user1",
+                  username = "john_doe",
+                  profilePictureUrl = "https://example.com/profile/john_doe.jpg"),
+          details =
+              UserDetails(
+                  firstName = "John",
+                  lastName = "Doe",
+                  email = "john.doe@example.com",
+                  favoriteParkings = listOf("Test_spot_1", "Test_spot_2")))
 
   val newUser =
       User(
-          userId = "usr",
-          username = "new_user",
-          firstName = "New",
-          lastName = "User",
-          email = "newuser@example.com",
-          profilePictureUrl = "",
-          favoriteParkings = emptyList(),
-          // homeAddress = "123 Main St",
-          // lastLoginTime = Timestamp(0,0),
-          // accountCreationDate = Timestamp(0,0)
-      )
+          public = UserPublic(userId = "usr", username = "new_user", profilePictureUrl = ""),
+          details =
+              UserDetails(
+                  firstName = "New",
+                  lastName = "User",
+                  email = "newuser@example.com",
+                  favoriteParkings = emptyList()))
 
-  // Act: Update an existing user
   val updatedUser =
       User(
-          userId = "usr",
-          username = "updated_user",
-          firstName = "Updated",
-          lastName = "User",
-          email = "updateduser@example.com",
-          profilePictureUrl = "https://example.com/profile.png",
-          favoriteParkings = emptyList(),
-          // homeAddress = "456 Updated St",
-          // lastLoginTime = Timestamp(0,0),
-          // accountCreationDate = Timestamp(0,0)
-      )
+          public =
+              UserPublic(
+                  userId = "usr",
+                  username = "updated_user",
+                  profilePictureUrl = "https://example.com/profile.png"),
+          details =
+              UserDetails(
+                  firstName = "Updated",
+                  lastName = "User",
+                  email = "updateduser@example.com",
+                  favoriteParkings = emptyList()))
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
@@ -11,16 +11,25 @@ package com.github.se.cyrcle.model.user
  * @property profilePictureUrl URL of the profile picture of the user.
  * @property favoriteParkings List of unique identifiers of the user's favorite parkings.
  */
-data class User(
+data class UserPublic(
     val userId: String,
     val username: String,
+    val profilePictureUrl: String = "",
+    // val lastLoginTime: Timestamp? = null,
+    // val accountCreationDate: Timestamp? = null,
+    // val numberOfContributedSpots: Int = 0,
+    // val userReputationScore: Int = 0
+)
+
+data class UserDetails(
     val firstName: String = "",
     val lastName: String = "",
-    val email: String,
-    val profilePictureUrl: String = "",
+    val email: String = "",
     val favoriteParkings: List<String> = emptyList(),
     // val lastLoginTime: Timestamp? = null,
     // val accountCreationDate: Timestamp? = null,
     // val numberOfContributedSpots: Int = 0,
     // val userReputationScore: Int = 0
 )
+
+data class User(val public: UserPublic, val details: UserDetails?)

--- a/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
@@ -1,35 +1,42 @@
 package com.github.se.cyrcle.model.user
 
 /**
- * Data class representing a user.
+ * Data class representing the public information of a user.
  *
- * @property userId Unique identifier of the user.
- * @property username Username of the user.
- * @property firstName First name of the user.
- * @property lastName Last name of the user.
- * @property email Email of the user.
- * @property profilePictureUrl URL of the profile picture of the user.
- * @property favoriteParkings List of unique identifiers of the user's favorite parkings.
+ * @property userId The unique identifier of the user.
+ * @property username The username of the user.
+ * @property profilePictureUrl The path to the profile picture of the user on the cloud storage.
+ *   (Not implemented)
  */
 data class UserPublic(
     val userId: String,
     val username: String,
     val profilePictureUrl: String = "",
-    // val lastLoginTime: Timestamp? = null,
     // val accountCreationDate: Timestamp? = null,
     // val numberOfContributedSpots: Int = 0,
     // val userReputationScore: Int = 0
 )
 
+/**
+ * Data class representing the private information of a user.
+ *
+ * @property firstName The first name of the user.
+ * @property lastName The last name of the user.
+ * @property email The email of the user.
+ * @property favoriteParkings The list of favorite parkings of the user.
+ */
 data class UserDetails(
     val firstName: String = "",
     val lastName: String = "",
     val email: String = "",
     val favoriteParkings: List<String> = emptyList(),
     // val lastLoginTime: Timestamp? = null,
-    // val accountCreationDate: Timestamp? = null,
-    // val numberOfContributedSpots: Int = 0,
-    // val userReputationScore: Int = 0
 )
 
+/**
+ * Data class representing a user.
+ *
+ * @property public Public information of the user.
+ * @property details Private information of the user.
+ */
 data class User(val public: UserPublic, val details: UserDetails?)

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
@@ -6,7 +6,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import javax.inject.Inject
 
 class UserRepositoryFirestore
@@ -32,12 +31,18 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
         .document(userId)
         .get()
         .addOnSuccessListener { document ->
-          val user = document.data?.let { deserializeUser(it) }
-          if (user != null) {
-            onSuccess(user)
-          } else {
-            onFailure(Exception("User not found"))
-          }
+          val userPublic = deserializeUser(document.data!!)
+
+          db.collection(collectionPath)
+              .document(userId)
+              .collection("private")
+              .document("details")
+              .get()
+              .addOnSuccessListener { detailsDocument ->
+                val userDetails = deserializeUserDetails(detailsDocument.data!!)
+                onSuccess(User(userPublic, userDetails))
+              }
+          onSuccess(User(userPublic, null))
         }
         .addOnFailureListener { onFailure(it) }
   }
@@ -52,11 +57,10 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
     db.collection(collectionPath)
         .get()
         .addOnSuccessListener { querySnapshot ->
-          Log.d("UserRepositoryFirestore", "getAllUsers")
           val users =
               querySnapshot.documents.mapNotNull { document ->
-                Log.d("UserRepositoryFirestore", document.data.toString())
-                document.data?.let { deserializeUser(it) }
+                val userPublic = deserializeUser(document.data!!)
+                User(userPublic!!, null)
               }
           onSuccess(users)
         }
@@ -64,18 +68,51 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
   }
 
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    db.collection(collectionPath)
-        .document(user.userId)
-        .set(serializeUser(user))
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
+    if (user.details == null) {
+      onFailure(Exception("User details are required"))
+      return
+    }
+    db.collection(collectionPath).document(user.public.userId).get().addOnSuccessListener {
+      if (it.exists()) {
+        onSuccess()
+        return@addOnSuccessListener
+      } else {
+        db.collection(collectionPath)
+            .document(user.public.userId)
+            .set(user.public)
+            .addOnSuccessListener {
+              db.collection(collectionPath)
+                  .document(user.public.userId)
+                  .collection("private")
+                  .document("details")
+                  .set(user.details!!)
+                  .addOnSuccessListener { onSuccess() }
+                  .addOnFailureListener { onFailure(it) }
+            }
+            .addOnFailureListener { onFailure(it) }
+      }
+    }
   }
 
   override fun updateUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    Log.d("UserRepositoryFirestore", "updateUser: $user")
+    if (user.details == null) {
+      Log.d("UserRepositoryFirestore", "updateUser: user details are null, can't update")
+      onFailure(Exception("User details are required"))
+      return
+    }
     db.collection(collectionPath)
-        .document(user.userId)
-        .set(serializeUser(user))
-        .addOnSuccessListener { onSuccess() }
+        .document(user.public.userId)
+        .set(user.public)
+        .addOnSuccessListener {
+          db.collection(collectionPath)
+              .document(user.public.userId)
+              .collection("private")
+              .document("details")
+              .set(user.details!!)
+              .addOnSuccessListener { onSuccess() }
+              .addOnFailureListener { onFailure(it) }
+        }
         .addOnFailureListener { onFailure(it) }
   }
 
@@ -109,14 +146,13 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
   }
    */
 
-  private fun serializeUser(user: User): Map<String, Any> {
+  private fun deserializeUser(data: Map<String, Any>): UserPublic {
     val gson = Gson()
-    val type = object : TypeToken<Map<String, Any>>() {}.type
-    return gson.fromJson(gson.toJson(user), type)
+    return gson.fromJson(gson.toJson(data), UserPublic::class.java)
   }
 
-  private fun deserializeUser(data: Map<String, Any>): User {
+  private fun deserializeUserDetails(data: Map<String, Any>): UserDetails {
     val gson = Gson()
-    return gson.fromJson(gson.toJson(data), User::class.java)
+    return gson.fromJson(gson.toJson(data), UserDetails::class.java)
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.model.user
 
-import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
@@ -60,7 +59,7 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
           val users =
               querySnapshot.documents.mapNotNull { document ->
                 val userPublic = deserializeUser(document.data!!)
-                User(userPublic!!, null)
+                User(userPublic, null)
               }
           onSuccess(users)
         }
@@ -85,19 +84,17 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
                   .document(user.public.userId)
                   .collection("private")
                   .document("details")
-                  .set(user.details!!)
+                  .set(user.details)
                   .addOnSuccessListener { onSuccess() }
-                  .addOnFailureListener { onFailure(it) }
+                  .addOnFailureListener { exception -> onFailure(exception) }
             }
-            .addOnFailureListener { onFailure(it) }
+            .addOnFailureListener { exception -> onFailure(exception) }
       }
     }
   }
 
   override fun updateUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    Log.d("UserRepositoryFirestore", "updateUser: $user")
     if (user.details == null) {
-      Log.d("UserRepositoryFirestore", "updateUser: user details are null, can't update")
       onFailure(Exception("User details are required"))
       return
     }
@@ -109,7 +106,7 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
               .document(user.public.userId)
               .collection("private")
               .document("details")
-              .set(user.details!!)
+              .set(user.details)
               .addOnSuccessListener { onSuccess() }
               .addOnFailureListener { onFailure(it) }
         }

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImpl.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImpl.kt
@@ -107,7 +107,8 @@ class AuthenticatorImpl @Inject constructor(private val auth: FirebaseAuth) : Au
 
           val user =
               User(
-                  UserPublic(authResult.user!!.uid, authResult.user!!.displayName!!), UserDetails())
+                  UserPublic(authResult.user!!.uid, authResult.user!!.displayName!!),
+                  UserDetails(email = authResult.user!!.email!!))
 
           onAuthComplete(user)
         }

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImpl.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImpl.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.model.user.UserDetails
+import com.github.se.cyrcle.model.user.UserPublic
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -105,9 +107,7 @@ class AuthenticatorImpl @Inject constructor(private val auth: FirebaseAuth) : Au
 
           val user =
               User(
-                  userId = authResult.user?.uid ?: "",
-                  username = authResult.user?.displayName ?: "",
-                  email = authResult.user?.email ?: "")
+                  UserPublic(authResult.user!!.uid, authResult.user!!.displayName!!), UserDetails())
 
           onAuthComplete(user)
         }

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -42,12 +42,11 @@ fun SignInScreen(
   val successSignInMsg = stringResource(R.string.sign_in_successful_toast)
 
   val onAuthComplete = { user: User ->
-    Log.d("Cyrcle", "User signed in: ${user.username}")
     Toast.makeText(context, successSignInMsg, Toast.LENGTH_LONG).show()
 
     // TODO add checks if user is already exists
 
-    userViewModel.setCurrentUser(user)
+    userViewModel.addUser(user)
     navigationActions.navigateTo(TopLevelDestinations.MAP)
   }
   val onAuthFailure = { e: Exception ->

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -61,10 +61,10 @@ fun ViewProfileScreen(
 ) {
   val userState by userViewModel.currentUser.collectAsState()
   var isEditing by remember { mutableStateOf(false) }
-  var firstName by remember { mutableStateOf(userState?.firstName ?: "") }
-  var lastName by remember { mutableStateOf(userState?.lastName ?: "") }
-  var username by remember { mutableStateOf(userState?.username ?: "") }
-  var profilePictureUrl by remember { mutableStateOf(userState?.profilePictureUrl ?: "") }
+  var firstName by remember { mutableStateOf(userState?.details?.firstName ?: "") }
+  var lastName by remember { mutableStateOf(userState?.details?.lastName ?: "") }
+  var username by remember { mutableStateOf(userState?.public?.username ?: "") }
+  var profilePictureUrl by remember { mutableStateOf(userState?.public?.profilePictureUrl ?: "") }
 
   val imagePickerLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -101,18 +101,25 @@ fun ViewProfileScreen(
                       onSave = {
                         userViewModel.updateUser(
                             userState?.copy(
-                                firstName = firstName,
-                                lastName = lastName,
-                                username = username,
-                                profilePictureUrl = profilePictureUrl) ?: return@EditProfileContent)
-                        userViewModel.getUserById(userState?.userId ?: "")
+                                public =
+                                    userState
+                                        ?.public!!
+                                        .copy(
+                                            username = username,
+                                            profilePictureUrl = profilePictureUrl),
+                                details =
+                                    userState
+                                        ?.details
+                                        ?.copy(firstName = firstName, lastName = lastName))
+                                ?: return@EditProfileContent)
+                        userViewModel.getUserById(userState?.public!!.userId)
                         isEditing = false
                       },
                       onCancel = {
-                        firstName = userState?.firstName ?: ""
-                        lastName = userState?.lastName ?: ""
-                        username = userState?.username ?: ""
-                        profilePictureUrl = userState?.profilePictureUrl ?: ""
+                        firstName = userState?.details?.firstName ?: ""
+                        lastName = userState?.details?.lastName ?: ""
+                        username = userState?.public!!.username
+                        profilePictureUrl = userState?.public!!.profilePictureUrl
                         isEditing = false
                       })
                 } else {

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -64,9 +64,9 @@ fun AllReviewsScreen(
   val (selectedCardIndex, setSelectedCardIndex) = remember { mutableStateOf(-1) }
 
   val ownerHasReviewed =
-      if (userViewModel.currentUser.value?.userId != null) {
+      if (userViewModel.currentUser.value?.public?.userId != null) {
         reviewViewModel.parkingReviews.value.any {
-          it.owner == userViewModel.currentUser.value?.userId
+          it.owner == userViewModel.currentUser.value?.public?.userId
         }
       } else {
         false
@@ -98,7 +98,8 @@ fun AllReviewsScreen(
                           items(reviewViewModel.parkingReviews.value.size) { index ->
                             val curReview = reviewViewModel.parkingReviews.value[index]
                             userViewModel.getUserById(curReview.owner)
-                            val uidOfOwner = userViewModel.currentUser.value?.username ?: "none"
+                            val uidOfOwner =
+                                userViewModel.currentUser.value?.public?.username ?: "none"
                             if (index == selectedCardIndex) {
                               Box(
                                   modifier =
@@ -200,7 +201,7 @@ fun AllReviewsScreen(
                   }
             }
 
-        if (userViewModel.currentUser.value?.userId != null) {
+        if (userViewModel.currentUser.value?.public?.userId != null) {
           Box(
               modifier = Modifier.fillMaxSize().padding(16.dp),
               contentAlignment = Alignment.BottomEnd) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -56,18 +57,18 @@ fun ReviewScreen(
   reviewViewModel.getReviewsByParking(selectedParking.uid)
   val ownerHasReviewed =
       reviewViewModel.parkingReviews.value.any {
-        it.owner == userViewModel.currentUser?.value?.userId
+        it.owner == userViewModel.currentUser.value?.public?.userId
       }
   val matchingReview =
       reviewViewModel.parkingReviews.value.find {
-        it.owner == userViewModel.currentUser?.value?.userId
+        it.owner == userViewModel.currentUser.value?.public?.userId
       }
   if (matchingReview != null) {
     reviewViewModel.selectReview(matchingReview)
   }
 
   var sliderValue by remember {
-    mutableStateOf(if (ownerHasReviewed) matchingReview?.rating?.toFloat()!! else 0f)
+    mutableFloatStateOf(if (ownerHasReviewed) matchingReview?.rating?.toFloat()!! else 0f)
   }
   var textValue by remember { mutableStateOf(if (ownerHasReviewed) matchingReview?.text!! else "") }
 
@@ -137,7 +138,7 @@ fun ReviewScreen(
                           newScore = sliderToValue, parking = selectedParking, isNewReview = true)
                       reviewViewModel.addReview(
                           Review(
-                              owner = userViewModel.currentUser.value?.userId ?: "default",
+                              owner = userViewModel.currentUser.value?.public?.userId ?: "default",
                               text = textValue,
                               parking = selectedParking.uid,
                               rating = sliderToValue,
@@ -151,7 +152,7 @@ fun ReviewScreen(
 
                       reviewViewModel.updateReview(
                           Review(
-                              owner = userViewModel.currentUser.value?.userId ?: "default",
+                              owner = userViewModel.currentUser.value?.public?.userId ?: "default",
                               text = textValue,
                               parking = selectedParking.uid,
                               rating = sliderToValue,

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
@@ -89,7 +89,7 @@ class UserRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.toObject(User::class.java)).thenReturn(user)
 
     userRepositoryFirestore.getUserById(
-        userId = user.userId,
+        userId = user.public.userId,
         onSuccess = { assert(it == user) },
         onFailure = { fail("Expected success but got failure") })
     verify(timeout(100)) { mockDocumentReference.get() }
@@ -123,7 +123,7 @@ class UserRepositoryFirestoreTest {
     `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
 
     userRepositoryFirestore.deleteUserById(
-        userId = user.userId,
+        userId = user.public.userId,
         onSuccess = { assert(true) },
         onFailure = { fail("Expected success but got failure") })
     verify(mockDocumentReference).delete()

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
@@ -99,6 +99,8 @@ class UserRepositoryFirestoreTest {
   @Test
   fun addUser_callsOnSuccess() {
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
+    // simulate that the user already exists
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
 
     userRepositoryFirestore.addUser(
         user = user,

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserTest.kt
@@ -5,17 +5,6 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class UserTest {
-  @Test
-  fun testConstructor() {
-    val user = TestInstancesUser.user1
-    assertEquals("user1", user.userId)
-    assertEquals("john_doe", user.username)
-    assertEquals("John", user.firstName)
-    assertEquals("Doe", user.lastName)
-    assertEquals("john.doe@example.com", user.email)
-    assertEquals("https://example.com/profile/john_doe.jpg", user.profilePictureUrl)
-    assertEquals(listOf("Test_spot_1", "Test_spot_2"), user.favoriteParkings)
-  }
 
   @Test
   fun testEqualsAndHashCode() {

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -75,7 +75,11 @@ class UserViewModelTest {
     userViewModel.addFavoriteParkingToSelectedUser("Test_spot_3")
 
     // Create a copy of the user with the favorite parking added
-    val updatedUser = user.copy(favoriteParkings = user.favoriteParkings + "Test_spot_3")
+    val updatedUser =
+        user.copy(
+            details =
+                user.details?.copy(
+                    favoriteParkings = user.details!!.favoriteParkings + "Test_spot_3"))
 
     // Check if the favorite parking was added to the selected user
     verify(userRepository).updateUser(eq(updatedUser), any(), any())
@@ -91,7 +95,10 @@ class UserViewModelTest {
     userViewModel.getSelectedUserFavoriteParking()
     // Check if the favorite parkings were fetched from the repository
     verify(parkingRepository)
-        .getParkingsByListOfIds(eq(TestInstancesUser.user1.favoriteParkings.toList()), any(), any())
+        .getParkingsByListOfIds(
+            eq(TestInstancesUser.user1.details?.favoriteParkings?.toList()) ?: emptyList(),
+            any(),
+            any())
   }
 
   @Test
@@ -118,7 +125,11 @@ class UserViewModelTest {
     userViewModel.removeFavoriteParkingFromSelectedUser("Test_spot_1")
 
     // Create a copy of the user with the favorite parking removed
-    val updatedUser = user.copy(favoriteParkings = user.favoriteParkings - "Test_spot_1")
+    val updatedUser =
+        user.copy(
+            details =
+                user.details?.copy(
+                    favoriteParkings = user.details!!.favoriteParkings - "Test_spot_1"))
 
     // Check if the favorite parking was removed from the selected user
     verify(userRepository).updateUser(eq(updatedUser), any(), any())


### PR DESCRIPTION
_closes #181_
In preparation for #180 
### What
This PR refactors the user data class and the way user's informations are stored in the database.

### Why
Security rules in firestore only work on a document-level basis, access to specifc fields can't be restricted.
The only solution is to create a sub-collection of the user document with its private fields.

### How
The `User` data class is now just 2 fields : `UserPublic` and `UserDetails`, which are two data classs each containing all public/private field.

The repository, viewmodel and all code related to user's informations has been adapted for this changes.
The `UserDetails` class of a `user` instances is set to null when reading information of another user, this is handled by the repository. 


#### Other minor changes
- The user is added to the database on logged-in as opposed to when modifying his profile.
- The user can see his private details on the profile screen with peristence.
-- -
### [Updated Firestore rules](https://console.firebase.google.com/u/2/project/cyrcle-ab198/firestore/databases/-default-/rules)


-- -

![image](https://github.com/user-attachments/assets/3df63b1b-f9a3-4804-9ddc-ec483cfc040d)

