### PR TITLE
Toggle between Rectangles and Markers on map

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
@@ -78,7 +78,7 @@ data class Location(
    *
    * @return The polygon representing the location.
    */
-  private fun toPolygon(): Polygon {
+  fun toPolygon(): Polygon {
     return Polygon.fromLngLats(listOf(listOf(topLeft, topRight, bottomRight, bottomLeft, topLeft)))
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -355,7 +355,7 @@ fun AttributePickerTopBar(mapViewModel: MapViewModel, title: MutableState<String
               fontWeight = FontWeight.Bold,
               maxLines = 1)
         }
-        drawRectangles(annotationManager, listOf(location))
+        drawRectangles(annotationManager, null, listOf(location))
       }
 }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -87,6 +88,7 @@ const val minZoom = 8.0
 const val thresholdDisplayZoom = 13.0
 const val LAYER_ID = "0128"
 const val LABEL_THRESHOLD = 15.5
+const val CLUSTER_COLORS = "#1A4988"
 
 /**
  * Enum class to represent the different modes of the map
@@ -190,7 +192,15 @@ fun MapScreen(
                 mapView.annotations.createPointAnnotationManager(
                     AnnotationConfig(
                         annotationSourceOptions =
-                            AnnotationSourceOptions(clusterOptions = ClusterOptions()),
+                            AnnotationSourceOptions(
+                                clusterOptions =
+                                    ClusterOptions(
+                                        colorLevels =
+                                            listOf(
+                                                Pair(
+                                                    1,
+                                                    android.graphics.Color.parseColor(
+                                                        CLUSTER_COLORS))))),
                         layerId = LAYER_ID))
             // Create polygon annotation manager to draw rectangles
             rectangleAnnotationManager = mapView.annotations.createPolygonAnnotationManager()

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -350,21 +350,6 @@ fun MapScreen(
           })
 
       IconButton(
-          icon = Icons.Default.Add,
-          contentDescription = "Add parking spots",
-          modifier =
-              Modifier.align(Alignment.BottomStart)
-                  .scale(1.2f)
-                  .padding(bottom = 25.dp, start = 16.dp),
-          onClick = {
-            mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
-            navigationActions.navigateTo(Route.ADD_SPOTS)
-          },
-          enabled = enableParkingAddition,
-          colorLevel = ColorLevel.PRIMARY,
-          testTag = "addButton")
-
-      IconButton(
           icon = Icons.Default.MyLocation,
           contentDescription = "Recenter on Location",
           modifier =
@@ -385,15 +370,6 @@ fun MapScreen(
           colorLevel =
               if (mapViewModel.isTrackingModeEnable.collectAsState().value) ColorLevel.SECONDARY
               else ColorLevel.PRIMARY)
-
-      ZoomControls(
-          modifier = Modifier.align(Alignment.TopEnd),
-          onZoomIn = {
-            mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom + 1.0) }
-          },
-          onZoomOut = {
-            mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom - 1.0) }
-          })
 
       if (enableParkingAddition) {
         IconButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
 
     <!-- Map Screen -->
     <string name="map_screen_capacity">Capacity is %s</string>
+    <string name="map_screen_mode_switch_label">Advanced</string>
 
     <!-- Create Profile Screen -->
     <string name="profile_screen_title">Create your profile</string>


### PR DESCRIPTION
_closes #94_
### Toggle between simple and advance mode on map screen

- The user can now choose if he wants to see markers or more detailed rectangles. 
- The pin on the map has been changed to not be a default red marker anymore


### How

- introduce a state that holds the mode of the map.
- Mode of the map are represented by an enum added in this PR
- added a toggle switch that changes the map mode state.
- when the map is too unzoomed the state is also automatically changed and the switch hidden on the UI.
- the state is observed and  either call `drawMarkers` or `drawRectangles`

A good portion of the lines changed in this PR are just reordering and grouping lines of code in the map screen for more readability.
-- -
### Demo. 
https://github.com/user-attachments/assets/0cfdb076-c1e7-456a-86a8-4ade0861c7da
-- -
### Code coverage 
<img width="536" alt="image" src="https://github.com/user-attachments/assets/53b1d755-933d-467b-b3a7-72c31dce398e">





