### PR TITLE
fix : back stack correctly clears itself.

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -94,7 +94,7 @@ class ListScreenTest {
     composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
 
-    verify(mockNavigationActions).navigateTo(Screen.CARD)
+    verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
     assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
   }
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -72,9 +72,6 @@ class MapScreenTest {
     composeTestRule.onNodeWithTag("ZoomControlsIn").assertIsDisplayed().assertHasClickAction()
     composeTestRule.onNodeWithTag("ZoomControlsOut").assertIsDisplayed().assertHasClickAction()
 
-    // Assert that the add button is displayed
-    composeTestRule.onNodeWithTag("addButton").assertIsDisplayed().assertHasClickAction()
-
     // Assert that the recenter button is displayed
     composeTestRule.onNodeWithTag("recenterButton").assertIsDisplayed().assertHasClickAction()
   }
@@ -109,7 +106,7 @@ class MapScreenTest {
     }
 
     // Check that the add button has no click action when there is no user
-    composeTestRule.onNodeWithTag("addButton").performClick()
+    composeTestRule.onNodeWithTag("addButton").assertDoesNotExist()
     verifyNoInteractions(mockNavigation)
 
     userViewModel.setCurrentUser(TestInstancesUser.user1)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -63,7 +63,7 @@ class ParkingDetailsScreenTest {
     userViewModel = UserViewModel(userRepository, parkingRepository)
     reviewViewModel = ReviewViewModel(reviewRepository)
 
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.CARD)
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.PARKING_DETAILS)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
@@ -2,14 +2,10 @@ package com.github.se.cyrcle.ui.profile
 
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import com.github.se.cyrcle.MainActivity
-import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -18,7 +14,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 
 @HiltAndroidTest
 class CreateProfileScreenTest {
@@ -52,25 +47,5 @@ class CreateProfileScreenTest {
 
     // Verify initial display mode elements
     composeTestRule.onNodeWithTag("CreateProfileScreen").assertExists()
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testTopAppBar() {
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("CreateProfileScreen"))
-
-    // Verify initial display mode elements
-    composeTestRule.onNodeWithTag("TopAppBar").assertExists()
-
-    val createProfileScreenTitle = composeTestRule.activity.getString(R.string.profile_screen_title)
-    composeTestRule.onNodeWithTag("TopAppBarTitle").assertTextEquals(createProfileScreenTitle)
-
-    composeTestRule
-        .onNodeWithTag("TopAppBarGoBackButton")
-        .assertExists()
-        .assertHasClickAction()
-        .performClick()
-
-    verify(mockNavigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -19,7 +19,7 @@ import com.github.se.cyrcle.model.user.UserDetails
 import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.navigation.Route
+import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.mapbox.geojson.Point
 import org.junit.Before
 import org.junit.Rule
@@ -88,7 +88,7 @@ class ViewProfileScreenTest {
     composeTestRule.waitForIdle()
 
     assert(userViewModel.currentUser.value == null)
-    verify(mockNavigationActions).navigateTo(Route.AUTH)
+    verify(mockNavigationActions).navigateTo(TopLevelDestinations.AUTH)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
@@ -96,7 +96,7 @@ class ReviewScreenTest {
 
   @Test
   fun reviewScreen_addReviewButtonSaves() {
-    doNothing().`when`(mockNavigationActions).navigateTo(Screen.CARD)
+    doNothing().`when`(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
 
     composeTestRule.setContent {
       ReviewScreen(mockNavigationActions, parkingViewModel, reviewViewModel, userViewModel)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -241,7 +241,6 @@ class MainActivityTest {
 
     fun assertMapScreen() {
       composeTestRule.onNodeWithTag("MapScreen").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("addButton").assertIsDisplayed().assertHasClickAction()
       composeTestRule.onNodeWithTag("ZoomControlsIn").assertIsDisplayed().assertHasClickAction()
       composeTestRule.onNodeWithTag("ZoomControlsOut").assertIsDisplayed().assertHasClickAction()
       composeTestRule.onNodeWithTag("NavigationBar").assertIsDisplayed()

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -48,10 +48,15 @@ fun CyrcleNavHost(
         route = Route.LIST,
     ) {
       composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel) }
-      composable(Screen.CARD) {
+      composable(Screen.PARKING_DETAILS) {
         ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
       }
-      composable(Screen.REVIEW) {
+    }
+    navigation(
+        startDestination = Screen.ALL_REVIEWS,
+        route = Route.REVIEW,
+    ) {
+      composable(Screen.ADD_REVIEW) {
         ReviewScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
       }
       composable(Screen.ALL_REVIEWS) {
@@ -76,7 +81,6 @@ fun CyrcleNavHost(
       }
     }
 
-    // Add this new navigation block for Profile
     navigation(
         startDestination = Screen.PROFILE,
         route = Route.PROFILE,

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -276,7 +276,7 @@ fun SpotCard(
               .clickable(
                   onClick = {
                     parkingViewModel.selectParking(parking)
-                    navigationActions.navigateTo(Screen.CARD)
+                    navigationActions.navigateTo(Screen.PARKING_DETAILS)
                   })
               .testTag("SpotListItem"),
       colors = CardDefaults.cardColors(containerColor = Color.Transparent)) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -292,20 +292,42 @@ fun MapScreen(
             mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom - 1.0) }
           })
 
+      if (enableParkingAddition) {
+        IconButton(
+            icon = Icons.Default.Add,
+            contentDescription = "Add parking spots",
+            modifier =
+                Modifier.align(Alignment.BottomStart)
+                    .scale(1.2f)
+                    .padding(bottom = 25.dp, start = 16.dp),
+            onClick = {
+              mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
+              navigationActions.navigateTo(Route.ADD_SPOTS)
+            },
+            colorLevel = ColorLevel.PRIMARY,
+            testTag = "addButton")
+      }
+
       IconButton(
-          icon = Icons.Default.Add,
-          contentDescription = "Add parking spots",
+          icon = Icons.Default.MyLocation,
+          contentDescription = "Recenter on Location",
           modifier =
-              Modifier.align(Alignment.BottomStart)
+              Modifier.align(Alignment.BottomEnd)
+                  .padding(bottom = 25.dp, end = 16.dp)
                   .scale(1.2f)
-                  .padding(bottom = 25.dp, start = 16.dp),
+                  .testTag("recenterButton"),
           onClick = {
-            mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
-            navigationActions.navigateTo(Route.ADD_SPOTS)
+            mapViewModel.updateTrackingMode(true)
+            mapViewportState.transitionToFollowPuckState(
+                FollowPuckViewportStateOptions.Builder()
+                    .pitch(0.0)
+                    .zoom(maxZoom)
+                    .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
+                    .build())
           },
-          enabled = enableParkingAddition,
-          colorLevel = ColorLevel.PRIMARY,
-          testTag = "addButton")
+          colorLevel =
+              if (mapViewModel.isTrackingModeEnable.collectAsState().value) ColorLevel.SECONDARY
+              else ColorLevel.PRIMARY)
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -65,7 +65,6 @@ import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.gestures
-import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.maps.plugin.viewport.data.FollowPuckViewportStateOptions
 import com.mapbox.maps.plugin.viewport.data.OverviewViewportStateOptions
 import com.mapbox.maps.viewannotation.annotatedLayerFeature
@@ -216,7 +215,7 @@ fun MapScreen(
                           screenCapacityString.format(parkingDeserialized.capacity.description)
                       selectButton.setOnClickListener {
                         parkingViewModel.selectParking(parkingDeserialized)
-                        navigationActions.navigateTo(Screen.CARD)
+                        navigationActions.navigateTo(Screen.PARKING_DETAILS)
                       }
                     }
                     removeViewAnnotation = true

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -94,7 +94,7 @@ fun MapScreen(
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
   var removeViewAnnotation = remember { true }
   var cancelables = remember { Cancelable {} }
-  var listener = remember<MapIdleCallback?> { null }
+  var listener: MapIdleCallback?
   var pointAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
   val selectedParking by parkingViewModel.selectedParking.collectAsState()
   val locationEnabled = PermissionsManager.areLocationPermissionsGranted(activity)
@@ -307,27 +307,6 @@ fun MapScreen(
             colorLevel = ColorLevel.PRIMARY,
             testTag = "addButton")
       }
-
-      IconButton(
-          icon = Icons.Default.MyLocation,
-          contentDescription = "Recenter on Location",
-          modifier =
-              Modifier.align(Alignment.BottomEnd)
-                  .padding(bottom = 25.dp, end = 16.dp)
-                  .scale(1.2f)
-                  .testTag("recenterButton"),
-          onClick = {
-            mapViewModel.updateTrackingMode(true)
-            mapViewportState.transitionToFollowPuckState(
-                FollowPuckViewportStateOptions.Builder()
-                    .pitch(0.0)
-                    .zoom(maxZoom)
-                    .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
-                    .build())
-          },
-          colorLevel =
-              if (mapViewModel.isTrackingModeEnable.collectAsState().value) ColorLevel.SECONDARY
-              else ColorLevel.PRIMARY)
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
 object Route {
@@ -14,16 +13,17 @@ object Route {
   const val MAP = "Map"
   const val ADD_SPOTS = "Add Spots"
   const val PROFILE = "Profile"
+  const val REVIEW = "Review"
 }
 
 object Screen {
   const val AUTH = "Auth Screen"
   const val LIST = "List Screen"
   const val MAP = "Map Screen"
-  const val CARD = "Card Screen"
-  const val REVIEW = "Review Screen"
-  const val LOCATION_PICKER = "Location Picker"
-  const val ATTRIBUTES_PICKER = "Attributes Picker"
+  const val PARKING_DETAILS = "Parking Details Screen"
+  const val ADD_REVIEW = "Add Review Screen"
+  const val LOCATION_PICKER = "Location Picker Screen"
+  const val ATTRIBUTES_PICKER = "Attributes Picker Screen"
   const val PROFILE = "Profile Screen"
   const val ALL_REVIEWS = "All Reviews"
 }
@@ -39,6 +39,8 @@ data class TopLevelDestination(val route: String, val icon: ImageVector, val tex
 
 /** Object containing the top level destinations in the app. */
 object TopLevelDestinations {
+  val AUTH =
+      TopLevelDestination(route = Route.AUTH, icon = Icons.Outlined.Menu, textId = Route.AUTH)
   val LIST =
       TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
   val MAP =
@@ -64,13 +66,8 @@ open class NavigationActions(private val navController: NavHostController) {
    */
   open fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
-      popUpTo(navController.graph.findStartDestination().id) {
-        // Pop up to the start destination of the graph to
-        // avoid building up a large stack of destinations
-        // on the back stack as users select items
-        saveState = true
-        inclusive = true
-      }
+      // Pop up the whole back stack to the start destination
+      popUpTo(0) { inclusive = true }
       // Avoid multiple copies of the same destination when
       // reselecting the same item
       launchSingleTop = true

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -19,43 +19,39 @@ import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
-import com.github.se.cyrcle.ui.navigation.TopLevelDestination
-import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
-import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 @Composable
 fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
-    val screenTitle = stringResource(R.string.profile_screen_title)
+  val screenTitle = stringResource(R.string.profile_screen_title)
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize().testTag("CreateProfileScreen"),
-        bottomBar =  { BottomNavigationBar(navigationActions, selectedItem = Route.PROFILE) },
-       ) { padding ->
-        Box(modifier = Modifier.padding(padding)) {
-            Column(
-                modifier = Modifier.fillMaxSize().padding(16.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    "You need to be signed-in to modify your profile",
-                    style = MaterialTheme.typography.titleLarge
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Text("Sign in now to add new spots, share reviews, and help fellow drivers find the perfect parking space.")
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(
-                    text = "Go back to sign in",
-                    onClick = {
-                        // navigate to the route to not clear backstack
-                        navigationActions.navigateTo(Route.AUTH)
-                    }
-                )
-                Spacer(modifier = Modifier.height(200.dp))
-            }
-        }
+  Scaffold(
+      modifier = Modifier.fillMaxSize().testTag("CreateProfileScreen"),
+      bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.PROFILE) },
+  ) { padding ->
+    Box(modifier = Modifier.padding(padding)) {
+      Column(
+          modifier = Modifier.fillMaxSize().padding(16.dp),
+          verticalArrangement = Arrangement.Center,
+          horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(
+            "You need to be signed-in to modify your profile",
+            style = MaterialTheme.typography.titleLarge)
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            "Sign in now to add new spots, share reviews, and help fellow drivers find the perfect parking space.")
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            text = "Go back to sign in",
+            onClick = {
+              // navigate to the route to not clear backstack
+              navigationActions.navigateTo(Route.AUTH)
+            })
+        Spacer(modifier = Modifier.height(200.dp))
+      }
     }
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -1,55 +1,61 @@
 package com.github.se.cyrcle.ui.profile
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Route
+import com.github.se.cyrcle.ui.navigation.TopLevelDestination
+import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
+import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 @Composable
 fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
-  val screenTitle = stringResource(R.string.profile_screen_title)
+    val screenTitle = stringResource(R.string.profile_screen_title)
 
-  Scaffold(
-      modifier = Modifier.fillMaxSize().testTag("CreateProfileScreen"),
-      topBar = { TopAppBar(navigationActions, screenTitle) }) { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
-            verticalArrangement = Arrangement.Center) {
-              Text("TODO")
-
-              // TODO Toast text need to take inspiration from this
-              // val failSignInMsg = stringResource(R.string.sign_in_failed_toast)
-              // val successSignInMsg = stringResource(R.string.sign_in_successful_toast)
-              //
-              // GoogleSignInButton(
-              //    onAuthComplete = { result: AuthResult ->
-              //      val user =
-              //          User(
-              //              userId = result.user?.uid ?: "",
-              //              username = result.user?.displayName ?: "",
-              //              email = result.user?.email ?: "")
-              //      Log.d("Cyrcle", "User account created: ${result.user?.displayName}")
-              //      Toast.makeText(context, "Welcome ${user.username}!", Toast.LENGTH_LONG).show()
-
-              //      userViewModel.addUser(user)
-              //      userViewModel.setCurrentUser(user)
-              //      navigationActions.navigateTo(TopLevelDestinations.MAP)
-              //    },
-              //    onAuthError = { e: ApiException ->
-              //      Log.e("Cyrcle", "Failed to sign in: ${e.statusCode}")
-              //      Toast.makeText(context, "Account creation failed...",
-              // Toast.LENGTH_LONG).show()
-              //    })
+    Scaffold(
+        modifier = Modifier.fillMaxSize().testTag("CreateProfileScreen"),
+        bottomBar =  { BottomNavigationBar(navigationActions, selectedItem = Route.PROFILE) },
+       ) { padding ->
+        Box(modifier = Modifier.padding(padding)) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    "You need to be signed-in to modify your profile",
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text("Sign in now to add new spots, share reviews, and help fellow drivers find the perfect parking space.")
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    text = "Go back to sign in",
+                    onClick = {
+                        // navigate to the route to not clear backstack
+                        navigationActions.navigateTo(Route.AUTH)
+                    }
+                )
+                Spacer(modifier = Modifier.height(200.dp))
             }
-      }
+        }
+    }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -42,7 +42,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: Use
             style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            "Sign in now to add new spots, share reviews, and help fellow drivers find the perfect parking space.")
+            "Sign in now to add new spots, share reviews, and help fellow cyclists find the perfect parking space.")
         Spacer(modifier = Modifier.height(8.dp))
         Button(
             text = "Go back to sign in",

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -40,6 +40,7 @@ import com.github.se.cyrcle.ui.authentication.Authenticator
 import com.github.se.cyrcle.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
+import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
@@ -82,7 +83,7 @@ fun ViewProfileScreen(
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
           authenticator.SignOutButton(Modifier.padding(10.dp).align(Alignment.TopEnd)) {
             userViewModel.setCurrentUser(null)
-            navigationActions.navigateTo(Route.AUTH)
+            navigationActions.navigateTo(TopLevelDestinations.AUTH)
           }
 
           Column(

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -214,7 +214,7 @@ fun AllReviewsScreen(
               modifier = Modifier.fillMaxSize().padding(16.dp),
               contentAlignment = Alignment.BottomEnd) {
                 FloatingActionButton(
-                    onClick = { navigationActions.navigateTo(Screen.REVIEW) },
+                    onClick = { navigationActions.navigateTo(Screen.ADD_REVIEW) },
                     containerColor = MaterialTheme.colorScheme.primary) {
                       Text(
                           text = if (ownerHasReviewed.value) "Edit Review" else "Add Review",


### PR DESCRIPTION
_closes #166_
### This small PR is about navigating in the app.
Its goal is the following  : 
- Not let any buttons without interactions.
- Clears the back stack when navigating to a TLD
- Propose the guest user to navigate back to the sign-in screen when on his profile screen.
- Make the navigation graph more readable and maintainable, keep the screen name coherent with the composable name

### Important changes
- Map, list and profile are now correctly set up as TLD so making a back action on them makes you leave the app.


### Other minors changes

- The popup() function has been modified to completely clear the back stack.
- The add button in guest mode is not shown. 
- The guest user now has the possibility to sign in
- The TopBar of the viewprofile screen has been removed because it contained a back arrow, but it is a TLD.
- REVIEW screen has been renamed ADD_REVIEW 
- CARD screen has been renamed PARKING_DETAILS
- Screens that belong to a common theme are placed in a ROUTE for clarity and readability.
- MAP, LIST and PARKING_DETAILS are placed alone in their ROUTE. 

### Why
Fixing the navigation brings our navigation closer to a standard android app.
the Renaming and reordering is for maintainability. 
The add Button removed and the profile screen of guest user is not let any button/screen with no interactions.

### Code coverage

<img width="560" alt="image" src="https://github.com/user-attachments/assets/9136ecb1-778b-433d-9543-aec37dfca637">


