### PR TITLE
Ensure synchronisation between the Viewmodel and the UI

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
@@ -32,11 +32,11 @@ class AllReviewsScreenTest {
 
   @Before
   fun setUp() {
-    parkingViewModel.selectParking(TestInstancesParking.parking2)
     reviewViewModel.addReview(TestInstancesReview.review4)
     reviewViewModel.addReview(TestInstancesReview.review3)
     reviewViewModel.addReview(TestInstancesReview.review2)
     reviewViewModel.addReview(TestInstancesReview.review1)
+    parkingViewModel.selectParking(TestInstancesParking.parking2)
   }
 
   @Test
@@ -45,7 +45,6 @@ class AllReviewsScreenTest {
     composeTestRule.setContent {
       AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
       userViewModel.setCurrentUser(TestInstancesUser.user1)
-      parkingViewModel.selectParking(TestInstancesParking.parking1)
     }
 
     composeTestRule.onNodeWithTag("AllReviewsScreenBox").assertIsDisplayed()
@@ -57,8 +56,6 @@ class AllReviewsScreenTest {
   fun clickingReviewCard_expandsAndCollapsesCard() {
     composeTestRule.setContent {
       AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
-      userViewModel.setCurrentUser(TestInstancesUser.user1)
-      parkingViewModel.selectParking(TestInstancesParking.parking1)
     }
 
     composeTestRule.onNodeWithTag("ReviewCard0").performClick()
@@ -75,7 +72,6 @@ class AllReviewsScreenTest {
     composeTestRule.setContent {
       AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
       userViewModel.setCurrentUser(TestInstancesUser.user1)
-      parkingViewModel.selectParking(TestInstancesParking.parking1)
     }
 
     composeTestRule.onNodeWithTag("ReviewCard1").performClick()

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -238,7 +238,14 @@ class ParkingViewModel(
           (100 * ((parking.avgScore * parking.nbReviews) + newScore) / (parking.nbReviews + 1))
               .toInt() / 100.00
       parking.nbReviews += 1
-      parkingRepository.updateParking(parking, {}, {})
+      parkingRepository.updateParking(
+          parking,
+          {
+            val tile = Tile.getTileFromPoint(parking.location.center)
+            tilesToParking.value[tile] =
+                tilesToParking.value[tile]!!.map { p -> if (p.uid == parking.uid) parking else p }
+          },
+          {})
     } else {
       val delta = if (parking.nbReviews != 0) (oldScore - newScore) / parking.nbReviews else 0.0
       parking.avgScore += delta

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -242,8 +242,10 @@ class ParkingViewModel(
           parking,
           {
             val tile = Tile.getTileFromPoint(parking.location.center)
-            tilesToParking.value[tile] =
-                tilesToParking.value[tile]!!.map { p -> if (p.uid == parking.uid) parking else p }
+            if (tilesToParking.value[tile] != null) {
+              tilesToParking.value[tile] =
+                  tilesToParking.value[tile]!!.map { p -> if (p.uid == parking.uid) parking else p }
+            }
           },
           {})
     } else {

--- a/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
@@ -43,6 +43,14 @@ class ReviewViewModel(private val reviewRepository: ReviewRepository) : ViewMode
         { Log.e("ReviewViewModel", "Error getting reviews", it) })
   }
 
+  /**
+   * Reset the selectedReview This is to prevent old review from being shown while the new spots
+   * review are being fetched
+   */
+  fun clearReviews() {
+    _parkingReviews.value = emptyList()
+  }
+
   // create factory (imported from bootcamp)
   companion object {
     val Factory: ViewModelProvider.Factory =

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.user
 
+import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
@@ -30,7 +31,15 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
         .document(userId)
         .get()
         .addOnSuccessListener { document ->
-          val userPublic = deserializeUser(document.data!!)
+          val userPublic: UserPublic =
+              try {
+                Log.d("UserRepositoryFirestore", " Correctly fetched UserPublic")
+                deserializeUserPublic(document.data!!)
+              } catch (e: Exception) {
+                Log.d("UserRepositoryFirestore", "Error fetching UserPublic")
+                onFailure(e)
+                return@addOnSuccessListener
+              }
 
           db.collection(collectionPath)
               .document(userId)
@@ -41,7 +50,7 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
                 val userDetails = deserializeUserDetails(detailsDocument.data!!)
                 onSuccess(User(userPublic, userDetails))
               }
-              .addOnFailureListener(onFailure)
+              .addOnFailureListener { onSuccess(User(userPublic, null)) }
         }
         .addOnFailureListener(onFailure)
   }
@@ -58,7 +67,7 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
         .addOnSuccessListener { querySnapshot ->
           val users =
               querySnapshot.documents.mapNotNull { document ->
-                val userPublic = deserializeUser(document.data!!)
+                val userPublic = deserializeUserPublic(document.data!!)
                 User(userPublic, null)
               }
           onSuccess(users)
@@ -147,7 +156,7 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
   }
    */
 
-  private fun deserializeUser(data: Map<String, Any>): UserPublic {
+  private fun deserializeUserPublic(data: Map<String, Any>): UserPublic {
     val gson = Gson()
     return gson.fromJson(gson.toJson(data), UserPublic::class.java)
   }

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
@@ -50,6 +50,13 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
                 val userDetails = deserializeUserDetails(detailsDocument.data!!)
                 onSuccess(User(userPublic, userDetails))
               }
+              /*
+              We still call onSuccess even if the request to get the user's private information fails.
+              This happens when trying to get the information of a user that is not the current user.
+              The user's public information is still useful to have. i.e when loading the reviewer's name in a review.
+              Another solution would be to make two separate function, one for the public information and one for the private information.
+              but this seems easier and robust.
+              */
               .addOnFailureListener { onSuccess(User(userPublic, null)) }
         }
         .addOnFailureListener(onFailure)

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -55,6 +55,25 @@ class UserViewModel(
   }
 
   /**
+   * Gets a user by ID from the Firestore database and calls the onSuccess callback with the user.
+   *
+   * @param userId the ID of the user to get
+   * @param onSuccess the callback to call with the user
+   */
+  fun getUserById(userId: String, onSuccess: (User) -> Unit) {
+    Log.d("UserViewModel", "Getting user by ID: $userId")
+    userRepository.getUserById(
+        userId,
+        onSuccess = { onSuccess(it) },
+        onFailure = { exception ->
+          Log.e(
+              "com.github.se.cyrcle.model.user.UserViewModel",
+              "Failed to fetch user by ID: $userId",
+              exception)
+        })
+  }
+
+  /**
    * Adds a user to the Firestore database.
    *
    * @param user the user to add

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -61,7 +61,6 @@ class UserViewModel(
    * @param onSuccess the callback to call with the user
    */
   fun getUserById(userId: String, onSuccess: (User) -> Unit) {
-    Log.d("UserViewModel", "Getting user by ID: $userId")
     userRepository.getUserById(
         userId,
         onSuccess = { onSuccess(it) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="all_review_title">All Reviews For %s</string>
     <string name="all_review_rating">Rating: %.1f</string>
     <string name="all_review_text">Text: %s</string>
+    <string name="undefined_username">Unknown user</string>
 
     <!-- Review Screen -->
     <string name="review_screen_title_new_review">Add your review</string>

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -58,6 +58,17 @@ class UserViewModelTest {
     // Check if the user was fetched from the repository
     verify(userRepository).getUserById(eq("user1"), any(), any())
   }
+  // Check that the user returned is the correct one
+  // and that onSuccess is called.
+  @Test
+  fun getUserBydWithCallbackTest() {
+    `when`(userRepository.getUserById(any(), any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.arguments[1] as (User) -> Unit
+      onSuccess(TestInstancesUser.user1)
+    }
+    userViewModel.getUserById("user1") { assert(it == TestInstancesUser.user1) }
+    verify(userRepository).getUserById(eq("user1"), any(), any())
+  }
 
   @Test
   fun updateUserTest() {


### PR DESCRIPTION
_closes #180_
_closes #183_
_closes #184_

### This PR addresses multiples bugs causing the UI to be out of sync with the data.
See the issue for more information about the issue that it fixes. 

## How
### Fixing #180
A state has been introduced that holds the string of the username of the review's owner.
This state has a default value of "Unknown user" and is updated when the backend is done fetching the username.
The review depend on this state, hence it is recomposed when the request terminates. 

This fix also prevent the viewmodel from overwritting the currentUser state, which holds the logged-in user, with the result of the query. This is done by overloading the function of the viewmodel with another version that does not replace the currentUser value


### Fixing #183 
Lifting the state outside the lazyColomn fixes this issue. 
The lazyColomn is now recomposed every time the state is updated.

### Fixing #184
To fix this, the function of the viewmodel that updatesTheReviewScore now also update the cache and not only the database.
Keeping the cache in sync with the data.


-- - 
![image](https://github.com/user-attachments/assets/ce42f3ee-0128-4e92-aa18-ea881005533d)

