### PR TITLE
List screen based on user's actual location

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingCapacity
@@ -50,12 +51,14 @@ class ListScreenTest {
   @Mock private lateinit var mockImageRepository: ImageRepository
   @Mock private lateinit var mockNavigationActions: NavigationActions
   private lateinit var parkingViewModel: ParkingViewModel
+  private lateinit var mapViewModel: MapViewModel
 
   @Before
   fun setUp() {
     // Set up the test environment for the Compose UI test
     MockitoAnnotations.openMocks(this)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
+    mapViewModel = MapViewModel()
 
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
   }
@@ -263,7 +266,9 @@ class ListScreenTest {
                 eq(Tile.getTileFromPoint(loc).bottomLeft), any(), any(), any()))
         .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
 
-    composeTestRule.setContent { SpotListScreen(mockNavigationActions, parkingViewModel) }
+    composeTestRule.setContent {
+      SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel)
+    }
     composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
 
     // Check that the list is displayed

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -47,7 +47,7 @@ fun CyrcleNavHost(
         startDestination = Screen.LIST,
         route = Route.LIST,
     ) {
-      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel) }
+      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel, mapViewModel) }
       composable(Screen.PARKING_DETAILS) {
         ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
       }

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -159,12 +159,12 @@ class MapViewModel : ViewModel() {
 
   private val handler = Handler(Looper.getMainLooper())
   private var lastUpdateTime = 0L
-  private val updateInterval = 1000L // 1 second
+  private val updateInterval = 500L // 0.5 seconds
 
   /**
    * Initialize the location component of the map and add a listener to update the user position
    *
-   * @param locationComponentPlugin the location component plugin to initialize
+   * @param mapView the MapView to initialize the location component on
    */
   fun initLocationComponent(mapView: MapView) {
     val locationComponentPlugin = mapView.location

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -1,9 +1,12 @@
 package com.github.se.cyrcle.model.map
 
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.cyrcle.model.parking.Location
 import com.github.se.cyrcle.model.parking.PARKING_MAX_AREA
+import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraState
@@ -35,6 +38,9 @@ class MapViewModel : ViewModel() {
   private val _isAreaTooLarge: MutableStateFlow<Boolean> = MutableStateFlow(false)
   val isAreaTooLarge: StateFlow<Boolean> = _isAreaTooLarge
 
+  private val _userPosition = MutableStateFlow<Point>(TestInstancesParking.EPFLCenter)
+  val userPosition: StateFlow<Point> = _userPosition
+
   /**
    * Update the state of the location picker, This state is used to determine which steps of the
    * process to set the new location are completed
@@ -60,7 +66,7 @@ class MapViewModel : ViewModel() {
    * Update the focus mode
    *
    * @param focusMode the new focus mode This function is used to update the focus mode of the map
-   *   screen. The focus mode is used to center the map on the user's location
+   *   screen. The focus mode is used to center the map on the user's position
    */
   fun updateTrackingMode(focusMode: Boolean) {
     _isTrackingModeEnable.value = focusMode
@@ -109,6 +115,15 @@ class MapViewModel : ViewModel() {
   }
 
   /**
+   * Update the user position
+   *
+   * @param position the new user position
+   */
+  fun updateUserPosition(position: Point) {
+    _userPosition.value = position
+  }
+
+  /**
    * Get the bottom left and top right corners of the screen in latitude and longitude coordinates.
    * The corners are calculated based on the center of the screen and the viewport dimensions. If
    * useBuffer is true, the corners are calculated with a buffer of 2x the viewport dimensions. This
@@ -142,16 +157,30 @@ class MapViewModel : ViewModel() {
     return Pair(bottomLeftCorner, topRightCorner)
   }
 
+  private val handler = Handler(Looper.getMainLooper())
+  private var lastUpdateTime = 0L
+  private val updateInterval = 1000L // 1 second
+
   /**
-   * Initialize the location component of the map.
+   * Initialize the location component of the map and add a listener to update the user position
    *
-   * @param mapView the MapView to initialize the location component on
+   * @param locationComponentPlugin the location component plugin to initialize
    */
   fun initLocationComponent(mapView: MapView) {
     val locationComponentPlugin = mapView.location
     locationComponentPlugin.updateSettings {
       this.enabled = true
       this.locationPuck = createDefault2DPuck(true)
+    }
+
+    locationComponentPlugin.addOnIndicatorPositionChangedListener { point ->
+      val currentTime = System.currentTimeMillis()
+      if (currentTime - lastUpdateTime >= updateInterval) {
+        handler.post {
+          updateUserPosition(point)
+          lastUpdateTime = currentTime
+        }
+      }
     }
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -181,6 +181,7 @@ class ParkingViewModel(
 
   /** set the center of the circle, and reset the radius to DEFAULT_RADIUS */
   fun setCircleCenter(center: Point) {
+    Log.d("ParkingViewModel", "Setting center to $center")
     _circleCenter.value = center
     _radius.value = DEFAULT_RADIUS
     getParkingsInRadius(center, DEFAULT_RADIUS)

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -181,7 +181,6 @@ class ParkingViewModel(
 
   /** set the center of the circle, and reset the radius to DEFAULT_RADIUS */
   fun setCircleCenter(center: Point) {
-    Log.d("ParkingViewModel", "Setting center to $center")
     _circleCenter.value = center
     _radius.value = DEFAULT_RADIUS
     getParkingsInRadius(center, DEFAULT_RADIUS)

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -64,7 +64,7 @@ import com.mapbox.turf.TurfMeasurement
 fun SpotListScreen(
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory),
-    mapViewModel: MapViewModel = viewModel(factory = MapViewModel.Factory)
+    mapViewModel: MapViewModel
 ) {
 
   val userPosition by mapViewModel.userPosition.collectAsState()

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -43,13 +43,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingAttribute
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
-import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
@@ -64,9 +64,10 @@ import com.mapbox.turf.TurfMeasurement
 fun SpotListScreen(
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory),
+    mapViewModel: MapViewModel = viewModel(factory = MapViewModel.Factory)
 ) {
 
-  val referencePoint = TestInstancesParking.EPFLCenter
+  val userPosition by mapViewModel.userPosition.collectAsState()
 
   val filteredParkingSpots by parkingViewModel.closestParkings.collectAsState()
 
@@ -75,11 +76,8 @@ fun SpotListScreen(
   val selectedCapacities by parkingViewModel.selectedCapacities.collectAsState()
   val onlyWithCCTV by parkingViewModel.onlyWithCCTV.collectAsState()
 
-  /**
-   * Set the center of the circle in the ViewModel when the screen is launched. This should be
-   * linked to the user's location in the future.
-   */
-  LaunchedEffect(Unit) { parkingViewModel.setCircleCenter(referencePoint) }
+  // Set the center of the circle as the user's location when the screen is launched.
+  LaunchedEffect(userPosition) { parkingViewModel.setCircleCenter(userPosition) }
 
   Scaffold(
       modifier = Modifier.testTag("SpotListScreen"),
@@ -114,7 +112,7 @@ fun SpotListScreen(
               verticalArrangement = Arrangement.spacedBy(8.dp),
               modifier = Modifier.testTag("SpotListColumn")) {
                 items(items = filteredParkingSpots) { parking ->
-                  val distance = TurfMeasurement.distance(referencePoint, parking.location.center)
+                  val distance = TurfMeasurement.distance(userPosition, parking.location.center)
                   SpotCard(navigationActions, parkingViewModel, parking, distance)
                   // Increment the radius when the last parking spot is reached
                   if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -153,7 +153,8 @@ fun MapScreen(
         else drawMarkers(markerAnnotationManager, listOfParkings, resizedBitmap)
       }
 
-  // Center the camera on th puck and transition to the follow puck state
+  // Center the camera on th puck and transition to the follow puck state. Update the user
+  // position to the center of the camera
   LaunchedEffect(PermissionsManager.areLocationPermissionsGranted(activity)) {
     mapViewportState.transitionToFollowPuckState(
         FollowPuckViewportStateOptions.Builder()

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -160,7 +160,9 @@ fun MapScreen(
             .pitch(0.0)
             .zoom(maxZoom)
             .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
-            .build())
+            .build()) {
+          mapViewportState.cameraState?.let { mapViewModel.updateUserPosition(it.center) }
+        }
   }
 
   Scaffold(bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.MAP) }) {


### PR DESCRIPTION
This PR updates the list screen to use the user's current location as the reference point for displaying the closest parkings, replacing the previous hardcoded point.

### Implementation Details:
- Used MapBox MapView to access the location component plugin
- Implemented a location listener with a 1Hz update frequency using a debouncer
- Use hardcoded point `EPFLCenter` if location permission is disabled

### Coverage
Coverage as of 13/11 19:15
![image](https://github.com/user-attachments/assets/68a832fa-7bf6-4be4-a114-94239753622c)

-- -
Closes #196