### PR TITLE
Text input verification

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -66,7 +67,7 @@ class AddScreensNavigationTest {
         addressViewModel,
         mockedAuthenticator,
         LocalContext.current as android.app.Activity)
-    return listOf<Any>(
+    return listOf(
         navigationActions,
         parkingViewModel,
         reviewViewModel,
@@ -133,6 +134,10 @@ class AddScreensNavigationTest {
       mapViewModel.updateLocation(Location(Point.fromLngLat(0.0, 0.0)))
       AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
     }
+
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("TitleInput"))
+    // Artificially set the title (otherwise the submit button is disabled)
+    composeTestRule.onNodeWithTag("TitleInput").assertExists().performTextInput("titleForParking")
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("submitButton"))
     // Perform click on the add button
     composeTestRule.onNodeWithTag("submitButton").performClick()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
@@ -135,9 +135,12 @@ class AddScreensNavigationTest {
       AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
     }
 
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("TitleInput"))
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("AttributesPickerTitle"))
     // Artificially set the title (otherwise the submit button is disabled)
-    composeTestRule.onNodeWithTag("TitleInput").assertExists().performTextInput("titleForParking")
+    composeTestRule
+        .onNodeWithTag("AttributesPickerTitle")
+        .assertExists()
+        .performTextInput("titleForParking")
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("submitButton"))
     // Perform click on the add button
     composeTestRule.onNodeWithTag("submitButton").performClick()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
@@ -75,7 +75,7 @@ class ReviewScreenTest {
     composeTestRule
         .onNodeWithTag("TopAppBarTitle")
         .assertIsDisplayed()
-        .assertTextContains("Add Your Review")
+        .assertTextContains("Add your review")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/ButtonTest.kt
@@ -33,7 +33,7 @@ class ButtonTest {
     var a = 1
     composeTestRule.setContent {
       Button("Button", { a++ })
-      Button("Button", { a++ }, Modifier, ColorLevel.PRIMARY, enabled, tag1)
+      Button("Button", { a++ }, Modifier, ColorLevel.PRIMARY, enabled.value, tag1)
     }
 
     composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/InputTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/InputTest.kt
@@ -1,9 +1,13 @@
 package com.github.se.cyrcle.ui.theme.atoms
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
@@ -48,5 +52,45 @@ class InputTest {
     composeTestRule.onNodeWithTag("${tag1}Text", true).assertIsDisplayed()
     composeTestRule.onNodeWithTag(tag1).performTextInput(expected)
     assertEquals(expected, text)
+  }
+
+  @Test
+  fun displayConditionCheckingInputText() {
+    val tag = "ConditionCheckingInputText"
+    val tag1 = "ConditionCheckingInputText1"
+    val expected = "Some text"
+    val text = mutableStateOf("")
+
+    composeTestRule.setContent {
+      ConditionCheckingInputText("Test", onValueChange = { newText -> text.value = newText })
+      ConditionCheckingInputText(
+          label = "Test",
+          onValueChange = { newText -> text.value = newText },
+          value = text.value,
+          minCharacters = 2,
+          maxCharacters = 10,
+          hasClearIcon = true,
+          testTag = tag1)
+    }
+
+    composeTestRule.onNodeWithTag(tag).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${tag}Text", true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(tag).performTextInput(expected)
+    assertEquals(expected, text.value)
+
+    text.value = ""
+    composeTestRule.onNodeWithTag(tag1).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${tag1}Text", true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(tag1).performTextInput(expected)
+    composeTestRule.onNodeWithTag("${tag1}ErrorRow").assertIsNotDisplayed()
+    assertEquals(expected, text.value)
+
+    composeTestRule.onNodeWithTag("${tag1}Clear").assertIsDisplayed().performClick()
+    assertEquals("", text.value)
+    // Check that the Error row is displayed and that the message is correct
+    composeTestRule
+        .onNodeWithTag("${tag1}Error")
+        .assertIsDisplayed()
+        .assertTextEquals("Minimum 2 characters required (current: 0)")
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/InputTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/atoms/InputTest.kt
@@ -25,7 +25,17 @@ class InputTest {
 
     composeTestRule.setContent {
       InputText("Test", onValueChange = { newText -> text = newText })
-      InputText("Test", Modifier, { newText -> text = newText }, text, false, 2, 1, tag1)
+      InputText(
+          "Test",
+          Modifier,
+          { newText -> text = newText },
+          text,
+          false,
+          2,
+          1,
+          hasClearIcon = false,
+          isError = false,
+          testTag = tag1)
     }
 
     composeTestRule.onNodeWithTag(tagD).assertIsDisplayed()

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -168,7 +168,7 @@ fun AttributesPicker(
                         modifier =
                             Modifier.fillMaxWidth()
                                 .padding(horizontal = horizontalPaddingScaleFactor),
-                        testTag = "TitleInput")
+                        testTag = "AttributesPickerTitle")
                     EnumDropDown(
                         options = ParkingProtection.entries.toList(),
                         selectedValue = protection,

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -56,7 +56,7 @@ import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.map.drawRectangles
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
-import com.github.se.cyrcle.ui.theme.atoms.InputText
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.molecules.BooleanRadioButton
 import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
 import com.mapbox.geojson.Point
@@ -68,6 +68,11 @@ import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
 import com.mapbox.maps.plugin.gestures.generated.GesturesSettings
+
+const val TITLE_MIN_LENGTH = 8
+const val TITLE_MAX_LENGTH = 48
+const val DESCRIPTION_MIN_LENGTH = 0
+const val DESCRIPTION_MAX_LENGTH = 128
 
 @Composable
 fun AttributesPicker(
@@ -89,7 +94,9 @@ fun AttributesPicker(
   val bottomBoxHeight = screenHeight * 0.15f // 15% of screen height for bottom box
 
   val title = remember { mutableStateOf("") }
+
   val description = remember { mutableStateOf("") }
+
   val rackType = remember { mutableStateOf<ParkingAttribute>(ParkingRackType.TWO_TIER) }
   val capacity = remember { mutableStateOf<ParkingAttribute>(ParkingCapacity.XSMALL) }
   val protection = remember { mutableStateOf<ParkingAttribute>(ParkingProtection.INDOOR) }
@@ -120,7 +127,11 @@ fun AttributesPicker(
   Scaffold(
       modifier = Modifier.testTag("AttributesPickerScreen"),
       topBar = { AttributePickerTopBar(mapViewModel, title) },
-      bottomBar = { BottomBarAddAttr(navigationActions) { onSubmit() } }) { padding ->
+      bottomBar = {
+        BottomBarAddAttr(navigationActions) {
+          if (areInputsValid(title.value, description.value)) onSubmit()
+        }
+      }) { padding ->
         // Apply screen-dimension-scaled padding for consistent spacing
         val scaledPaddingValues =
             scaledPadding(
@@ -148,14 +159,16 @@ fun AttributesPicker(
                               horizontal = horizontalPaddingScaleFactor,
                               vertical = verticalPaddingScaleFactor),
                   verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    InputText(
+                    ConditionCheckingInputText(
                         value = title.value,
                         onValueChange = { title.value = it },
                         label = stringResource(R.string.attributes_picker_title_label),
+                        minCharacters = TITLE_MIN_LENGTH,
+                        maxCharacters = TITLE_MAX_LENGTH,
                         modifier =
                             Modifier.fillMaxWidth()
                                 .padding(horizontal = horizontalPaddingScaleFactor),
-                        testTag = "AttributesPickerTitle")
+                        testTag = "TitleInput")
                     EnumDropDown(
                         options = ParkingProtection.entries.toList(),
                         selectedValue = protection,
@@ -174,13 +187,12 @@ fun AttributesPicker(
                         question =
                             stringResource(R.string.attributes_picker_has_surveillance_question),
                         hasSecurity)
-                    InputText(
+                    ConditionCheckingInputText(
                         value = description.value,
-                        label = stringResource(R.string.attributes_picker_description_label),
                         onValueChange = { description.value = it },
-                        singleLine = false,
-                        minLines = 3,
-                        maxLines = 5,
+                        label = stringResource(R.string.attributes_picker_description_label),
+                        minCharacters = DESCRIPTION_MIN_LENGTH,
+                        maxCharacters = DESCRIPTION_MAX_LENGTH,
                         modifier =
                             Modifier.fillMaxWidth()
                                 .height(screenHeight * 0.2f) // Dynamic height for description field
@@ -332,4 +344,9 @@ fun AttributePickerTopBar(mapViewModel: MapViewModel, title: MutableState<String
         }
         drawRectangles(annotationManager, listOf(location))
       }
+}
+
+private fun areInputsValid(title: String, description: String): Boolean {
+  return title.length in TITLE_MIN_LENGTH..TITLE_MAX_LENGTH &&
+      description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -42,9 +42,16 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
-import com.github.se.cyrcle.ui.theme.atoms.InputText
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
+
+const val FIRST_NAME_MIN_LENGTH = 0
+const val FIRST_NAME_MAX_LENGTH = 32
+const val LAST_NAME_MIN_LENGTH = 0
+const val LAST_NAME_MAX_LENGTH = 32
+const val USERNAME_MIN_LENGTH = 4
+const val USERNAME_MAX_LENGTH = 32
 
 @Composable
 fun ViewProfileScreen(
@@ -142,26 +149,32 @@ private fun EditProfileContent(
 
   Spacer(modifier = Modifier.height(24.dp))
 
-  InputText(
+  ConditionCheckingInputText(
       value = firstName,
       onValueChange = onFirstNameChange,
       label = stringResource(R.string.view_profile_screen_first_name_label),
+      minCharacters = FIRST_NAME_MIN_LENGTH,
+      maxCharacters = FIRST_NAME_MAX_LENGTH,
       testTag = "FirstNameField")
 
   Spacer(modifier = Modifier.height(8.dp))
 
-  InputText(
+  ConditionCheckingInputText(
       value = lastName,
       onValueChange = onLastNameChange,
       label = stringResource(R.string.view_profile_screen_last_name_label),
+      minCharacters = LAST_NAME_MIN_LENGTH,
+      maxCharacters = LAST_NAME_MAX_LENGTH,
       testTag = "LastNameField")
 
   Spacer(modifier = Modifier.height(8.dp))
 
-  InputText(
+  ConditionCheckingInputText(
       value = username,
       onValueChange = onUsernameChange,
       label = stringResource(R.string.view_profile_screen_username_label),
+      minCharacters = USERNAME_MIN_LENGTH,
+      maxCharacters = USERNAME_MAX_LENGTH,
       testTag = "UsernameField")
 
   Spacer(modifier = Modifier.height(16.dp))
@@ -171,6 +184,7 @@ private fun EditProfileContent(
         text = stringResource(R.string.view_profile_screen_save_button),
         onClick = onSave,
         colorLevel = ColorLevel.PRIMARY,
+        enabled = areInputsValid(firstName, lastName, username),
         testTag = "SaveButton")
 
     Button(
@@ -179,6 +193,12 @@ private fun EditProfileContent(
         colorLevel = ColorLevel.SECONDARY,
         testTag = "CancelButton")
   }
+}
+
+fun areInputsValid(firstName: String, lastName: String, username: String): Boolean {
+  return firstName.length in FIRST_NAME_MIN_LENGTH..FIRST_NAME_MAX_LENGTH &&
+      lastName.length in LAST_NAME_MIN_LENGTH..LAST_NAME_MAX_LENGTH &&
+      username.length in USERNAME_MIN_LENGTH..USERNAME_MAX_LENGTH
 }
 
 @Composable

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.runtime.Composable
@@ -33,9 +32,13 @@ import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+
+const val REVIEW_MIN_LENGTH = 0
+const val REVIEW_MAX_LENGTH = 256
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
@@ -74,7 +77,8 @@ fun ReviewScreen(
       topBar = {
         TopAppBar(
             navigationActions = navigationActions,
-            if (ownerHasReviewed) "Edit Your Review" else "Add Your Review")
+            if (ownerHasReviewed) stringResource(R.string.review_screen_title_edit_review)
+            else stringResource(R.string.review_screen_title_new_review))
       }) { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp),
@@ -109,18 +113,20 @@ fun ReviewScreen(
 
               Spacer(modifier = Modifier.height(16.dp))
 
-              // OutlinedTextField for text input
-              OutlinedTextField(
-                  value = textValue,
+              ConditionCheckingInputText(
+                  label = stringResource(R.string.review_screen_write_review_label),
                   onValueChange = { newText -> textValue = newText },
-                  label = { Text("Write your review") },
-                  modifier = Modifier.fillMaxWidth().testTag("ReviewInput"))
+                  value = textValue,
+                  minCharacters = REVIEW_MIN_LENGTH,
+                  maxCharacters = REVIEW_MAX_LENGTH,
+                  hasClearIcon = true,
+                  testTag = "ReviewInput")
 
               Spacer(modifier = Modifier.height(16.dp))
 
               // Add Review Button
               Button(
-                  text = "Save my Review",
+                  text = stringResource(R.string.review_screen_submit_button),
                   onClick = {
                     Toast.makeText(context, "Review Added!", Toast.LENGTH_SHORT).show()
                     // to avoid problematic castings
@@ -153,6 +159,7 @@ fun ReviewScreen(
                     }
                     navigationActions.goBack()
                   },
+                  enabled = textValue.length in REVIEW_MIN_LENGTH..REVIEW_MAX_LENGTH,
                   modifier = Modifier.fillMaxWidth().height(60.dp),
                   colorLevel = ColorLevel.PRIMARY,
                   testTag = "AddReviewButton")

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Button.kt
@@ -20,8 +20,6 @@ import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -168,14 +166,14 @@ fun Button(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     colorLevel: ColorLevel = ColorLevel.PRIMARY,
-    enabled: State<Boolean> = mutableStateOf(true),
+    enabled: Boolean = true,
     testTag: String = "Button"
 ) {
   Button(
-      onClick = { if (enabled.value) onClick() },
+      onClick = { if (enabled) onClick() },
       modifier = modifier.testTag(testTag),
       colors = getButtonColors(colorLevel),
-      enabled = enabled.value) {
+      enabled = enabled) {
         Text(text, Modifier.testTag("${testTag}Text"))
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
@@ -124,9 +124,9 @@ fun ConditionCheckingInputText(
             Text(
                 text =
                     if (value.length < minCharacters) {
-                      stringResource(R.string.input_min_characters, minCharacters)
+                      stringResource(R.string.input_min_characters, minCharacters, value.length)
                     } else {
-                      stringResource(R.string.input_max_characters, maxCharacters)
+                      stringResource(R.string.input_max_characters, maxCharacters, value.length)
                     },
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
@@ -1,10 +1,23 @@
 package com.github.se.cyrcle.ui.theme.atoms
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.WarningAmber
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
 
 /**
  * Create a themed `OutlinedTextField`, with simplified arguments. The value contained in the text
@@ -21,6 +34,7 @@ import androidx.compose.ui.platform.testTag
  * @param singleLine Boolean indicating if the text field should only contain one line.
  * @param maxLines If not single line, contains the field within a maximum line number.
  * @param minLines The minimal number of lines that should be displayed at the same time.
+ * @param hasClearIcon Boolean indicating if the field should have an icon to clear the text.
  * @param testTag The test tag of the object.
  */
 @Composable
@@ -32,6 +46,8 @@ fun InputText(
     singleLine: Boolean = true,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
+    hasClearIcon: Boolean = true,
+    isError: Boolean = false,
     testTag: String = "InputText"
 ) {
   OutlinedTextField(
@@ -42,5 +58,81 @@ fun InputText(
       singleLine = singleLine,
       maxLines = maxLines,
       minLines = minLines,
-  )
+      isError = isError,
+      trailingIcon = {
+        if (hasClearIcon && value.isNotEmpty()) {
+          Icon(
+              imageVector = Icons.Filled.Close,
+              contentDescription = "Clear",
+              modifier = Modifier.clickable { onValueChange("") }.testTag("${testTag}Clear"))
+        }
+      })
+}
+
+/**
+ * Create a themed `OutlinedTextField` with a condition checking the input. The value contained in
+ * the text field must be declared as follow before calling this function :
+ * ```
+ * var text by remember { mutableStateOf("InitialText") }
+ * ConditionCheckingInputText(
+ *     onValueChange = { newText -> text = newText },
+ *     value = text)
+ * ```
+ *
+ * @param label The label of the field.
+ * @param value The initial text that the field should contain.
+ * @param onValueChange The function to update your mutable variable. Will often be `{ newText ->
+ *   yourMutableVariable = newText }`.
+ * @param minCharacters The minimum number of characters that the input should contain.
+ * @param maxCharacters The maximum number of characters that the input should contain.
+ * @param hasClearIcon Boolean indicating if the field should have an icon to clear the text.
+ * @param testTag The test tag of the object.
+ */
+@Composable
+fun ConditionCheckingInputText(
+    label: String,
+    modifier: Modifier = Modifier,
+    onValueChange: (String) -> Unit,
+    value: String = "",
+    minCharacters: Int = 0,
+    maxCharacters: Int = Int.MAX_VALUE,
+    hasClearIcon: Boolean = true,
+    testTag: String = "InputText"
+) {
+  Column {
+    val isError = value.length !in minCharacters..maxCharacters
+    InputText(
+        label = label,
+        modifier = modifier,
+        onValueChange = onValueChange,
+        value = value,
+        singleLine = false,
+        hasClearIcon = hasClearIcon,
+        testTag = testTag,
+        isError = isError)
+    // Display error message below the text field if the input is not valid
+    if (isError) {
+      Row(
+          modifier = Modifier.padding(start = 16.dp, top = 4.dp),
+          verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Filled.WarningAmber,
+                contentDescription = "Error",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text =
+                    if (value.length < minCharacters) {
+                      stringResource(R.string.input_min_characters, minCharacters)
+                    } else {
+                      stringResource(R.string.input_max_characters, maxCharacters)
+                    },
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 4.dp),
+                testTag = "${testTag}Error")
+          }
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
@@ -97,7 +97,7 @@ fun ConditionCheckingInputText(
     minCharacters: Int = 0,
     maxCharacters: Int = Int.MAX_VALUE,
     hasClearIcon: Boolean = true,
-    testTag: String = "InputText"
+    testTag: String = "ConditionCheckingInputText"
 ) {
   Column {
     val isError = value.length !in minCharacters..maxCharacters
@@ -113,7 +113,7 @@ fun ConditionCheckingInputText(
     // Display error message below the text field if the input is not valid
     if (isError) {
       Row(
-          modifier = Modifier.padding(start = 16.dp, top = 4.dp),
+          modifier = Modifier.padding(start = 16.dp, top = 4.dp).testTag("${testTag}ErrorRow"),
           verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.Filled.WarningAmber,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,8 +17,8 @@
     </plurals>
 
     <!-- Error Messages -->
-    <string name="input_min_characters">Minimum %1$d characters required</string>
-    <string name="input_max_characters">Maximum %1$d characters allowed</string>
+    <string name="input_min_characters">Minimum %1$d characters required (current: %2$d)</string>
+    <string name="input_max_characters">Maximum %1$d characters allowed (current: %2$d)</string>
 
     <!-- Attributes Picker -->
     <string name="attributes_picker_title_label">Title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,10 @@
         <item quantity="other">(%d reviews)</item>
     </plurals>
 
+    <!-- Error Messages -->
+    <string name="input_min_characters">Minimum %1$d characters required</string>
+    <string name="input_max_characters">Maximum %1$d characters allowed</string>
+
     <!-- Attributes Picker -->
     <string name="attributes_picker_title_label">Title</string>
     <string name="attributes_picker_protection_label">How protected from the weather is the spot?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,7 +111,8 @@
     <string name="all_review_text">Text: %s</string>
 
     <!-- Review Screen -->
-    <string name="review_screen_title">Add Your Review</string>
+    <string name="review_screen_title_new_review">Add your review</string>
+    <string name="review_screen_title_edit_review">Edit your review</string>
     <string name="review_screen_terrible_review">Terrible experience >:(</string>
     <string name="review_screen_poor_review">Poor experience :(</string>
     <string name="review_screen_bad_review">Bad experience :/</string>
@@ -120,8 +121,8 @@
     <string name="review_screen_great_review">Great experience :D</string>
     <string name="review_screen_rating">Rating: %.1f</string>
     <string name="review_screen_write_review_label">Write your review</string>
-    <string name="review_screen_submit_button">Save my Review</string>
-    <string name="review_screen_submit_button_toast">Review Added!</string>
+    <string name="review_screen_submit_button">Save my review</string>
+    <string name="review_screen_submit_button_toast">Review added!</string>
     <string name="review_screen_default_review_owner">default</string>
 
     <!-- TopAppBar -->


### PR DESCRIPTION
### Key changes
Introduced a new atom component called ConditionCheckingInputText. This component:
- Wraps the existing InputText component
- Validates input's length against given bounds
- Displays an appropriate error message for invalid input

The InputText component has been enhanced with the following features:
- isError argument: Highlights the input field in red if validation fails
- hasClearIcon argument: When true, displays a button to clear the user's input

The new ConditionCheckingInputText has been integrated into relevant screens
"Save" and "Submit" buttons are now disabled when input validation fails
The affected screens are
- AttributePicker
- EditProfile
- AddReview

No error vs with error:

<img width="250" alt="image" src="https://github.com/user-attachments/assets/7ac6dea0-f4e9-4ecc-809a-58e25c4642b9">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/02817760-d024-4fcb-8938-3654faeeeb95">

### Coverage
![image](https://github.com/user-attachments/assets/0d3eb337-a06e-49d9-8ea2-d27573170a73)


