### PR TITLE
Feature parking size verification

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -31,6 +31,9 @@ class MapViewModel : ViewModel() {
   private val _isTrackingModeEnable = MutableStateFlow(true)
   val isTrackingModeEnable: StateFlow<Boolean> = _isTrackingModeEnable
 
+  private val _isAreaTooLarge: MutableStateFlow<Boolean> = MutableStateFlow(false)
+  val isAreaTooLarge: StateFlow<Boolean> = _isAreaTooLarge
+
   /**
    * Update the state of the location picker, This state is used to determine which steps of the
    * process to set the new location are completed
@@ -140,6 +143,16 @@ class MapViewModel : ViewModel() {
       this.enabled = true
       this.locationPuck = createDefault2DPuck(true)
     }
+  }
+
+  /**
+   * Update the isAreaTooLarge state
+   *
+   * @param isAreaTooLarge the new state of the area This function is used to store the state of the
+   *   area when the user is selecting a parking area
+   */
+  fun updateIsAreaTooLarge(isAreaTooLarge: Boolean) {
+    _isAreaTooLarge.value = isAreaTooLarge
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -3,6 +3,7 @@ package com.github.se.cyrcle.model.map
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.cyrcle.model.parking.Location
+import com.github.se.cyrcle.model.parking.PARKING_MAX_AREA
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraState
@@ -99,6 +100,15 @@ class MapViewModel : ViewModel() {
   }
 
   /**
+   * Update the isAreaTooLarge state
+   *
+   * @param area the area of the selected parking
+   */
+  fun updateIsAreaTooLarge(area: Double) {
+    _isAreaTooLarge.value = area > PARKING_MAX_AREA
+  }
+
+  /**
    * Get the bottom left and top right corners of the screen in latitude and longitude coordinates.
    * The corners are calculated based on the center of the screen and the viewport dimensions. If
    * useBuffer is true, the corners are calculated with a buffer of 2x the viewport dimensions. This
@@ -143,16 +153,6 @@ class MapViewModel : ViewModel() {
       this.enabled = true
       this.locationPuck = createDefault2DPuck(true)
     }
-  }
-
-  /**
-   * Update the isAreaTooLarge state
-   *
-   * @param isAreaTooLarge the new state of the area This function is used to store the state of the
-   *   area when the user is selecting a parking area
-   */
-  fun updateIsAreaTooLarge(isAreaTooLarge: Boolean) {
-    _isAreaTooLarge.value = isAreaTooLarge
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
@@ -2,6 +2,8 @@ package com.github.se.cyrcle.model.parking
 
 import com.github.se.cyrcle.ui.theme.molecules.DropDownableEnum
 import com.mapbox.geojson.Point
+import com.mapbox.geojson.Polygon
+import com.mapbox.turf.TurfMeasurement
 
 /**
  * Data class representing a parking spot.
@@ -70,6 +72,26 @@ data class Location(
     val bottomLeft: Point?,
     val bottomRight: Point?,
 ) {
+
+  /**
+   * Convert the location to a polygon.
+   *
+   * @return The polygon representing the location.
+   */
+  private fun toPolygon(): Polygon {
+    return Polygon.fromLngLats(listOf(listOf(topLeft, topRight, bottomRight, bottomLeft, topLeft)))
+  }
+
+  /**
+   * Compute the area of the location in square meters. The area is computed using the Turf
+   * Measurement library.
+   *
+   * @return The area of the location in square meters.
+   */
+  fun computeArea(): Double {
+    return TurfMeasurement.area(toPolygon())
+  }
+
   constructor(
       topLeft: Point,
       topRight: Point,

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -7,16 +7,19 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.mapbox.geojson.Point
+import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-const val KM_TO_METERS = 1000.0
 const val DEFAULT_RADIUS = 100.0
 const val MAX_RADIUS = 1000.0
 const val RADIUS_INCREMENT = 100.0
 const val MIN_NB_PARKINGS = 10
+
+const val PARKING_MAX_AREA = 1000.0
+
 /**
  * ViewModel for the Parking feature.
  *
@@ -266,8 +269,9 @@ class ParkingViewModel(
     _closestParkings.value =
         _rectParkings.value
             .filter { parking ->
-              TurfMeasurement.distance(_circleCenter.value!!, parking.location.center) *
-                  KM_TO_METERS <= _radius.value
+              TurfMeasurement.distance(
+                  _circleCenter.value!!, parking.location.center, TurfConstants.UNIT_METERS) <=
+                  _radius.value
             }
             .sortedBy { parking ->
               TurfMeasurement.distance(_circleCenter.value!!, parking.location.center)

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.ui.addParking.attributes
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,6 +37,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -128,9 +130,8 @@ fun AttributesPicker(
       modifier = Modifier.testTag("AttributesPickerScreen"),
       topBar = { AttributePickerTopBar(mapViewModel, title) },
       bottomBar = {
-        BottomBarAddAttr(navigationActions) {
-          if (areInputsValid(title.value, description.value)) onSubmit()
-        }
+        val validInputs = areInputsValid(title.value, description.value)
+        BottomBarAddAttr(navigationActions, validInputs) { onSubmit() }
       }) { padding ->
         // Apply screen-dimension-scaled padding for consistent spacing
         val scaledPaddingValues =
@@ -223,8 +224,14 @@ private fun scaledPadding(
       bottom = padding.calculateBottomPadding() * verticalScaleFactor)
 }
 
+private const val s = "Please fill in all fields appropriately"
+
 @Composable
-fun BottomBarAddAttr(navigationActions: NavigationActions, onSubmit: () -> Unit) {
+fun BottomBarAddAttr(
+    navigationActions: NavigationActions,
+    validInputs: Boolean,
+    onSubmit: () -> Unit
+) {
   Box(Modifier.background(Color.White).testTag("AttributesPickerBottomBar")) {
     Row(
         Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
@@ -246,13 +253,19 @@ fun BottomBarAddAttr(navigationActions: NavigationActions, onSubmit: () -> Unit)
               color = MaterialTheme.colorScheme.primary,
               modifier = Modifier.height(32.dp).width(1.dp),
               thickness = 2.dp)
+
+          val toast =
+              Toast.makeText(
+                  LocalContext.current,
+                  stringResource(R.string.attributes_picker_bottom_bar_submit_button_toast),
+                  Toast.LENGTH_SHORT)
           Button(
-              onClick = { onSubmit() },
+              onClick = { if (validInputs) onSubmit() else toast.show() },
               modifier = Modifier.testTag("submitButton"),
               colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
                 Text(
                     stringResource(R.string.attributes_picker_bottom_bar_submit_button),
-                    color = MaterialTheme.colorScheme.primary,
+                    color = if (validInputs) MaterialTheme.colorScheme.primary else Color.Gray,
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center)
               }

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPicker.kt
@@ -48,7 +48,7 @@ fun LocationPicker(
             onDispose {}
           }
         }
-        RectangleSelection(mapViewModel, padding)
+        RectangleSelection(mapViewModel, padding, mapView.value)
         Crosshair(mapViewModel, padding)
       }
   LaunchedEffect(locationPickerState) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.ui.addParking.location
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -40,6 +41,7 @@ fun LocationPickerBottomBar(
     mapView: MutableState<MapView?>,
 ) {
   val locationPickerState by mapViewModel.locationPickerState.collectAsState()
+  val isAreaTooLarge by mapViewModel.isAreaTooLarge.collectAsState()
   Box(Modifier.background(Color.White).height(100.dp).testTag("LocationPickerBottomBar")) {
     Row(
         Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
@@ -78,14 +80,25 @@ fun LocationPickerBottomBar(
                       textAlign = TextAlign.Center)
                 }
           } else if (locationPickerState == LocationPickerState.TOP_LEFT_SET) {
+            val toast =
+                Toast.makeText(
+                    mapView.value?.context,
+                    R.string.location_picker_invalid_area,
+                    Toast.LENGTH_SHORT)
             Button(
-                { onBottomRightSelected(mapViewModel) },
+                {
+                  if (isAreaTooLarge) {
+                    toast.show()
+                  } else {
+                    onBottomRightSelected(mapViewModel)
+                  }
+                },
                 modifier = Modifier.testTag("nextButton"),
                 colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
                   Text(
                       stringResource(R.string.location_picker_bottom_bar_next_button),
                       modifier = Modifier.width(100.dp),
-                      color = MaterialTheme.colorScheme.primary,
+                      color = if (isAreaTooLarge) Color.Gray else MaterialTheme.colorScheme.primary,
                       style = Typography.headlineMedium,
                       textAlign = TextAlign.Center)
                 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
@@ -80,15 +80,14 @@ fun LocationPickerBottomBar(
                       textAlign = TextAlign.Center)
                 }
           } else if (locationPickerState == LocationPickerState.TOP_LEFT_SET) {
-            val toast =
-                Toast.makeText(
-                    mapView.value?.context,
-                    R.string.location_picker_invalid_area,
-                    Toast.LENGTH_SHORT)
             Button(
                 {
                   if (isAreaTooLarge) {
-                    toast.show()
+                    Toast.makeText(
+                            mapView.value?.context,
+                            R.string.location_picker_invalid_area,
+                            Toast.LENGTH_SHORT)
+                        .show()
                   } else {
                     onBottomRightSelected(mapViewModel)
                   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
@@ -69,8 +69,8 @@ fun RectangleSelection(
           val rectSize = Size(width, height)
 
           val listScreenCoordinates = computeScreenCoordinates(canvasCenter, width, height)
-          val pointsList = mapView?.mapboxMap?.coordinatesForPixels(listScreenCoordinates)!!
-          val area = Location(pointsList).computeArea()
+          val pointsList = mapView?.mapboxMap?.coordinatesForPixels(listScreenCoordinates)
+          val area = pointsList?.let { Location(it).computeArea() } ?: 0.0
           mapViewModel.updateIsAreaTooLarge(area > PARKING_MAX_AREA)
 
           if (hasDragged.value) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.Location
-import com.github.se.cyrcle.model.parking.PARKING_MAX_AREA
 import com.github.se.cyrcle.ui.theme.Red
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.mapbox.maps.MapView
@@ -68,10 +67,9 @@ fun RectangleSelection(
           // Convert width to the same unit as the canvas center
           val rectSize = Size(width, height)
 
-          val listScreenCoordinates = computeScreenCoordinates(canvasCenter, width, height)
+          val listScreenCoordinates = computeCornersScreenCoordinates(canvasCenter, width, height)
           val pointsList = mapView?.mapboxMap?.coordinatesForPixels(listScreenCoordinates)
-          val area = pointsList?.let { Location(it).computeArea() } ?: 0.0
-          mapViewModel.updateIsAreaTooLarge(area > PARKING_MAX_AREA)
+          mapViewModel.updateIsAreaTooLarge(pointsList?.let { Location(it).computeArea() } ?: 0.0)
 
           if (hasDragged.value) {
             // Fill of the rectangle
@@ -109,12 +107,21 @@ fun RectangleSelection(
     }
   }
   if (locationPickerState == MapViewModel.LocationPickerState.BOTTOM_RIGHT_SET) {
-    mapViewModel.updateScreenCoordinates(computeScreenCoordinates(canvasCenter, width, height))
+    mapViewModel.updateScreenCoordinates(
+        computeCornersScreenCoordinates(canvasCenter, width, height))
     mapViewModel.updateLocationPickerState(MapViewModel.LocationPickerState.RECTANGLE_SET)
   }
 }
 
-fun computeScreenCoordinates(
+/**
+ * Compute the screen coordinates of the 4 corners of the rectangle.
+ *
+ * @param canvasCenter The center of the canvas
+ * @param width The width of the rectangle
+ * @param height The height of the rectangle
+ * @return The screen coordinates of the rectangle as a list of ScreenCoordinate
+ */
+private fun computeCornersScreenCoordinates(
     canvasCenter: Offset,
     width: Float,
     height: Float

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
@@ -20,13 +20,22 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
+import com.github.se.cyrcle.model.parking.Location
+import com.github.se.cyrcle.model.parking.PARKING_MAX_AREA
+import com.github.se.cyrcle.ui.theme.Red
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.mapbox.maps.MapView
 import com.mapbox.maps.ScreenCoordinate
 
 /** This composable is used to draw a rectangle on the map to select a region. */
 @Composable
-fun RectangleSelection(mapViewModel: MapViewModel, paddingValues: PaddingValues) {
+fun RectangleSelection(
+    mapViewModel: MapViewModel,
+    paddingValues: PaddingValues,
+    mapView: MapView?
+) {
   val locationPickerState by mapViewModel.locationPickerState.collectAsState()
+  val isAreaTooLarge by mapViewModel.isAreaTooLarge.collectAsState()
   val center = Offset(0.5f, 0.5f)
   var touchPosition by remember { mutableStateOf(Offset.Unspecified) }
   val hasDragged = remember { mutableStateOf(false) }
@@ -56,15 +65,26 @@ fun RectangleSelection(mapViewModel: MapViewModel, paddingValues: PaddingValues)
           }
           width = touchPosition.x - canvasCenter.x
           height = touchPosition.y - canvasCenter.y
-          // Convert width o the same unit as the canvas center
+          // Convert width to the same unit as the canvas center
           val rectSize = Size(width, height)
+
+          val listScreenCoordinates = computeScreenCoordinates(canvasCenter, width, height)
+          val pointsList = mapView?.mapboxMap?.coordinatesForPixels(listScreenCoordinates)!!
+          val area = Location(pointsList).computeArea()
+          mapViewModel.updateIsAreaTooLarge(area > PARKING_MAX_AREA)
+
           if (hasDragged.value) {
+            // Fill of the rectangle
             drawRect(
-                color = Color(0xFF22799B).copy(alpha = 0.7f),
+                color =
+                    if (isAreaTooLarge) Red.copy(alpha = 0.5f)
+                    else Color(0xFF22799B).copy(alpha = 0.7f),
                 topLeft = canvasCenter,
                 size = rectSize)
+
+            // Outline of the rectangle
             drawRect(
-                color = Color(0xFF22799B),
+                color = if (isAreaTooLarge) Red else Color(0xFF22799B),
                 topLeft = canvasCenter,
                 size = rectSize,
                 style = Stroke(width = 2f))
@@ -89,15 +109,21 @@ fun RectangleSelection(mapViewModel: MapViewModel, paddingValues: PaddingValues)
     }
   }
   if (locationPickerState == MapViewModel.LocationPickerState.BOTTOM_RIGHT_SET) {
-    // get all four coordinates of the rectangle
-    val topLeft = ScreenCoordinate((canvasCenter.x).toDouble(), (canvasCenter.y).toDouble())
-    val topRight =
-        ScreenCoordinate((canvasCenter.x + width).toDouble(), (canvasCenter.y).toDouble())
-    val bottomRight =
-        ScreenCoordinate((canvasCenter.x + width).toDouble(), (canvasCenter.y + height).toDouble())
-    val bottomLeft =
-        ScreenCoordinate((canvasCenter.x).toDouble(), (canvasCenter.y + height).toDouble())
-    mapViewModel.updateScreenCoordinates(listOf(topLeft, topRight, bottomRight, bottomLeft))
+    mapViewModel.updateScreenCoordinates(computeScreenCoordinates(canvasCenter, width, height))
     mapViewModel.updateLocationPickerState(MapViewModel.LocationPickerState.RECTANGLE_SET)
   }
+}
+
+fun computeScreenCoordinates(
+    canvasCenter: Offset,
+    width: Float,
+    height: Float
+): List<ScreenCoordinate> {
+  val topLeft = ScreenCoordinate((canvasCenter.x).toDouble(), (canvasCenter.y).toDouble())
+  val topRight = ScreenCoordinate((canvasCenter.x + width).toDouble(), (canvasCenter.y).toDouble())
+  val bottomRight =
+      ScreenCoordinate((canvasCenter.x + width).toDouble(), (canvasCenter.y + height).toDouble())
+  val bottomLeft =
+      ScreenCoordinate((canvasCenter.x).toDouble(), (canvasCenter.y + height).toDouble())
+  return listOf(topLeft, topRight, bottomRight, bottomLeft)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <!-- Attributes Picker > TopBarAddAttr -->
     <string name="attributes_picker_top_bar_new_parking_spot">New Parking Spot</string>
     <string name="attributes_picker_top_bar_set_attributes">Set the attributes of the parking spot</string>
+    <string name="attributes_picker_bottom_bar_submit_button_toast">Please fill in all mandatory fields appropriately</string>
 
     <!-- Rectangle Selection -->
     <string name="rectangle_selection_lock_map">Lock Map</string>
@@ -40,6 +41,7 @@
     <!-- Location Picker Bottom Bar -->
     <string name="location_picker_bottom_bar_cancel_button">Cancel</string>
     <string name="location_picker_bottom_bar_next_button">Next</string>
+    <string name="location_picker_invalid_area">Please select a valid area</string>
     <!-- Location Picker Top Bar -->
     <string name="location_picker_top_bar_where">Where is the Parking ?</string>
     <string name="location_picker_top_bar_select_top_left">Set the top-left corner of the parking, by placing it under the crosshair below</string>


### PR DESCRIPTION
### Overview
This PR introduces a validation mechanism for parking area inputs to prevent unrealistic sizes. Previously, users could input parking areas of any size, including implausibly large areas. This update implements a maximum area limit and provides visual feedback to guide users.

NB: The area serving as bound has arbitrarily been set to 1000 m²

### Functional Changes
Implement a maximum area limit for parking inputs
Disable the "Next" button when the selected parking area exceeds the defined limit
Add area calculation logic to validate user selections in real-timebound

### UI enhancements
Dynamic color update for the selected area:
- Default color: Valid selection
- Red: Invalid selection (exceeds area limit)

"Next" button state changes:
- Grayed out when selection is invalid
- Displays a toast message on click if the selection is invalid, explaining the issue

### Visual comparison
<img width="250" alt="image" src="https://github.com/user-attachments/assets/cdf9c3b9-ebe7-43ad-8d3d-5159340e83ec">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/790dc4b4-15f6-4375-a0db-f8ca400ecb89">

### Coverage
![image](https://github.com/user-attachments/assets/1029e8d9-184d-4b85-9893-8f27ed443814)


