### PR TITLE
Quick favorite and pin actions in list screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -1,8 +1,6 @@
 package com.github.se.cyrcle.ui.list
 
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertAll
@@ -95,24 +93,13 @@ class ListScreenTest {
   @Test
   fun testPinActionCardDisplayed() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1,
           0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     // Verify that the PinActionCard is displayed
@@ -123,23 +110,13 @@ class ListScreenTest {
   @Test
   fun testUnpinActionCardDisplayed() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1,
           0.0,
-          initialIsPinned = true,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = true)
     }
     composeTestRule.onNodeWithTag("PinActionCard").assertIsNotDisplayed()
     composeTestRule.onNodeWithTag("UnpinActionCard").assertIsDisplayed()
@@ -148,24 +125,13 @@ class ListScreenTest {
   @Test
   fun testAddToFavoritesActionCardDisplayed() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking3, // not in our user's favorites
           0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     // Verify that the AddToFavoriteActionCard is displayed
@@ -176,24 +142,13 @@ class ListScreenTest {
   @Test
   fun testAlreadyFavoriteActionCardDisplayed() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1, // in our user's favorites
           0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     // Verify that the AlreadyFavoriteActionCard is displayed
@@ -204,24 +159,13 @@ class ListScreenTest {
   @Test
   fun testQuickFavoriteAddsToUserFavorites() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking3,
           0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     val isFavorite =
@@ -248,24 +192,13 @@ class ListScreenTest {
   @Test
   fun testQuickFavoriteDoesNothingOnQuickAddAlreadyFavorite() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1, // already in favorites
           0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     val isFavorite =
@@ -293,24 +226,13 @@ class ListScreenTest {
   fun testQuickFavoriteDoesNothingForUnsignedUsers() {
     userViewModel.setCurrentUser(null)
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           mockNavigationActions,
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking3,
           0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsDisplayed()
@@ -389,24 +311,13 @@ class ListScreenTest {
   @Test
   fun testSpotCardIsDisplayed() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           navigationActions = mockNavigationActions,
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = TestInstancesParking.parking1,
           distance = 0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
@@ -424,24 +335,13 @@ class ListScreenTest {
   @Test
   fun testSpotCardIsClickable() {
     composeTestRule.setContent {
-      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings =
-            if (isPinned) {
-              pinnedParkings + parkingId
-            } else {
-              pinnedParkings - parkingId
-            }
-      }
-
       SpotCard(
           navigationActions = mockNavigationActions,
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = TestInstancesParking.parking2,
           distance = 0.0,
-          initialIsPinned = false,
-          onPinStatusChanged = handlePinStatusChanged)
+          initialIsPinned = false)
     }
 
     composeTestRule
@@ -606,93 +506,4 @@ class ListScreenTest {
     composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
     assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
   }
-
-  /*@OptIn(ExperimentalTestApi::class)
-  @Test
-  fun testParkingDetailsScreenListsParkings() {
-    val testParking = TestInstancesParking.parking1
-    val loc = testParking.location.center
-    // Prepare to populate the parking list
-    `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
-      it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
-    }
-    `when`(
-            mockParkingRepository.getParkingsBetween(
-                eq(Tile.getTileFromPoint(loc).bottomLeft), any(), any(), any()))
-        .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
-
-    composeTestRule.setContent {
-      SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel, userViewModel)
-    }
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
-
-    // Check that the list is displayed
-    composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag("SpotListItem", useUnmergedTree = true)
-        .assertCountEquals(1)
-        .assertAll(hasClickAction())
-
-    // Check that the parking name is displayed
-    composeTestRule
-        .onNodeWithTag("ParkingName", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(testParking.optName ?: "Unnamed Parking")
-
-    // Check that the parking distance is displayed
-    composeTestRule
-        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(
-            String.format(
-                "%.0f m",
-                TurfMeasurement.distance(
-                    TestInstancesParking.EPFLCenter, testParking.location.center)))
-
-    // Select all 3 criteria
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-
-    // Select Protection
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Protection"))
-    composeTestRule.onNodeWithTag("Protection", useUnmergedTree = true).performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-
-    composeTestRule
-        .onNodeWithTag("ProtectionFilter")
-        .performScrollToIndex(testParking.protection.ordinal)
-    composeTestRule.onNodeWithText(testParking.protection.description).performClick()
-
-    // Select Rack Type
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Rack Type"))
-    composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-
-    composeTestRule
-        .onNodeWithTag("RackTypeFilter")
-        .performScrollToIndex(testParking.rackType.ordinal)
-    composeTestRule
-        .onNodeWithText(testParking.rackType.description)
-        .assertHasClickAction()
-        .performClick()
-
-    composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
-
-    // Select Capacity
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Capacity"))
-    composeTestRule.onNodeWithTag("Capacity", useUnmergedTree = true).performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-
-    composeTestRule
-        .onNodeWithTag("CapacityFilter")
-        .performScrollToIndex(testParking.capacity.ordinal)
-    composeTestRule
-        .onNodeWithText(testParking.capacity.description)
-        .assertHasClickAction()
-        .performClick()
-
-    // Store filters away
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
-    composeTestRule.onAllNodesWithTag("SpotListItem").assertCountEquals(1)
-  }*/
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -1,6 +1,8 @@
 package com.github.se.cyrcle.ui.list
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertAll
@@ -15,21 +17,23 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.swipe
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.MockImageRepository
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ImageRepository
+import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
+import com.github.se.cyrcle.model.parking.Tile
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserDetails
 import com.github.se.cyrcle.model.user.UserPublic
@@ -37,473 +41,394 @@ import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
+import com.mapbox.turf.TurfMeasurement
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class ListScreenTest {
-  @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule val composeTestRule = createComposeRule()
 
-  private lateinit var mockUserRepository: UserRepository
-  private lateinit var mockParkingRepository: ParkingRepository
-  private lateinit var mockImageRepository: ImageRepository
-  private lateinit var mockNavigationActions: NavigationActions
-  private lateinit var parkingViewModel: ParkingViewModel
-  private lateinit var mapViewModel: MapViewModel
-  private lateinit var userViewModel: UserViewModel
+    private lateinit var mockUserRepository: UserRepository
+    private lateinit var mockParkingRepository: ParkingRepository
+    private lateinit var mockImageRepository: ImageRepository
+    private lateinit var mockNavigationActions: NavigationActions
+    private lateinit var parkingViewModel: ParkingViewModel
+    private lateinit var mapViewModel: MapViewModel
+    private lateinit var userViewModel: UserViewModel
 
-  @Before
-  fun setUp() {
-    MockitoAnnotations.openMocks(this)
-    mockNavigationActions = mock(NavigationActions::class.java)
-    mockUserRepository = MockUserRepository()
-    mockParkingRepository = MockParkingRepository()
-    mockImageRepository = MockImageRepository()
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        mockNavigationActions = mock(NavigationActions::class.java)
+        mockUserRepository = MockUserRepository()
+        mockParkingRepository = MockParkingRepository()
+        mockImageRepository = MockImageRepository()
 
-    parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
-    mapViewModel = MapViewModel()
-    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+        parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
+        mapViewModel = MapViewModel()
+        userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
 
-    `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
+        `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
 
-    // Set up test user
-    val user =
-        User(
+        // Set up test user
+        val user = User(
             UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
-            UserDetails("Jane", "Smith", "jane.smith@example.com"))
+            UserDetails("Jane", "Smith", "jane.smith@example.com")
+        )
 
-    // Set up test data
-    // parking1 already in
-    parkingViewModel.addParking(TestInstancesParking.parking2)
-    parkingViewModel.addParking(TestInstancesParking.parking3)
-    userViewModel.addUser(user)
-    userViewModel.getUserById(user.public.userId)
-    userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
-    userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking2.uid)
-    userViewModel.getSelectedUserFavoriteParking()
-  }
-
-  @Test
-  fun testPinActionCardDisplayed() {
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking1,
-          0.0,
-          initialIsPinned = false)
+        // Set up test data
+        parkingViewModel.addParking(TestInstancesParking.parking1)
+        parkingViewModel.addParking(TestInstancesParking.parking2)
+        parkingViewModel.addParking(TestInstancesParking.parking3)
+        userViewModel.addUser(user)
+        userViewModel.getUserById(user.public.userId)
+        userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
+        userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking2.uid)
+        userViewModel.getSelectedUserFavoriteParking()
     }
 
-    // Verify that the PinActionCard is displayed
-    composeTestRule.onNodeWithTag("PinActionCard").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("UnpinActionCard").assertIsNotDisplayed()
-  }
 
-  @Test
-  fun testUnpinActionCardDisplayed() {
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking1,
-          0.0,
-          initialIsPinned = true)
-    }
-    composeTestRule.onNodeWithTag("PinActionCard").assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag("UnpinActionCard").assertIsDisplayed()
-  }
-
-  @Test
-  fun testAddToFavoritesActionCardDisplayed() {
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking3, // not in our user's favorites
-          0.0,
-          initialIsPinned = false)
+    @Test
+    fun testPinActionCardDisplayed() {
     }
 
-    // Verify that the AddToFavoriteActionCard is displayed
-    composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsNotDisplayed()
-  }
-
-  @Test
-  fun testAlreadyFavoriteActionCardDisplayed() {
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking1, // in our user's favorites
-          0.0,
-          initialIsPinned = false)
+    @Test
+    fun testUnpinActionCardDisplayed() {
     }
 
-    // Verify that the AlreadyFavoriteActionCard is displayed
-    composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsDisplayed()
-  }
-
-  @Test
-  fun testQuickFavoriteAddsToUserFavorites() {
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking3,
-          0.0,
-          initialIsPinned = false)
+    @Test
+    fun testAddToFavoritesActionCardDisplayed() {
     }
 
-    val isFavorite =
-        userViewModel.currentUser.value
-            ?.details
-            ?.favoriteParkings
-            ?.contains(TestInstancesParking.parking3.uid) ?: false
-    assert(!isFavorite)
-
-    // Perform swipe left to add to favorites using general swipe
-    composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
-      swipe(start = centerRight, end = centerLeft, durationMillis = 300)
+    @Test
+    fun testAlreadyFavoriteActionCardDisplayed() {
     }
 
-    // Check if the parking was added to favorites
-    val isFavoriteAdded =
-        userViewModel.currentUser.value
-            ?.details
-            ?.favoriteParkings
-            ?.contains(TestInstancesParking.parking3.uid) ?: true
-    assert(isFavoriteAdded)
-  }
-
-  @Test
-  fun testQuickFavoriteDoesNothingOnQuickAddAlreadyFavorite() {
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking1, // already in favorites
-          0.0,
-          initialIsPinned = false)
+    @Test
+    fun testQuickFavoriteAddsToUserFavorites() {
     }
 
-    val isFavorite =
-        userViewModel.currentUser.value
-            ?.details
-            ?.favoriteParkings
-            ?.contains(TestInstancesParking.parking1.uid) ?: false
-    assert(isFavorite)
 
-    // Perform swipe left to add to favorites using general swipe
-    composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
-      swipe(start = centerRight, end = centerLeft, durationMillis = 300)
-    }
-
-    // Check if the parking was added to favorites
-    val isFavoriteAdded =
-        userViewModel.currentUser.value
-            ?.details
-            ?.favoriteParkings
-            ?.contains(TestInstancesParking.parking1.uid) ?: true
-    assert(isFavoriteAdded)
-  }
-
-  @Test
-  fun testQuickFavoriteDoesNothingForUnsignedUsers() {
-    userViewModel.setCurrentUser(null)
-    composeTestRule.setContent {
-      SpotCard(
-          mockNavigationActions,
-          parkingViewModel,
-          userViewModel,
-          TestInstancesParking.parking3,
-          0.0,
-          initialIsPinned = false)
-    }
-
-    composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsNotDisplayed()
-
-    // Perform swipe left to add to favorites using general swipe
-    composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
-      swipe(start = centerRight, end = centerLeft, durationMillis = 300)
-    }
-
-    composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsNotDisplayed()
-  }
-
-  @Test
-  fun testCCTVCheckboxIntegration() {
-    composeTestRule.setContent {
-      SpotListScreen(
-          navigationActions = mockNavigationActions,
-          parkingViewModel = parkingViewModel,
-          mapViewModel = mapViewModel,
-          userViewModel = userViewModel)
-    }
-
-    // Show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-
-    // Initial state should be unchecked
-    composeTestRule.onNodeWithTag("CCTVCheckbox").assertIsDisplayed().performClick()
-
-    // Verify the ViewModel was updated
-    assert(parkingViewModel.onlyWithCCTV.value == true)
-
-    // Click again to uncheck
-    composeTestRule.onNodeWithTag("CCTVCheckbox").performClick()
-
-    // Verify the ViewModel was updated back to false
-    assert(parkingViewModel.onlyWithCCTV.value == false)
-  }
-
-  @Test
-  fun testCCTVCheckboxInteraction() {
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {},
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
-    }
-
-    // Show filters first
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-
-    // Check both checkbox and label are displayed
-    composeTestRule.onNodeWithTag("CCTVCheckbox").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("CCTVCheckboxLabel").assertIsDisplayed()
-  }
-
-  @Test
-  fun testSpotListScreenStructure() {
-    composeTestRule.setContent {
-      SpotListScreen(
-          navigationActions = mockNavigationActions,
-          parkingViewModel = parkingViewModel,
-          mapViewModel = mapViewModel,
-          userViewModel = userViewModel)
-    }
-
-    // Verify main screen components
-    composeTestRule.onNodeWithTag("SpotListScreen").assertExists()
-    composeTestRule.onNodeWithTag("SpotListColumn").assertExists()
-  }
-
-  @Test
-  fun testSpotCardIsDisplayed() {
-    composeTestRule.setContent {
-      SpotCard(
-          navigationActions = mockNavigationActions,
-          parkingViewModel = parkingViewModel,
-          userViewModel = userViewModel,
-          parking = TestInstancesParking.parking1,
-          distance = 0.0,
-          initialIsPinned = false)
-    }
-
-    composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("ParkingName", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(TestInstancesParking.parking1.optName ?: "Unnamed Parking")
-    composeTestRule
-        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(String.format("%.0f m", 0.0))
-    composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
-  }
-
-  @Test
-  fun testSpotCardIsClickable() {
-    composeTestRule.setContent {
-      SpotCard(
-          navigationActions = mockNavigationActions,
-          parkingViewModel = parkingViewModel,
-          userViewModel = userViewModel,
-          parking = TestInstancesParking.parking2,
-          distance = 0.0,
-          initialIsPinned = false)
-    }
-
-    composeTestRule
-        .onNodeWithTag("SpotListItem", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertHasClickAction()
-        .performClick()
-
-    composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsDisplayed()
-    composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
-
-    verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
-    assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
-  }
-
-  @Test
-  fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
-    // Arrange
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {},
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
-    }
-
-    // Act & Assert
-    composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testShowFiltersButtonTogglesFilterSection() {
-    // Arrange
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {},
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
-    }
-
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
-
-    // Act: Click to hide filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testProtectionFilters() {
-
-    val selectedProtection = mutableSetOf<ParkingProtection>()
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = selectedProtection,
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {
-            when (it) {
-              is ParkingProtection -> selectedProtection.add(it)
+    @Test
+    fun testSpotCardIsDisplayed() {
+        composeTestRule.setContent {
+            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+                pinnedParkings = if (isPinned) {
+                    pinnedParkings + parkingId
+                } else {
+                    pinnedParkings - parkingId
+                }
             }
-          },
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+
+            SpotCard(
+                navigationActions = mockNavigationActions,
+                parkingViewModel = parkingViewModel,
+                userViewModel = userViewModel,
+                parking = TestInstancesParking.parking1,
+                distance = 0.0,
+                initialIsPinned = false,
+                onPinStatusChanged = handlePinStatusChanged
+            )
+        }
+
+        composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("ParkingName", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(TestInstancesParking.parking1.optName ?: "Unnamed Parking")
+        composeTestRule
+            .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(String.format("%.0f m", 0.0))
+        composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
-
-    composeTestRule
-        .onNodeWithTag("Protection")
-        .assertIsDisplayed()
-        .assertTextEquals("Protection")
-        .performClick()
-
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-    composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag("ProtectionFilterItem")
-        .assertCountEquals(ParkingProtection.entries.size)
-        .assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
-    assert(selectedProtection.contains(ParkingProtection.entries[0]))
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testRackTypeFilters() {
-    // Arrange
-    val selectedRackType = mutableSetOf<ParkingRackType>()
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = selectedRackType,
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {
-            when (it) {
-              is ParkingRackType -> selectedRackType.add(it)
+    @Test
+    fun testSpotCardIsClickable() {
+        composeTestRule.setContent {
+            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+                pinnedParkings = if (isPinned) {
+                    pinnedParkings + parkingId
+                } else {
+                    pinnedParkings - parkingId
+                }
             }
-          },
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+
+            SpotCard(
+                navigationActions = mockNavigationActions,
+                parkingViewModel = parkingViewModel,
+                userViewModel = userViewModel,
+                parking = TestInstancesParking.parking2,
+                distance = 0.0,
+                initialIsPinned = false,
+                onPinStatusChanged = handlePinStatusChanged
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("SpotListItem", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performClick()
+
+        composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
+        composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
+
+        verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
+        assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
+    @Test
+    fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
+        // Arrange
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = emptySet(),
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {},
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
 
-    composeTestRule
-        .onNodeWithTag("Rack Type")
-        .assertIsDisplayed()
-        .assertTextEquals("Rack Type")
-        .performClick()
-
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-    composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
-    assert(selectedRackType.contains(ParkingRackType.entries[0]))
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testCapacityFilters() {
-    // Arrange
-    val selectedCapacities = mutableSetOf(ParkingCapacity.XSMALL)
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = selectedCapacities,
-          onAttributeSelected = {
-            when (it) {
-              is ParkingCapacity -> selectedCapacities.add(it)
-            }
-          },
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+        // Act & Assert
+        composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
-    composeTestRule
-        .onNodeWithTag("Capacity")
-        .assertIsDisplayed()
-        .assertTextEquals("Capacity")
-        .performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-    composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
-    assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
-  }
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testShowFiltersButtonTogglesFilterSection() {
+        // Arrange
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = emptySet(),
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {},
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+
+        // Act: Click to hide filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testProtectionFilters() {
+
+        val selectedProtection = mutableSetOf<ParkingProtection>()
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = selectedProtection,
+                selectedRackTypes = emptySet(),
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {
+                    when (it) {
+                        is ParkingProtection -> selectedProtection.add(it)
+                    }
+                },
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
+
+        composeTestRule
+            .onNodeWithTag("Protection")
+            .assertIsDisplayed()
+            .assertTextEquals("Protection")
+            .performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+        composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag("ProtectionFilterItem")
+            .assertCountEquals(ParkingProtection.entries.size)
+            .assertAll(hasClickAction())
+        composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
+        assert(selectedProtection.contains(ParkingProtection.entries[0]))
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testRackTypeFilters() {
+        // Arrange
+        val selectedRackType = mutableSetOf<ParkingRackType>()
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = selectedRackType,
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {
+                    when (it) {
+                        is ParkingRackType -> selectedRackType.add(it)
+                    }
+                },
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
+
+        composeTestRule
+            .onNodeWithTag("Rack Type")
+            .assertIsDisplayed()
+            .assertTextEquals("Rack Type")
+            .performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+        composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
+        composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
+        assert(selectedRackType.contains(ParkingRackType.entries[0]))
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testCapacityFilters() {
+        // Arrange
+        val selectedCapacities = mutableSetOf(ParkingCapacity.XSMALL)
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = emptySet(),
+                selectedCapacities = selectedCapacities,
+                onAttributeSelected = {
+                    when (it) {
+                        is ParkingCapacity -> selectedCapacities.add(it)
+                    }
+                },
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
+
+        composeTestRule
+            .onNodeWithTag("Capacity")
+            .assertIsDisplayed()
+            .assertTextEquals("Capacity")
+            .performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+        composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
+        composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
+        assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testParkingDetailsScreenListsParkings() {
+        val testParking = TestInstancesParking.parking1
+        val loc = testParking.location.center
+        // Prepare to populate the parking list
+        `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
+            it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
+        }
+        `when`(
+            mockParkingRepository.getParkingsBetween(
+                eq(Tile.getTileFromPoint(loc).bottomLeft), any(), any(), any()))
+            .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
+
+        composeTestRule.setContent {
+            SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel, userViewModel)
+        }
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
+
+        // Check that the list is displayed
+        composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag("SpotListItem", useUnmergedTree = true)
+            .assertCountEquals(1)
+            .assertAll(hasClickAction())
+
+        // Check that the parking name is displayed
+        composeTestRule
+            .onNodeWithTag("ParkingName", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(testParking.optName ?: "Unnamed Parking")
+
+        // Check that the parking distance is displayed
+        composeTestRule
+            .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(
+                String.format(
+                    "%.0f m",
+                    TurfMeasurement.distance(
+                        TestInstancesParking.EPFLCenter, testParking.location.center)))
+
+        // Select all 3 criteria
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+
+        // Select Protection
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Protection"))
+        composeTestRule.onNodeWithTag("Protection", useUnmergedTree = true).performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+
+        composeTestRule
+            .onNodeWithTag("ProtectionFilter")
+            .performScrollToIndex(testParking.protection.ordinal)
+        composeTestRule.onNodeWithText(testParking.protection.description).performClick()
+
+        // Select Rack Type
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Rack Type"))
+        composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+
+        composeTestRule
+            .onNodeWithTag("RackTypeFilter")
+            .performScrollToIndex(testParking.rackType.ordinal)
+        composeTestRule
+            .onNodeWithText(testParking.rackType.description)
+            .assertHasClickAction()
+            .performClick()
+
+        composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
+
+        // Select Capacity
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Capacity"))
+        composeTestRule.onNodeWithTag("Capacity", useUnmergedTree = true).performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+
+        composeTestRule
+            .onNodeWithTag("CapacityFilter")
+            .performScrollToIndex(testParking.capacity.ordinal)
+        composeTestRule
+            .onNodeWithText(testParking.capacity.description)
+            .assertHasClickAction()
+            .performClick()
+
+        // Store filters away
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
+        composeTestRule.onAllNodesWithTag("SpotListItem").assertCountEquals(1)
+    }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -506,4 +506,62 @@ class ListScreenTest {
     composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
     assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
   }
+
+  @Test
+  fun testDistanceFormattingM() {
+    composeTestRule.setContent {
+      SpotCard(
+          navigationActions = mockNavigationActions,
+          parkingViewModel = parkingViewModel,
+          userViewModel = userViewModel,
+          parking = TestInstancesParking.parking1,
+          distance = 0.5, // 500m
+          initialIsPinned = false)
+    }
+
+    // Test meters display
+    composeTestRule
+        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+        .assertTextEquals("500 m")
+  }
+
+  @Test
+  fun testDistanceFormattingKM() {
+    composeTestRule.setContent {
+      SpotCard(
+          navigationActions = mockNavigationActions,
+          parkingViewModel = parkingViewModel,
+          userViewModel = userViewModel,
+          parking = TestInstancesParking.parking1,
+          distance = 2.5, // 2.5km
+          initialIsPinned = false)
+    }
+
+    // Test kilometers display
+    composeTestRule
+        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+        .assertTextEquals("2.50 km")
+  }
+
+  @Test
+  fun testParkingNameTruncation() {
+    val longNameParking =
+        TestInstancesParking.parking1.copy(
+            optName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    parkingViewModel.addParking(longNameParking)
+
+    composeTestRule.setContent {
+      SpotCard(
+          navigationActions = mockNavigationActions,
+          parkingViewModel = parkingViewModel,
+          userViewModel = userViewModel,
+          parking = longNameParking,
+          distance = 0.0,
+          initialIsPinned = false)
+    }
+
+    composeTestRule
+        .onNodeWithTag("ParkingName", useUnmergedTree = true)
+        .assertTextEquals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...")
+  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -49,7 +49,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -59,563 +58,553 @@ import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class ListScreenTest {
-    @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private lateinit var mockUserRepository: UserRepository
-    private lateinit var mockParkingRepository: ParkingRepository
-    private lateinit var mockImageRepository: ImageRepository
-    private lateinit var mockNavigationActions: NavigationActions
-    private lateinit var parkingViewModel: ParkingViewModel
-    private lateinit var mapViewModel: MapViewModel
-    private lateinit var userViewModel: UserViewModel
+  private lateinit var mockUserRepository: UserRepository
+  private lateinit var mockParkingRepository: ParkingRepository
+  private lateinit var mockImageRepository: ImageRepository
+  private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var parkingViewModel: ParkingViewModel
+  private lateinit var mapViewModel: MapViewModel
+  private lateinit var userViewModel: UserViewModel
 
-    @Before
-    fun setUp() {
-        MockitoAnnotations.openMocks(this)
-        mockNavigationActions = mock(NavigationActions::class.java)
-        mockUserRepository = MockUserRepository()
-        mockParkingRepository = MockParkingRepository()
-        mockImageRepository = MockImageRepository()
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    mockNavigationActions = mock(NavigationActions::class.java)
+    mockUserRepository = MockUserRepository()
+    mockParkingRepository = MockParkingRepository()
+    mockImageRepository = MockImageRepository()
 
-        parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
-        mapViewModel = MapViewModel()
-        userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+    parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
+    mapViewModel = MapViewModel()
+    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
 
-        `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
+    `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
 
-        // Set up test user
-        val user = User(
+    // Set up test user
+    val user =
+        User(
             UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
-            UserDetails("Jane", "Smith", "jane.smith@example.com")
-        )
+            UserDetails("Jane", "Smith", "jane.smith@example.com"))
 
-        // Set up test data
-        // parking1 already in
-        parkingViewModel.addParking(TestInstancesParking.parking2)
-        parkingViewModel.addParking(TestInstancesParking.parking3)
-        userViewModel.addUser(user)
-        userViewModel.getUserById(user.public.userId)
-        userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
-        userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking2.uid)
-        userViewModel.getSelectedUserFavoriteParking()
-    }
+    // Set up test data
+    // parking1 already in
+    parkingViewModel.addParking(TestInstancesParking.parking2)
+    parkingViewModel.addParking(TestInstancesParking.parking3)
+    userViewModel.addUser(user)
+    userViewModel.getUserById(user.public.userId)
+    userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
+    userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking2.uid)
+    userViewModel.getSelectedUserFavoriteParking()
+  }
 
-
-    @Test
-    fun testPinActionCardDisplayed() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings =
-                    if (isPinned) {
-                        pinnedParkings + parkingId
-                    } else {
-                        pinnedParkings - parkingId
-                    }
+  @Test
+  fun testPinActionCardDisplayed() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                mockNavigationActions,
-                parkingViewModel,
-                userViewModel,
-                TestInstancesParking.parking1,
-                0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged)
-        }
-
-        // Verify that the PinActionCard is displayed
-        composeTestRule.onNodeWithTag("PinActionCard").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("UnpinActionCard").assertIsNotDisplayed()
+      SpotCard(
+          mockNavigationActions,
+          parkingViewModel,
+          userViewModel,
+          TestInstancesParking.parking1,
+          0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
-    @Test
-    fun testUnpinActionCardDisplayed() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings =
-                    if (isPinned) {
-                        pinnedParkings + parkingId
-                    } else {
-                        pinnedParkings - parkingId
-                    }
+    // Verify that the PinActionCard is displayed
+    composeTestRule.onNodeWithTag("PinActionCard").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("UnpinActionCard").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun testUnpinActionCardDisplayed() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
-            SpotCard(
-                mockNavigationActions,
-                parkingViewModel,
-                userViewModel,
-                TestInstancesParking.parking1,
-                0.0,
-                initialIsPinned = true,
-                onPinStatusChanged = handlePinStatusChanged)
-        }
-        composeTestRule.onNodeWithTag("PinActionCard").assertIsNotDisplayed()
-        composeTestRule.onNodeWithTag("UnpinActionCard").assertIsDisplayed()
+      }
+      SpotCard(
+          mockNavigationActions,
+          parkingViewModel,
+          userViewModel,
+          TestInstancesParking.parking1,
+          0.0,
+          initialIsPinned = true,
+          onPinStatusChanged = handlePinStatusChanged)
     }
+    composeTestRule.onNodeWithTag("PinActionCard").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("UnpinActionCard").assertIsDisplayed()
+  }
 
-    @Test
-    fun testAddToFavoritesActionCardDisplayed() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings =
-                    if (isPinned) {
-                        pinnedParkings + parkingId
-                    } else {
-                        pinnedParkings - parkingId
-                    }
+  @Test
+  fun testAddToFavoritesActionCardDisplayed() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                mockNavigationActions,
-                parkingViewModel,
-                userViewModel,
-                TestInstancesParking.parking3, // not in our user's favorites
-                0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged)
-        }
-
-        // Verify that the AddToFavoriteActionCard is displayed
-        composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsNotDisplayed()
+      SpotCard(
+          mockNavigationActions,
+          parkingViewModel,
+          userViewModel,
+          TestInstancesParking.parking3, // not in our user's favorites
+          0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
-    @Test
-    fun testAlreadyFavoriteActionCardDisplayed() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings =
-                    if (isPinned) {
-                        pinnedParkings + parkingId
-                    } else {
-                        pinnedParkings - parkingId
-                    }
+    // Verify that the AddToFavoriteActionCard is displayed
+    composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun testAlreadyFavoriteActionCardDisplayed() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                mockNavigationActions,
-                parkingViewModel,
-                userViewModel,
-                TestInstancesParking.parking1, // in our user's favorites
-                0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged)
-        }
-
-        // Verify that the AlreadyFavoriteActionCard is displayed
-        composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsNotDisplayed()
-        composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsDisplayed()
+      SpotCard(
+          mockNavigationActions,
+          parkingViewModel,
+          userViewModel,
+          TestInstancesParking.parking1, // in our user's favorites
+          0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
-    @Test
-    fun testQuickFavoriteAddsToUserFavorites() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings =
-                    if (isPinned) {
-                        pinnedParkings + parkingId
-                    } else {
-                        pinnedParkings - parkingId
-                    }
+    // Verify that the AlreadyFavoriteActionCard is displayed
+    composeTestRule.onNodeWithTag("AddToFavoriteActionCard").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("AlreadyFavoriteActionCard").assertIsDisplayed()
+  }
+
+  @Test
+  fun testQuickFavoriteAddsToUserFavorites() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                mockNavigationActions,
-                parkingViewModel,
-                userViewModel,
-                TestInstancesParking.parking3,
-                0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged)
-        }
-
-        val isFavorite =
-            userViewModel.currentUser.value
-                ?.details
-                ?.favoriteParkings
-                ?.contains(TestInstancesParking.parking3.uid) ?: false
-        assert(!isFavorite)
-
-        // Perform swipe left to add to favorites using general swipe
-        composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
-            swipe(
-                start = centerRight,
-                end = centerLeft,
-                durationMillis = 300
-            )
-        }
-
-        // Check if the parking was added to favorites
-        val isFavoriteAdded =
-            userViewModel.currentUser.value
-                ?.details
-                ?.favoriteParkings
-                ?.contains(TestInstancesParking.parking3.uid) ?: true
-        assert(isFavoriteAdded)
+      SpotCard(
+          mockNavigationActions,
+          parkingViewModel,
+          userViewModel,
+          TestInstancesParking.parking3,
+          0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
-    @Test
-    fun testQuickFavoriteDoesNothingOnQuickAddAlreadyFavorite() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings =
-                    if (isPinned) {
-                        pinnedParkings + parkingId
-                    } else {
-                        pinnedParkings - parkingId
-                    }
+    val isFavorite =
+        userViewModel.currentUser.value
+            ?.details
+            ?.favoriteParkings
+            ?.contains(TestInstancesParking.parking3.uid) ?: false
+    assert(!isFavorite)
+
+    // Perform swipe left to add to favorites using general swipe
+    composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
+      swipe(start = centerRight, end = centerLeft, durationMillis = 300)
+    }
+
+    // Check if the parking was added to favorites
+    val isFavoriteAdded =
+        userViewModel.currentUser.value
+            ?.details
+            ?.favoriteParkings
+            ?.contains(TestInstancesParking.parking3.uid) ?: true
+    assert(isFavoriteAdded)
+  }
+
+  @Test
+  fun testQuickFavoriteDoesNothingOnQuickAddAlreadyFavorite() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                mockNavigationActions,
-                parkingViewModel,
-                userViewModel,
-                TestInstancesParking.parking1, // already in favorites
-                0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged)
-        }
-
-        val isFavorite =
-            userViewModel.currentUser.value
-                ?.details
-                ?.favoriteParkings
-                ?.contains(TestInstancesParking.parking1.uid) ?: false
-        assert(isFavorite)
-
-        // Perform swipe left to add to favorites using general swipe
-        composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
-            swipe(
-                start = centerRight,
-                end = centerLeft,
-                durationMillis = 300
-            )
-        }
-
-        // Check if the parking was added to favorites
-        val isFavoriteAdded =
-            userViewModel.currentUser.value
-                ?.details
-                ?.favoriteParkings
-                ?.contains(TestInstancesParking.parking1.uid) ?: true
-        assert(isFavoriteAdded)
+      SpotCard(
+          mockNavigationActions,
+          parkingViewModel,
+          userViewModel,
+          TestInstancesParking.parking1, // already in favorites
+          0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
+    val isFavorite =
+        userViewModel.currentUser.value
+            ?.details
+            ?.favoriteParkings
+            ?.contains(TestInstancesParking.parking1.uid) ?: false
+    assert(isFavorite)
 
-    @Test
-    fun testSpotCardIsDisplayed() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings = if (isPinned) {
-                    pinnedParkings + parkingId
-                } else {
-                    pinnedParkings - parkingId
-                }
+    // Perform swipe left to add to favorites using general swipe
+    composeTestRule.onNodeWithTag("SpotListItem").performTouchInput {
+      swipe(start = centerRight, end = centerLeft, durationMillis = 300)
+    }
+
+    // Check if the parking was added to favorites
+    val isFavoriteAdded =
+        userViewModel.currentUser.value
+            ?.details
+            ?.favoriteParkings
+            ?.contains(TestInstancesParking.parking1.uid) ?: true
+    assert(isFavoriteAdded)
+  }
+
+  @Test
+  fun testSpotCardIsDisplayed() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                navigationActions = mockNavigationActions,
-                parkingViewModel = parkingViewModel,
-                userViewModel = userViewModel,
-                parking = TestInstancesParking.parking1,
-                distance = 0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged
-            )
-        }
-
-        composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag("ParkingName", useUnmergedTree = true)
-            .assertIsDisplayed()
-            .assertTextEquals(TestInstancesParking.parking1.optName ?: "Unnamed Parking")
-        composeTestRule
-            .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
-            .assertIsDisplayed()
-            .assertTextEquals(String.format("%.0f m", 0.0))
-        composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
+      SpotCard(
+          navigationActions = mockNavigationActions,
+          parkingViewModel = parkingViewModel,
+          userViewModel = userViewModel,
+          parking = TestInstancesParking.parking1,
+          distance = 0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
-    @Test
-    fun testSpotCardIsClickable() {
-        composeTestRule.setContent {
-            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-                pinnedParkings = if (isPinned) {
-                    pinnedParkings + parkingId
-                } else {
-                    pinnedParkings - parkingId
-                }
+    composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("ParkingName", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextEquals(TestInstancesParking.parking1.optName ?: "Unnamed Parking")
+    composeTestRule
+        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextEquals(String.format("%.0f m", 0.0))
+    composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun testSpotCardIsClickable() {
+    composeTestRule.setContent {
+      var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+      val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+        pinnedParkings =
+            if (isPinned) {
+              pinnedParkings + parkingId
+            } else {
+              pinnedParkings - parkingId
             }
+      }
 
-            SpotCard(
-                navigationActions = mockNavigationActions,
-                parkingViewModel = parkingViewModel,
-                userViewModel = userViewModel,
-                parking = TestInstancesParking.parking2,
-                distance = 0.0,
-                initialIsPinned = false,
-                onPinStatusChanged = handlePinStatusChanged
-            )
-        }
-
-        composeTestRule
-            .onNodeWithTag("SpotListItem", useUnmergedTree = true)
-            .assertIsDisplayed()
-            .assertHasClickAction()
-            .performClick()
-
-        composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsDisplayed()
-        composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
-        composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
-
-        verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
-        assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
+      SpotCard(
+          navigationActions = mockNavigationActions,
+          parkingViewModel = parkingViewModel,
+          userViewModel = userViewModel,
+          parking = TestInstancesParking.parking2,
+          distance = 0.0,
+          initialIsPinned = false,
+          onPinStatusChanged = handlePinStatusChanged)
     }
 
-    @Test
-    fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
-        // Arrange
-        composeTestRule.setContent {
-            FilterHeader(
-                selectedProtection = emptySet(),
-                selectedRackTypes = emptySet(),
-                selectedCapacities = emptySet(),
-                onAttributeSelected = {},
-                onlyWithCCTV = false,
-                onCCTVCheckedChange = {})
-        }
+    composeTestRule
+        .onNodeWithTag("SpotListItem", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
-        // Act & Assert
-        composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
+
+    verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
+    assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
+  }
+
+  @Test
+  fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
+    // Arrange
+    composeTestRule.setContent {
+      FilterHeader(
+          selectedProtection = emptySet(),
+          selectedRackTypes = emptySet(),
+          selectedCapacities = emptySet(),
+          onAttributeSelected = {},
+          onlyWithCCTV = false,
+          onCCTVCheckedChange = {})
     }
 
-    @Test
-    @OptIn(ExperimentalTestApi::class)
-    fun testShowFiltersButtonTogglesFilterSection() {
-        // Arrange
-        composeTestRule.setContent {
-            FilterHeader(
-                selectedProtection = emptySet(),
-                selectedRackTypes = emptySet(),
-                selectedCapacities = emptySet(),
-                onAttributeSelected = {},
-                onlyWithCCTV = false,
-                onCCTVCheckedChange = {})
-        }
+    // Act & Assert
+    composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
+  }
 
-        // Act: Click to show filters
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
-
-        // Act: Click to hide filters
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testShowFiltersButtonTogglesFilterSection() {
+    // Arrange
+    composeTestRule.setContent {
+      FilterHeader(
+          selectedProtection = emptySet(),
+          selectedRackTypes = emptySet(),
+          selectedCapacities = emptySet(),
+          onAttributeSelected = {},
+          onlyWithCCTV = false,
+          onCCTVCheckedChange = {})
     }
 
-    @Test
-    @OptIn(ExperimentalTestApi::class)
-    fun testProtectionFilters() {
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
 
-        val selectedProtection = mutableSetOf<ParkingProtection>()
-        composeTestRule.setContent {
-            FilterHeader(
-                selectedProtection = selectedProtection,
-                selectedRackTypes = emptySet(),
-                selectedCapacities = emptySet(),
-                onAttributeSelected = {
-                    when (it) {
-                        is ParkingProtection -> selectedProtection.add(it)
-                    }
-                },
-                onlyWithCCTV = false,
-                onCCTVCheckedChange = {})
-        }
+    // Act: Click to hide filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+  }
 
-        // Act: Click to show filters
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testProtectionFilters() {
 
-        composeTestRule
-            .onNodeWithTag("Protection")
-            .assertIsDisplayed()
-            .assertTextEquals("Protection")
-            .performClick()
-
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-        composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
-        composeTestRule
-            .onAllNodesWithTag("ProtectionFilterItem")
-            .assertCountEquals(ParkingProtection.entries.size)
-            .assertAll(hasClickAction())
-        composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
-        assert(selectedProtection.contains(ParkingProtection.entries[0]))
+    val selectedProtection = mutableSetOf<ParkingProtection>()
+    composeTestRule.setContent {
+      FilterHeader(
+          selectedProtection = selectedProtection,
+          selectedRackTypes = emptySet(),
+          selectedCapacities = emptySet(),
+          onAttributeSelected = {
+            when (it) {
+              is ParkingProtection -> selectedProtection.add(it)
+            }
+          },
+          onlyWithCCTV = false,
+          onCCTVCheckedChange = {})
     }
 
-    @Test
-    @OptIn(ExperimentalTestApi::class)
-    fun testRackTypeFilters() {
-        // Arrange
-        val selectedRackType = mutableSetOf<ParkingRackType>()
-        composeTestRule.setContent {
-            FilterHeader(
-                selectedProtection = emptySet(),
-                selectedRackTypes = selectedRackType,
-                selectedCapacities = emptySet(),
-                onAttributeSelected = {
-                    when (it) {
-                        is ParkingRackType -> selectedRackType.add(it)
-                    }
-                },
-                onlyWithCCTV = false,
-                onCCTVCheckedChange = {})
-        }
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
 
-        // Act: Click to show filters
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
+    composeTestRule
+        .onNodeWithTag("Protection")
+        .assertIsDisplayed()
+        .assertTextEquals("Protection")
+        .performClick()
 
-        composeTestRule
-            .onNodeWithTag("Rack Type")
-            .assertIsDisplayed()
-            .assertTextEquals("Rack Type")
-            .performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+    composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
+    composeTestRule
+        .onAllNodesWithTag("ProtectionFilterItem")
+        .assertCountEquals(ParkingProtection.entries.size)
+        .assertAll(hasClickAction())
+    composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
+    assert(selectedProtection.contains(ParkingProtection.entries[0]))
+  }
 
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-        composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
-        composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
-        composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
-        assert(selectedRackType.contains(ParkingRackType.entries[0]))
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testRackTypeFilters() {
+    // Arrange
+    val selectedRackType = mutableSetOf<ParkingRackType>()
+    composeTestRule.setContent {
+      FilterHeader(
+          selectedProtection = emptySet(),
+          selectedRackTypes = selectedRackType,
+          selectedCapacities = emptySet(),
+          onAttributeSelected = {
+            when (it) {
+              is ParkingRackType -> selectedRackType.add(it)
+            }
+          },
+          onlyWithCCTV = false,
+          onCCTVCheckedChange = {})
     }
 
-    @Test
-    @OptIn(ExperimentalTestApi::class)
-    fun testCapacityFilters() {
-        // Arrange
-        val selectedCapacities = mutableSetOf(ParkingCapacity.XSMALL)
-        composeTestRule.setContent {
-            FilterHeader(
-                selectedProtection = emptySet(),
-                selectedRackTypes = emptySet(),
-                selectedCapacities = selectedCapacities,
-                onAttributeSelected = {
-                    when (it) {
-                        is ParkingCapacity -> selectedCapacities.add(it)
-                    }
-                },
-                onlyWithCCTV = false,
-                onCCTVCheckedChange = {})
-        }
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
 
-        // Act: Click to show filters
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
+    composeTestRule
+        .onNodeWithTag("Rack Type")
+        .assertIsDisplayed()
+        .assertTextEquals("Rack Type")
+        .performClick()
 
-        composeTestRule
-            .onNodeWithTag("Capacity")
-            .assertIsDisplayed()
-            .assertTextEquals("Capacity")
-            .performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+    composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
+    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
+    assert(selectedRackType.contains(ParkingRackType.entries[0]))
+  }
 
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-        composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
-        composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
-        composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
-        assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testCapacityFilters() {
+    // Arrange
+    val selectedCapacities = mutableSetOf(ParkingCapacity.XSMALL)
+    composeTestRule.setContent {
+      FilterHeader(
+          selectedProtection = emptySet(),
+          selectedRackTypes = emptySet(),
+          selectedCapacities = selectedCapacities,
+          onAttributeSelected = {
+            when (it) {
+              is ParkingCapacity -> selectedCapacities.add(it)
+            }
+          },
+          onlyWithCCTV = false,
+          onCCTVCheckedChange = {})
     }
 
-    @OptIn(ExperimentalTestApi::class)
-    @Test
-    fun testParkingDetailsScreenListsParkings() {
-        val testParking = TestInstancesParking.parking1
-        val loc = testParking.location.center
-        // Prepare to populate the parking list
-        `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
-            it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
-        }
-        `when`(
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
+
+    composeTestRule
+        .onNodeWithTag("Capacity")
+        .assertIsDisplayed()
+        .assertTextEquals("Capacity")
+        .performClick()
+
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+    composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
+    composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
+    assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testParkingDetailsScreenListsParkings() {
+    val testParking = TestInstancesParking.parking1
+    val loc = testParking.location.center
+    // Prepare to populate the parking list
+    `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
+      it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
+    }
+    `when`(
             mockParkingRepository.getParkingsBetween(
                 eq(Tile.getTileFromPoint(loc).bottomLeft), any(), any(), any()))
-            .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
+        .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
 
-        composeTestRule.setContent {
-            SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel, userViewModel)
-        }
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
-
-        // Check that the list is displayed
-        composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
-        composeTestRule
-            .onAllNodesWithTag("SpotListItem", useUnmergedTree = true)
-            .assertCountEquals(1)
-            .assertAll(hasClickAction())
-
-        // Check that the parking name is displayed
-        composeTestRule
-            .onNodeWithTag("ParkingName", useUnmergedTree = true)
-            .assertIsDisplayed()
-            .assertTextEquals(testParking.optName ?: "Unnamed Parking")
-
-        // Check that the parking distance is displayed
-        composeTestRule
-            .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
-            .assertIsDisplayed()
-            .assertTextEquals(
-                String.format(
-                    "%.0f m",
-                    TurfMeasurement.distance(
-                        TestInstancesParking.EPFLCenter, testParking.location.center)))
-
-        // Select all 3 criteria
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-
-        // Select Protection
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Protection"))
-        composeTestRule.onNodeWithTag("Protection", useUnmergedTree = true).performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-
-        composeTestRule
-            .onNodeWithTag("ProtectionFilter")
-            .performScrollToIndex(testParking.protection.ordinal)
-        composeTestRule.onNodeWithText(testParking.protection.description).performClick()
-
-        // Select Rack Type
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Rack Type"))
-        composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-
-        composeTestRule
-            .onNodeWithTag("RackTypeFilter")
-            .performScrollToIndex(testParking.rackType.ordinal)
-        composeTestRule
-            .onNodeWithText(testParking.rackType.description)
-            .assertHasClickAction()
-            .performClick()
-
-        composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
-
-        // Select Capacity
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Capacity"))
-        composeTestRule.onNodeWithTag("Capacity", useUnmergedTree = true).performClick()
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-
-        composeTestRule
-            .onNodeWithTag("CapacityFilter")
-            .performScrollToIndex(testParking.capacity.ordinal)
-        composeTestRule
-            .onNodeWithText(testParking.capacity.description)
-            .assertHasClickAction()
-            .performClick()
-
-        // Store filters away
-        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
-        composeTestRule.onAllNodesWithTag("SpotListItem").assertCountEquals(1)
+    composeTestRule.setContent {
+      SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel, userViewModel)
     }
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
+
+    // Check that the list is displayed
+    composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
+    composeTestRule
+        .onAllNodesWithTag("SpotListItem", useUnmergedTree = true)
+        .assertCountEquals(1)
+        .assertAll(hasClickAction())
+
+    // Check that the parking name is displayed
+    composeTestRule
+        .onNodeWithTag("ParkingName", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextEquals(testParking.optName ?: "Unnamed Parking")
+
+    // Check that the parking distance is displayed
+    composeTestRule
+        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextEquals(
+            String.format(
+                "%.0f m",
+                TurfMeasurement.distance(
+                    TestInstancesParking.EPFLCenter, testParking.location.center)))
+
+    // Select all 3 criteria
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+
+    // Select Protection
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Protection"))
+    composeTestRule.onNodeWithTag("Protection", useUnmergedTree = true).performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+
+    composeTestRule
+        .onNodeWithTag("ProtectionFilter")
+        .performScrollToIndex(testParking.protection.ordinal)
+    composeTestRule.onNodeWithText(testParking.protection.description).performClick()
+
+    // Select Rack Type
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Rack Type"))
+    composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+
+    composeTestRule
+        .onNodeWithTag("RackTypeFilter")
+        .performScrollToIndex(testParking.rackType.ordinal)
+    composeTestRule
+        .onNodeWithText(testParking.rackType.description)
+        .assertHasClickAction()
+        .performClick()
+
+    composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
+
+    // Select Capacity
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Capacity"))
+    composeTestRule.onNodeWithTag("Capacity", useUnmergedTree = true).performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+
+    composeTestRule
+        .onNodeWithTag("CapacityFilter")
+        .performScrollToIndex(testParking.capacity.ordinal)
+    composeTestRule
+        .onNodeWithText(testParking.capacity.description)
+        .assertHasClickAction()
+        .performClick()
+
+    // Store filters away
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
+    composeTestRule.onAllNodesWithTag("SpotListItem").assertCountEquals(1)
+  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -1,5 +1,9 @@
 package com.github.se.cyrcle.ui.list
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertCountEquals
@@ -17,6 +21,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.di.mocks.MockImageRepository
+import com.github.se.cyrcle.di.mocks.MockParkingRepository
+import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ImageRepository
 import com.github.se.cyrcle.model.parking.Parking
@@ -27,6 +34,11 @@ import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.parking.Tile
+import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.model.user.UserDetails
+import com.github.se.cyrcle.model.user.UserPublic
+import com.github.se.cyrcle.model.user.UserRepository
+import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.mapbox.turf.TurfMeasurement
@@ -36,6 +48,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
@@ -44,300 +57,378 @@ import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class ListScreenTest {
+    @get:Rule val composeTestRule = createComposeRule()
 
-  @get:Rule val composeTestRule = createComposeRule()
+    private lateinit var mockUserRepository: UserRepository
+    private lateinit var mockParkingRepository: ParkingRepository
+    private lateinit var mockImageRepository: ImageRepository
+    private lateinit var mockNavigationActions: NavigationActions
+    private lateinit var parkingViewModel: ParkingViewModel
+    private lateinit var mapViewModel: MapViewModel
+    private lateinit var userViewModel: UserViewModel
 
-  @Mock private lateinit var mockParkingRepository: ParkingRepository
-  @Mock private lateinit var mockImageRepository: ImageRepository
-  @Mock private lateinit var mockNavigationActions: NavigationActions
-  private lateinit var parkingViewModel: ParkingViewModel
-  private lateinit var mapViewModel: MapViewModel
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        mockNavigationActions = mock(NavigationActions::class.java)
+        mockUserRepository = MockUserRepository()
+        mockParkingRepository = MockParkingRepository()
+        mockImageRepository = MockImageRepository()
 
-  @Before
-  fun setUp() {
-    // Set up the test environment for the Compose UI test
-    MockitoAnnotations.openMocks(this)
-    parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
-    mapViewModel = MapViewModel()
+        parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
+        mapViewModel = MapViewModel()
+        userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
 
-    `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
-  }
+        `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
 
-  @Test
-  fun testSpotCardIsDisplayed() {
-    composeTestRule.setContent {
-      SpotCard(mockNavigationActions, parkingViewModel, TestInstancesParking.parking1, 0.0)
+        // Set up test user
+        val user = User(
+            UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
+            UserDetails("Jane", "Smith", "jane.smith@example.com")
+        )
+
+        // Set up test data
+        parkingViewModel.addParking(TestInstancesParking.parking1)
+        parkingViewModel.addParking(TestInstancesParking.parking2)
+        parkingViewModel.addParking(TestInstancesParking.parking3)
+        userViewModel.addUser(user)
+        userViewModel.getUserById(user.public.userId)
+        userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
+        userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking2.uid)
+        userViewModel.getSelectedUserFavoriteParking()
     }
 
-    composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("ParkingName", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(TestInstancesParking.parking1.optName ?: "Unnamed Parking")
-    composeTestRule
-        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(String.format("%.0f m", 0.0))
-    composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
-  }
 
-  @Test
-  fun testSpotCardIsClickable() {
-    composeTestRule.setContent {
-      SpotCard(mockNavigationActions, parkingViewModel, TestInstancesParking.parking2, 0.0)
+    @Test
+    fun testPinActionCardDisplayed() {
     }
 
-    composeTestRule
-        .onNodeWithTag("SpotListItem", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertHasClickAction()
-        .performClick()
-
-    composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsDisplayed()
-    composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
-
-    verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
-    assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
-  }
-
-  @Test
-  fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
-    // Arrange
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {},
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+    @Test
+    fun testUnpinActionCardDisplayed() {
     }
 
-    // Act & Assert
-    composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testShowFiltersButtonTogglesFilterSection() {
-    // Arrange
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {},
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+    @Test
+    fun testAddToFavoritesActionCardDisplayed() {
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+    @Test
+    fun testAlreadyFavoriteActionCardDisplayed() {
+    }
 
-    // Act: Click to hide filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
-  }
+    @Test
+    fun testQuickFavoriteAddsToUserFavorites() {
+    }
 
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testProtectionFilters() {
 
-    val selectedProtection = mutableSetOf<ParkingProtection>()
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = selectedProtection,
-          selectedRackTypes = emptySet(),
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {
-            when (it) {
-              is ParkingProtection -> selectedProtection.add(it)
+    @Test
+    fun testSpotCardIsDisplayed() {
+        composeTestRule.setContent {
+            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+                pinnedParkings = if (isPinned) {
+                    pinnedParkings + parkingId
+                } else {
+                    pinnedParkings - parkingId
+                }
             }
-          },
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+
+            SpotCard(
+                navigationActions = mockNavigationActions,
+                parkingViewModel = parkingViewModel,
+                userViewModel = userViewModel,
+                parking = TestInstancesParking.parking1,
+                distance = 0.0,
+                initialIsPinned = false,
+                onPinStatusChanged = handlePinStatusChanged
+            )
+        }
+
+        composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("ParkingName", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(TestInstancesParking.parking1.optName ?: "Unnamed Parking")
+        composeTestRule
+            .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(String.format("%.0f m", 0.0))
+        composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
-
-    composeTestRule
-        .onNodeWithTag("Protection")
-        .assertIsDisplayed()
-        .assertTextEquals("Protection")
-        .performClick()
-
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-    composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag("ProtectionFilterItem")
-        .assertCountEquals(ParkingProtection.entries.size)
-        .assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
-    assert(selectedProtection.contains(ParkingProtection.entries[0]))
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testRackTypeFilters() {
-    // Arrange
-    val selectedRackType = mutableSetOf<ParkingRackType>()
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = selectedRackType,
-          selectedCapacities = emptySet(),
-          onAttributeSelected = {
-            when (it) {
-              is ParkingRackType -> selectedRackType.add(it)
+    @Test
+    fun testSpotCardIsClickable() {
+        composeTestRule.setContent {
+            var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+            val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+                pinnedParkings = if (isPinned) {
+                    pinnedParkings + parkingId
+                } else {
+                    pinnedParkings - parkingId
+                }
             }
-          },
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+
+            SpotCard(
+                navigationActions = mockNavigationActions,
+                parkingViewModel = parkingViewModel,
+                userViewModel = userViewModel,
+                parking = TestInstancesParking.parking2,
+                distance = 0.0,
+                initialIsPinned = false,
+                onPinStatusChanged = handlePinStatusChanged
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTag("SpotListItem", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performClick()
+
+        composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("ParkingNbReviews", useUnmergedTree = true).assertIsNotDisplayed()
+        composeTestRule.onNodeWithTag("ParkingRating", useUnmergedTree = true).assertIsNotDisplayed()
+
+        verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
+        assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
+    @Test
+    fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
+        // Arrange
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = emptySet(),
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {},
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
 
-    composeTestRule
-        .onNodeWithTag("Rack Type")
-        .assertIsDisplayed()
-        .assertTextEquals("Rack Type")
-        .performClick()
-
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-    composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
-    assert(selectedRackType.contains(ParkingRackType.entries[0]))
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testCapacityFilters() {
-    // Arrange
-    val selectedCapacities = mutableSetOf(ParkingCapacity.XSMALL)
-    composeTestRule.setContent {
-      FilterHeader(
-          selectedProtection = emptySet(),
-          selectedRackTypes = emptySet(),
-          selectedCapacities = selectedCapacities,
-          onAttributeSelected = {
-            when (it) {
-              is ParkingCapacity -> selectedCapacities.add(it)
-            }
-          },
-          onlyWithCCTV = false,
-          onCCTVCheckedChange = {})
+        // Act & Assert
+        composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
     }
 
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testShowFiltersButtonTogglesFilterSection() {
+        // Arrange
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = emptySet(),
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {},
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
 
-    composeTestRule
-        .onNodeWithTag("Capacity")
-        .assertIsDisplayed()
-        .assertTextEquals("Capacity")
-        .performClick()
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
 
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-    composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
-    assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
-  }
-
-  @OptIn(ExperimentalTestApi::class)
-  @Test
-  fun testParkingDetailsScreenListsParkings() {
-    val testParking = TestInstancesParking.parking1
-    val loc = testParking.location.center
-    // Prepare to populate the parking list
-    `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
-      it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
+        // Act: Click to hide filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
     }
-    `when`(
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testProtectionFilters() {
+
+        val selectedProtection = mutableSetOf<ParkingProtection>()
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = selectedProtection,
+                selectedRackTypes = emptySet(),
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {
+                    when (it) {
+                        is ParkingProtection -> selectedProtection.add(it)
+                    }
+                },
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
+
+        composeTestRule
+            .onNodeWithTag("Protection")
+            .assertIsDisplayed()
+            .assertTextEquals("Protection")
+            .performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+        composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag("ProtectionFilterItem")
+            .assertCountEquals(ParkingProtection.entries.size)
+            .assertAll(hasClickAction())
+        composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
+        assert(selectedProtection.contains(ParkingProtection.entries[0]))
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testRackTypeFilters() {
+        // Arrange
+        val selectedRackType = mutableSetOf<ParkingRackType>()
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = selectedRackType,
+                selectedCapacities = emptySet(),
+                onAttributeSelected = {
+                    when (it) {
+                        is ParkingRackType -> selectedRackType.add(it)
+                    }
+                },
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
+
+        composeTestRule
+            .onNodeWithTag("Rack Type")
+            .assertIsDisplayed()
+            .assertTextEquals("Rack Type")
+            .performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+        composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
+        composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
+        assert(selectedRackType.contains(ParkingRackType.entries[0]))
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun testCapacityFilters() {
+        // Arrange
+        val selectedCapacities = mutableSetOf(ParkingCapacity.XSMALL)
+        composeTestRule.setContent {
+            FilterHeader(
+                selectedProtection = emptySet(),
+                selectedRackTypes = emptySet(),
+                selectedCapacities = selectedCapacities,
+                onAttributeSelected = {
+                    when (it) {
+                        is ParkingCapacity -> selectedCapacities.add(it)
+                    }
+                },
+                onlyWithCCTV = false,
+                onCCTVCheckedChange = {})
+        }
+
+        // Act: Click to show filters
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
+
+        composeTestRule
+            .onNodeWithTag("Capacity")
+            .assertIsDisplayed()
+            .assertTextEquals("Capacity")
+            .performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+        composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
+        composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
+        assert(selectedCapacities.contains(ParkingCapacity.entries[0]))
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testParkingDetailsScreenListsParkings() {
+        val testParking = TestInstancesParking.parking1
+        val loc = testParking.location.center
+        // Prepare to populate the parking list
+        `when`(mockParkingRepository.getParkingsBetween(any(), any(), any(), any())).then {
+            it.getArgument<(List<Parking>) -> Unit>(2)(emptyList())
+        }
+        `when`(
             mockParkingRepository.getParkingsBetween(
                 eq(Tile.getTileFromPoint(loc).bottomLeft), any(), any(), any()))
-        .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
+            .then { it.getArgument<(List<Parking>) -> Unit>(2)(listOf(testParking)) }
 
-    composeTestRule.setContent {
-      SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel)
+        composeTestRule.setContent {
+            SpotListScreen(mockNavigationActions, parkingViewModel, mapViewModel, userViewModel)
+        }
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
+
+        // Check that the list is displayed
+        composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag("SpotListItem", useUnmergedTree = true)
+            .assertCountEquals(1)
+            .assertAll(hasClickAction())
+
+        // Check that the parking name is displayed
+        composeTestRule
+            .onNodeWithTag("ParkingName", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(testParking.optName ?: "Unnamed Parking")
+
+        // Check that the parking distance is displayed
+        composeTestRule
+            .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
+            .assertIsDisplayed()
+            .assertTextEquals(
+                String.format(
+                    "%.0f m",
+                    TurfMeasurement.distance(
+                        TestInstancesParking.EPFLCenter, testParking.location.center)))
+
+        // Select all 3 criteria
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+
+        // Select Protection
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Protection"))
+        composeTestRule.onNodeWithTag("Protection", useUnmergedTree = true).performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+
+        composeTestRule
+            .onNodeWithTag("ProtectionFilter")
+            .performScrollToIndex(testParking.protection.ordinal)
+        composeTestRule.onNodeWithText(testParking.protection.description).performClick()
+
+        // Select Rack Type
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Rack Type"))
+        composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+
+        composeTestRule
+            .onNodeWithTag("RackTypeFilter")
+            .performScrollToIndex(testParking.rackType.ordinal)
+        composeTestRule
+            .onNodeWithText(testParking.rackType.description)
+            .assertHasClickAction()
+            .performClick()
+
+        composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
+
+        // Select Capacity
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Capacity"))
+        composeTestRule.onNodeWithTag("Capacity", useUnmergedTree = true).performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+
+        composeTestRule
+            .onNodeWithTag("CapacityFilter")
+            .performScrollToIndex(testParking.capacity.ordinal)
+        composeTestRule
+            .onNodeWithText(testParking.capacity.description)
+            .assertHasClickAction()
+            .performClick()
+
+        // Store filters away
+        composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
+        composeTestRule.onAllNodesWithTag("SpotListItem").assertCountEquals(1)
     }
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListColumn"))
-
-    // Check that the list is displayed
-    composeTestRule.onNodeWithTag("SpotListColumn").assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag("SpotListItem", useUnmergedTree = true)
-        .assertCountEquals(1)
-        .assertAll(hasClickAction())
-
-    // Check that the parking name is displayed
-    composeTestRule
-        .onNodeWithTag("ParkingName", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(testParking.optName ?: "Unnamed Parking")
-
-    // Check that the parking distance is displayed
-    composeTestRule
-        .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(
-            String.format(
-                "%.0f m",
-                TurfMeasurement.distance(
-                    TestInstancesParking.EPFLCenter, testParking.location.center)))
-
-    // Select all 3 criteria
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-
-    // Select Protection
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Protection"))
-    composeTestRule.onNodeWithTag("Protection", useUnmergedTree = true).performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-
-    composeTestRule
-        .onNodeWithTag("ProtectionFilter")
-        .performScrollToIndex(testParking.protection.ordinal)
-    composeTestRule.onNodeWithText(testParking.protection.description).performClick()
-
-    // Select Rack Type
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Rack Type"))
-    composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-
-    composeTestRule
-        .onNodeWithTag("RackTypeFilter")
-        .performScrollToIndex(testParking.rackType.ordinal)
-    composeTestRule
-        .onNodeWithText(testParking.rackType.description)
-        .assertHasClickAction()
-        .performClick()
-
-    composeTestRule.onNodeWithTag("Rack Type", useUnmergedTree = true).performClick()
-
-    // Select Capacity
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("Capacity"))
-    composeTestRule.onNodeWithTag("Capacity", useUnmergedTree = true).performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-
-    composeTestRule
-        .onNodeWithTag("CapacityFilter")
-        .performScrollToIndex(testParking.capacity.ordinal)
-    composeTestRule
-        .onNodeWithText(testParking.capacity.description)
-        .assertHasClickAction()
-        .performClick()
-
-    // Store filters away
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
-    composeTestRule.onAllNodesWithTag("SpotListItem").assertCountEquals(1)
-  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
@@ -83,15 +82,8 @@ class ReviewScreenTest {
     composeTestRule.setContent {
       ReviewScreen(mockNavigationActions, parkingViewModel, reviewViewModel, userViewModel)
     }
-
-    // Assert initial value of the slider
-    composeTestRule.onNodeWithText("Rating: 0.0").assertExists()
-
     // Perform actions on the slider
     composeTestRule.onNodeWithTag("Slider").performTouchInput { swipeRight() }
-
-    // Assert value after slider change
-    composeTestRule.onNodeWithText("Rating: 5.0").assertExists()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onChildAt
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -206,8 +205,7 @@ class MainActivityTest {
       composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SpotListItem"))
       composeTestRule.onNodeWithTag("SpotListColumn").performScrollToIndex(index)
       composeTestRule
-          .onNodeWithTag("SpotListColumn")
-          .onChildAt(index)
+          .onAllNodesWithTag("SpotListItem")[index]
           .assertIsDisplayed()
           .assertHasClickAction()
           .performClick()

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -47,9 +47,7 @@ fun CyrcleNavHost(
         startDestination = Screen.LIST,
         route = Route.LIST,
     ) {
-      composable(Screen.LIST) {
-        SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
-      }
+      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel) }
       composable(Screen.PARKING_DETAILS) {
         ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
       }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -47,7 +47,9 @@ fun CyrcleNavHost(
         startDestination = Screen.LIST,
         route = Route.LIST,
     ) {
-      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel) }
+      composable(Screen.LIST) {
+        SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
+      }
       composable(Screen.PARKING_DETAILS) {
         ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
       }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -47,7 +47,7 @@ fun CyrcleNavHost(
         startDestination = Screen.LIST,
         route = Route.LIST,
     ) {
-      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel, mapViewModel) }
+      composable(Screen.LIST) { SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel) }
       composable(Screen.PARKING_DETAILS) {
         ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
       }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -11,6 +11,7 @@ import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 const val DEFAULT_RADIUS = 100.0
@@ -209,6 +210,25 @@ class ParkingViewModel(
   fun setSelectedCapacities(capacities: Set<ParkingCapacity>) {
     _selectedCapacities.value = capacities
     updateClosestParkings(0)
+  }
+
+  // State for pins
+  private val _pinnedParkings = MutableStateFlow<Set<Parking>>(emptySet())
+  val pinnedParkings: StateFlow<Set<Parking>> = _pinnedParkings
+
+  /**
+   * Toggles the pin status of a parking.
+   *
+   * @param parking the parking to toggle the pin status of
+   */
+  fun togglePinStatus(parking: Parking) {
+    _pinnedParkings.update { currentPinned ->
+      if (currentPinned.contains(parking)) {
+        currentPinned - parking
+      } else {
+        currentPinned + parking
+      }
+    }
   }
 
   private val _onlyWithCCTV = MutableStateFlow(false)

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -58,6 +58,7 @@ import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.map.drawRectangles
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
+import com.github.se.cyrcle.ui.theme.Typography
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.molecules.BooleanRadioButton
 import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
@@ -232,45 +233,52 @@ fun BottomBarAddAttr(
     validInputs: Boolean,
     onSubmit: () -> Unit
 ) {
-  Box(Modifier.background(Color.White).testTag("AttributesPickerBottomBar")) {
-    Row(
-        Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically) {
-          Button(
-              { navigationActions.navigateTo(TopLevelDestinations.MAP) },
-              modifier = Modifier.testTag("cancelButton"),
-              colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
-                Text(
-                    stringResource(R.string.attributes_picker_bottom_bar_cancel_button),
-                    color = MaterialTheme.colorScheme.primary,
-                    fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center)
-              }
+  Box(
+      Modifier.background(Color.White)
+          .height(100.dp) // Matching the height of LocationPickerBottomBar
+          .testTag("AttributesPickerBottomBar")) {
+        Row(
+            Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp).background(Color.White),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically) {
+              Button(
+                  onClick = { navigationActions.navigateTo(TopLevelDestinations.MAP) },
+                  modifier = Modifier.testTag("cancelButton"),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
+                    Text(
+                        text = stringResource(R.string.attributes_picker_bottom_bar_cancel_button),
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold,
+                        style = Typography.headlineMedium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.width(100.dp))
+                  }
 
-          VerticalDivider(
-              color = MaterialTheme.colorScheme.primary,
-              modifier = Modifier.height(32.dp).width(1.dp),
-              thickness = 2.dp)
+              VerticalDivider(
+                  color = MaterialTheme.colorScheme.primary,
+                  modifier = Modifier.height(32.dp).width(1.dp),
+                  thickness = 2.dp)
 
-          val toast =
-              Toast.makeText(
-                  LocalContext.current,
-                  stringResource(R.string.attributes_picker_bottom_bar_submit_button_toast),
-                  Toast.LENGTH_SHORT)
-          Button(
-              onClick = { if (validInputs) onSubmit() else toast.show() },
-              modifier = Modifier.testTag("submitButton"),
-              colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
-                Text(
-                    stringResource(R.string.attributes_picker_bottom_bar_submit_button),
-                    color = if (validInputs) MaterialTheme.colorScheme.primary else Color.Gray,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center)
-              }
-        }
-  }
+              val toast =
+                  Toast.makeText(
+                      LocalContext.current,
+                      stringResource(R.string.attributes_picker_bottom_bar_submit_button_toast),
+                      Toast.LENGTH_SHORT)
+
+              Button(
+                  onClick = { if (validInputs) onSubmit() else toast.show() },
+                  modifier = Modifier.testTag("submitButton"),
+                  colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
+                    Text(
+                        text = stringResource(R.string.attributes_picker_bottom_bar_submit_button),
+                        color = if (validInputs) MaterialTheme.colorScheme.primary else Color.Gray,
+                        fontWeight = FontWeight.Bold,
+                        style = Typography.headlineMedium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.width(100.dp))
+                  }
+            }
+      }
 }
 
 @Composable

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -82,93 +81,70 @@ fun SpotListScreen(
     userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
 ) {
 
-    val userPosition by mapViewModel.userPosition.collectAsState()
+  val userPosition by mapViewModel.userPosition.collectAsState()
 
-    var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
-    val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
-        pinnedParkings = if (isPinned) {
-            pinnedParkings + parkingId
+  var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
+  val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
+    pinnedParkings =
+        if (isPinned) {
+          pinnedParkings + parkingId
         } else {
-            pinnedParkings - parkingId
+          pinnedParkings - parkingId
         }
-    }
+  }
 
-    val filteredParkingSpots by parkingViewModel.closestParkings.collectAsState()
+  val filteredParkingSpots by parkingViewModel.closestParkings.collectAsState()
 
-    val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
-    val selectedRackTypes by parkingViewModel.selectedRackTypes.collectAsState()
-    val selectedCapacities by parkingViewModel.selectedCapacities.collectAsState()
-    val onlyWithCCTV by parkingViewModel.onlyWithCCTV.collectAsState()
+  val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
+  val selectedRackTypes by parkingViewModel.selectedRackTypes.collectAsState()
+  val selectedCapacities by parkingViewModel.selectedCapacities.collectAsState()
+  val onlyWithCCTV by parkingViewModel.onlyWithCCTV.collectAsState()
 
-    // Set the center of the circle as the user's location when the screen is launched.
-    LaunchedEffect(userPosition) { parkingViewModel.setCircleCenter(userPosition) }
+  // Set the center of the circle as the user's location when the screen is launched.
+  LaunchedEffect(userPosition) { parkingViewModel.setCircleCenter(userPosition) }
 
-    Scaffold(
-        modifier = Modifier.testTag("SpotListScreen"),
-        bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.LIST) }) {
-            innerPadding ->
+  Scaffold(
+      modifier = Modifier.testTag("SpotListScreen"),
+      bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.LIST) }) {
+          innerPadding ->
         Column(modifier = Modifier.fillMaxSize().padding(innerPadding).padding(bottom = 16.dp)) {
-            FilterHeader(
-                selectedProtection = selectedProtection,
-                selectedRackTypes = selectedRackTypes,
-                selectedCapacities = selectedCapacities,
-                onAttributeSelected = { attribute ->
-                    when (attribute) {
-                        is ParkingProtection ->
-                            parkingViewModel.setSelectedProtection(
-                                toggleSelection(selectedProtection, attribute))
-                        is ParkingRackType ->
-                            parkingViewModel.setSelectedRackTypes(
-                                toggleSelection(selectedRackTypes, attribute))
-                        is ParkingCapacity ->
-                            parkingViewModel.setSelectedCapacities(
-                                toggleSelection(selectedCapacities, attribute))
-                    }
-                },
-                onlyWithCCTV = onlyWithCCTV,
-                onCCTVCheckedChange = { parkingViewModel.setOnlyWithCCTV(it) },
-                parkingViewModel = parkingViewModel)
-
-            val listState = rememberLazyListState()
-            LazyColumn(
-                state = listState,
-                contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.testTag("SpotListColumn")
-            ) {
-                if (pinnedParkings.isNotEmpty()) {
-                    item {
-                        Text(
-                            text = "Pinned Spots",
-                            style = MaterialTheme.typography.titleMedium,
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                    items(items = filteredParkingSpots.filter { it.uid in pinnedParkings }) { parking ->
-                        val distance = TurfMeasurement.distance(userPosition, parking.location.center)
-                        SpotCard(
-                            navigationActions = navigationActions,
-                            parkingViewModel = parkingViewModel,
-                            userViewModel = userViewModel,
-                            parking = parking,
-                            distance = distance,
-                            initialIsPinned = true,
-                            onPinStatusChanged = handlePinStatusChanged
-                        )
-                    }
-                    item {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "All Spots",
-                            style = MaterialTheme.typography.titleMedium,
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
+          FilterHeader(
+              selectedProtection = selectedProtection,
+              selectedRackTypes = selectedRackTypes,
+              selectedCapacities = selectedCapacities,
+              onAttributeSelected = { attribute ->
+                when (attribute) {
+                  is ParkingProtection ->
+                      parkingViewModel.setSelectedProtection(
+                          toggleSelection(selectedProtection, attribute))
+                  is ParkingRackType ->
+                      parkingViewModel.setSelectedRackTypes(
+                          toggleSelection(selectedRackTypes, attribute))
+                  is ParkingCapacity ->
+                      parkingViewModel.setSelectedCapacities(
+                          toggleSelection(selectedCapacities, attribute))
                 }
+              },
+              onlyWithCCTV = onlyWithCCTV,
+              onCCTVCheckedChange = { parkingViewModel.setOnlyWithCCTV(it) },
+              parkingViewModel = parkingViewModel)
 
-                items(items = filteredParkingSpots.filter { it.uid !in pinnedParkings }) { parking ->
+          val listState = rememberLazyListState()
+          LazyColumn(
+              state = listState,
+              contentPadding = PaddingValues(16.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+              modifier = Modifier.testTag("SpotListColumn")) {
+                if (pinnedParkings.isNotEmpty()) {
+                  item {
+                    Text(
+                        text = "Pinned Spots",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.primary)
+                  }
+                  items(items = filteredParkingSpots.filter { it.uid in pinnedParkings }) { parking
+                    ->
                     val distance = TurfMeasurement.distance(userPosition, parking.location.center)
                     SpotCard(
                         navigationActions = navigationActions,
@@ -176,17 +152,38 @@ fun SpotListScreen(
                         userViewModel = userViewModel,
                         parking = parking,
                         distance = distance,
-                        initialIsPinned = false,
-                        onPinStatusChanged = handlePinStatusChanged
-                    )
-
-                    if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
-                        parkingViewModel.incrementRadius()
-                    }
+                        initialIsPinned = true,
+                        onPinStatusChanged = handlePinStatusChanged)
+                  }
+                  item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "All Spots",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.primary)
+                  }
                 }
-            }
+
+                items(items = filteredParkingSpots.filter { it.uid !in pinnedParkings }) { parking
+                  ->
+                  val distance = TurfMeasurement.distance(userPosition, parking.location.center)
+                  SpotCard(
+                      navigationActions = navigationActions,
+                      parkingViewModel = parkingViewModel,
+                      userViewModel = userViewModel,
+                      parking = parking,
+                      distance = distance,
+                      initialIsPinned = false,
+                      onPinStatusChanged = handlePinStatusChanged)
+
+                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
+                    parkingViewModel.incrementRadius()
+                  }
+                }
+              }
         }
-    }
+      }
 }
 
 @Composable
@@ -199,101 +196,101 @@ fun FilterHeader(
     onCCTVCheckedChange: (Boolean) -> Unit,
     parkingViewModel: ParkingViewModel = viewModel(factory = ParkingViewModel.Factory)
 ) {
-    var showProtectionOptions by remember { mutableStateOf(false) }
-    var showRackTypeOptions by remember { mutableStateOf(false) }
-    var showCapacityOptions by remember { mutableStateOf(false) }
-    var showFilters by remember { mutableStateOf(false) }
-    val radius = parkingViewModel.radius.collectAsState()
-    Column(modifier = Modifier.padding(16.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically) {
+  var showProtectionOptions by remember { mutableStateOf(false) }
+  var showRackTypeOptions by remember { mutableStateOf(false) }
+  var showCapacityOptions by remember { mutableStateOf(false) }
+  var showFilters by remember { mutableStateOf(false) }
+  val radius = parkingViewModel.radius.collectAsState()
+  Column(modifier = Modifier.padding(16.dp)) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically) {
+          Text(
+              text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
+              modifier = Modifier.weight(1f),
+              style = MaterialTheme.typography.headlineMedium,
+              color = MaterialTheme.colorScheme.onSurface)
+
+          SmallFloatingActionButton(
+              onClick = { showFilters = !showFilters },
+              icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
+              contentDescription = "Filter",
+              testTag = "ShowFiltersButton")
+        }
+
+    if (showFilters) {
+      FilterSection(
+          title = stringResource(R.string.list_screen_protection),
+          isExpanded = showProtectionOptions,
+          onToggle = { showProtectionOptions = !showProtectionOptions }) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().testTag("ProtectionFilter"),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                  items(ParkingProtection.entries.toTypedArray()) { option ->
+                    ToggleButton(
+                        text = option.description,
+                        onClick = { onAttributeSelected(option) },
+                        value = selectedProtection.contains(option),
+                        modifier = Modifier.padding(2.dp),
+                        testTag = "ProtectionFilterItem")
+                  }
+                }
+          }
+
+      FilterSection(
+          title = stringResource(R.string.list_screen_rack_type),
+          isExpanded = showRackTypeOptions,
+          onToggle = { showRackTypeOptions = !showRackTypeOptions }) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().testTag("RackTypeFilter"),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                  items(ParkingRackType.entries.toTypedArray()) { option ->
+                    ToggleButton(
+                        text = option.description,
+                        onClick = { onAttributeSelected(option) },
+                        value = selectedRackTypes.contains(option),
+                        modifier = Modifier.padding(2.dp),
+                        testTag = "RackTypeFilterItem")
+                  }
+                }
+          }
+
+      FilterSection(
+          title = stringResource(R.string.list_screen_capacity),
+          isExpanded = showCapacityOptions,
+          onToggle = { showCapacityOptions = !showCapacityOptions }) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().testTag("CapacityFilter"),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                  items(ParkingCapacity.entries.toTypedArray()) { option ->
+                    ToggleButton(
+                        text = option.description,
+                        onClick = { onAttributeSelected(option) },
+                        value = selectedCapacities.contains(option),
+                        modifier = Modifier.padding(2.dp),
+                        testTag = "CapacityFilterItem")
+                  }
+                }
+          }
+
+      // CCTV filter with checkbox
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(8.dp),
+          verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = onlyWithCCTV,
+                onCheckedChange = onCCTVCheckedChange,
+                modifier = Modifier.testTag("CCTVCheckbox"))
+            Spacer(modifier = Modifier.width(4.dp))
             Text(
-                text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
-                modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface)
-
-            SmallFloatingActionButton(
-                onClick = { showFilters = !showFilters },
-                icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
-                contentDescription = "Filter",
-                testTag = "ShowFiltersButton")
-        }
-
-        if (showFilters) {
-            FilterSection(
-                title = stringResource(R.string.list_screen_protection),
-                isExpanded = showProtectionOptions,
-                onToggle = { showProtectionOptions = !showProtectionOptions }) {
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth().testTag("ProtectionFilter"),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    items(ParkingProtection.entries.toTypedArray()) { option ->
-                        ToggleButton(
-                            text = option.description,
-                            onClick = { onAttributeSelected(option) },
-                            value = selectedProtection.contains(option),
-                            modifier = Modifier.padding(2.dp),
-                            testTag = "ProtectionFilterItem")
-                    }
-                }
-            }
-
-            FilterSection(
-                title = stringResource(R.string.list_screen_rack_type),
-                isExpanded = showRackTypeOptions,
-                onToggle = { showRackTypeOptions = !showRackTypeOptions }) {
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth().testTag("RackTypeFilter"),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    items(ParkingRackType.entries.toTypedArray()) { option ->
-                        ToggleButton(
-                            text = option.description,
-                            onClick = { onAttributeSelected(option) },
-                            value = selectedRackTypes.contains(option),
-                            modifier = Modifier.padding(2.dp),
-                            testTag = "RackTypeFilterItem")
-                    }
-                }
-            }
-
-            FilterSection(
-                title = stringResource(R.string.list_screen_capacity),
-                isExpanded = showCapacityOptions,
-                onToggle = { showCapacityOptions = !showCapacityOptions }) {
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth().testTag("CapacityFilter"),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    items(ParkingCapacity.entries.toTypedArray()) { option ->
-                        ToggleButton(
-                            text = option.description,
-                            onClick = { onAttributeSelected(option) },
-                            value = selectedCapacities.contains(option),
-                            modifier = Modifier.padding(2.dp),
-                            testTag = "CapacityFilterItem")
-                    }
-                }
-            }
-
-            // CCTV filter with checkbox
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(
-                    checked = onlyWithCCTV,
-                    onCheckedChange = onCCTVCheckedChange,
-                    modifier = Modifier.testTag("CCTVCheckbox"))
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = stringResource(R.string.list_screen_display_only_cctv),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.testTag("CCTVCheckboxLabel"))
-            }
-        }
+                text = stringResource(R.string.list_screen_display_only_cctv),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.testTag("CCTVCheckboxLabel"))
+          }
     }
+  }
 }
 
 @Composable
@@ -303,12 +300,12 @@ fun FilterSection(
     onToggle: () -> Unit,
     content: @Composable () -> Unit
 ) {
-    Column(
-        modifier =
-        Modifier.padding(8.dp)
-            .border(1.dp, Color.Gray, shape = MaterialTheme.shapes.medium)
-            .background(MaterialTheme.colorScheme.surface, shape = MaterialTheme.shapes.medium)
-            .padding(8.dp)) {
+  Column(
+      modifier =
+          Modifier.padding(8.dp)
+              .border(1.dp, Color.Gray, shape = MaterialTheme.shapes.medium)
+              .background(MaterialTheme.colorScheme.surface, shape = MaterialTheme.shapes.medium)
+              .padding(8.dp)) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleMedium,
@@ -317,9 +314,9 @@ fun FilterSection(
             testTag = title)
 
         if (isExpanded) {
-            content()
+          content()
         }
-    }
+      }
 }
 
 @Composable
@@ -332,142 +329,142 @@ fun SpotCard(
     initialIsPinned: Boolean,
     onPinStatusChanged: (String, Boolean) -> Unit
 ) {
-    val context = LocalContext.current
-    var offsetX by remember { mutableStateOf(0f) }
-    val maxSwipeDistance = 150.dp
-    val userState by userViewModel.currentUser.collectAsState()
-    val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
-    val isFavorite = userState?.details?.favoriteParkings.orEmpty().contains(parking.uid)
+  val context = LocalContext.current
+  var offsetX by remember { mutableStateOf(0f) }
+  val maxSwipeDistance = 150.dp
+  val userState by userViewModel.currentUser.collectAsState()
+  val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
+  val isFavorite = userState?.details?.favoriteParkings.orEmpty().contains(parking.uid)
 
-    Box(modifier = Modifier.fillMaxWidth().height(120.dp).padding(4.dp)) {
-        // Background actions
-        Row(
-            modifier = Modifier.fillMaxSize(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically) {
+  Box(modifier = Modifier.fillMaxWidth().height(120.dp).padding(4.dp)) {
+    // Background actions
+    Row(
+        modifier = Modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically) {
+          ActionCard(
+              text = if (initialIsPinned) "Remove pin" else "Pin parking spot",
+              icon = Icons.Default.PushPin,
+              backgroundColor =
+                  if (initialIsPinned) Color.Red.copy(alpha = 0.7f) else Color.LightGray,
+              modifier =
+                  Modifier.fillMaxHeight()
+                      .weight(1f)
+                      .testTag(if (initialIsPinned) "UnpinActionCard" else "PinActionCard"))
+
+          if (isFavorite) {
             ActionCard(
-                text = if (initialIsPinned) "Remove pin" else "Pin parking spot",
-                icon = Icons.Default.PushPin,
-                backgroundColor =
-                if (initialIsPinned) Color.Red.copy(alpha = 0.7f) else Color.LightGray,
-                modifier =
-                Modifier.fillMaxHeight()
-                    .weight(1f)
-                    .testTag(if (initialIsPinned) "UnpinActionCard" else "PinActionCard"))
-
-            if (isFavorite) {
-                ActionCard(
-                    text = "Already in favorites",
-                    icon = Icons.Default.Star,
-                    backgroundColor = Color.Gray,
-                    modifier = Modifier.fillMaxHeight().weight(1f).testTag("AlreadyFavoriteActionCard"))
-            } else {
-                ActionCard(
-                    text = "Add to favorites",
-                    icon = Icons.Default.Star,
-                    backgroundColor = Color.Yellow,
-                    modifier = Modifier.fillMaxHeight().weight(1f).testTag("AddToFavoriteActionCard"))
-            }
+                text = "Already in favorites",
+                icon = Icons.Default.Star,
+                backgroundColor = Color.Gray,
+                modifier = Modifier.fillMaxHeight().weight(1f).testTag("AlreadyFavoriteActionCard"))
+          } else {
+            ActionCard(
+                text = "Add to favorites",
+                icon = Icons.Default.Star,
+                backgroundColor = Color.Yellow,
+                modifier = Modifier.fillMaxHeight().weight(1f).testTag("AddToFavoriteActionCard"))
+          }
         }
 
-        // Main card
-        Card(
-            modifier =
+    // Main card
+    Card(
+        modifier =
             Modifier.fillMaxWidth()
                 .height(120.dp)
                 .offset { IntOffset(offsetX.roundToInt(), 0) }
                 .pointerInput(Unit) {
-                    detectHorizontalDragGestures(
-                        onDragEnd = {
-                            if (offsetX > maxSwipeDistance.toPx() / 2) {
-                                // Swipe right action: Pin parking
-                                onPinStatusChanged(parking.uid, !initialIsPinned)
-                            } else if (offsetX < -maxSwipeDistance.toPx() / 2) {
-                                // Swipe left action: Add to favorites
-                                if (!isFavorite && userSignedIn.value) {
-                                    userState?.let { user ->
-                                        userViewModel.addFavoriteParkingToSelectedUser(parking.uid)
-                                        userViewModel.getSelectedUserFavoriteParking()
-                                    }
-                                } else if (!userSignedIn.value) {
-                                    Toast.makeText(
-                                        context, "Please sign in to add favorites", Toast.LENGTH_SHORT)
-                                        .show()
-                                } else if (isFavorite) {
-                                    Toast.makeText(
-                                        context, "Parking is already in favorites", Toast.LENGTH_SHORT)
-                                        .show()
-                                }
+                  detectHorizontalDragGestures(
+                      onDragEnd = {
+                        if (offsetX > maxSwipeDistance.toPx() / 2) {
+                          // Swipe right action: Pin parking
+                          onPinStatusChanged(parking.uid, !initialIsPinned)
+                        } else if (offsetX < -maxSwipeDistance.toPx() / 2) {
+                          // Swipe left action: Add to favorites
+                          if (!isFavorite && userSignedIn.value) {
+                            userState?.let { user ->
+                              userViewModel.addFavoriteParkingToSelectedUser(parking.uid)
+                              userViewModel.getSelectedUserFavoriteParking()
                             }
-                            offsetX = 0f
-                        }) { change, dragAmount ->
+                          } else if (!userSignedIn.value) {
+                            Toast.makeText(
+                                    context, "Please sign in to add favorites", Toast.LENGTH_SHORT)
+                                .show()
+                          } else if (isFavorite) {
+                            Toast.makeText(
+                                    context, "Parking is already in favorites", Toast.LENGTH_SHORT)
+                                .show()
+                          }
+                        }
+                        offsetX = 0f
+                      }) { change, dragAmount ->
                         change.consume()
                         offsetX =
                             (offsetX + dragAmount).coerceIn(
                                 -maxSwipeDistance.toPx(), maxSwipeDistance.toPx())
-                    }
+                      }
                 }
                 .clickable(
                     onClick = {
-                        parkingViewModel.selectParking(parking)
-                        navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                      parkingViewModel.selectParking(parking)
+                      navigationActions.navigateTo(Screen.PARKING_DETAILS)
                     })
                 .testTag("SpotListItem"),
-            colors =
+        colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 1f)),
-            shape = MaterialTheme.shapes.medium) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag("SpotCardContent")) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween) {
-                        Text(
-                            text =
+        shape = MaterialTheme.shapes.medium) {
+          Box(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag("SpotCardContent")) {
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text(
+                        text =
                             parking.optName?.let { if (it.length > 35) it.take(32) + "..." else it }
                                 ?: stringResource(R.string.default_parking_name),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            testTag = "ParkingName")
-                        Text(
-                            text =
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        testTag = "ParkingName")
+                    Text(
+                        text =
                             if (distance < 1)
                                 stringResource(R.string.distance_m).format(distance * 1000)
                             else stringResource(R.string.distance_km).format(distance),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            testTag = "ParkingDistance")
-                    }
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        testTag = "ParkingDistance")
+                  }
 
-                    // Rating
-                    Spacer(modifier = Modifier.height(4.dp))
-                    if (parking.nbReviews > 0) {
-                        Row {
-                            ScoreStars(
-                                parking.avgScore,
-                                scale = 0.8f,
-                                starColor = MaterialTheme.colorScheme.onSurface)
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text =
-                                pluralStringResource(R.plurals.reviews_count, count = parking.nbReviews)
-                                    .format(parking.nbReviews),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                testTag = "ParkingNbReviews")
-                        }
-                    } else {
-                        Text(
-                            text = stringResource(R.string.no_reviews),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            testTag = "ParkingNoReviews")
-                    }
+              // Rating
+              Spacer(modifier = Modifier.height(4.dp))
+              if (parking.nbReviews > 0) {
+                Row {
+                  ScoreStars(
+                      parking.avgScore,
+                      scale = 0.8f,
+                      starColor = MaterialTheme.colorScheme.onSurface)
+                  Spacer(modifier = Modifier.width(8.dp))
+                  Text(
+                      text =
+                          pluralStringResource(R.plurals.reviews_count, count = parking.nbReviews)
+                              .format(parking.nbReviews),
+                      style = MaterialTheme.typography.bodySmall,
+                      color = MaterialTheme.colorScheme.onSurface,
+                      testTag = "ParkingNbReviews")
                 }
+              } else {
+                Text(
+                    text = stringResource(R.string.no_reviews),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    testTag = "ParkingNoReviews")
+              }
             }
+          }
         }
-    }
+  }
 }
 
 @Composable
@@ -477,21 +474,21 @@ fun ActionCard(
     backgroundColor: Color,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier =
-        modifier.background(backgroundColor, shape = MaterialTheme.shapes.medium).padding(8.dp),
-        contentAlignment = Alignment.Center) {
+  Box(
+      modifier =
+          modifier.background(backgroundColor, shape = MaterialTheme.shapes.medium).padding(8.dp),
+      contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(icon, contentDescription = null, tint = Color.Black)
-            Text(text, color = Color.Black)
+          Icon(icon, contentDescription = null, tint = Color.Black)
+          Text(text, color = Color.Black)
         }
-    }
+      }
 }
 
 private fun <T> toggleSelection(set: Set<T>, item: T): Set<T> {
-    return if (set.contains(item)) {
-        set - item
-    } else {
-        set + item
-    }
+  return if (set.contains(item)) {
+    set - item
+  } else {
+    set + item
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FilterList
@@ -65,10 +66,12 @@ import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
+import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
 import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
+import com.github.se.cyrcle.ui.theme.getCheckBoxColors
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.mapbox.turf.TurfMeasurement
 import kotlin.math.roundToInt
@@ -128,7 +131,7 @@ fun SpotListScreen(
                 if (pinnedParkings.isNotEmpty()) {
                   item {
                     Text(
-                        text = "Pinned Spots",
+                        text = stringResource(R.string.pinned_spots),
                         style = MaterialTheme.typography.titleMedium,
                         modifier = Modifier.padding(horizontal = 16.dp),
                         color = MaterialTheme.colorScheme.primary)
@@ -149,7 +152,7 @@ fun SpotListScreen(
                   item {
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
-                        text = "All Spots",
+                        text = stringResource(R.string.all_spots),
                         style = MaterialTheme.typography.titleMedium,
                         modifier = Modifier.padding(horizontal = 16.dp),
                         color = MaterialTheme.colorScheme.primary)
@@ -272,12 +275,12 @@ fun FilterHeader(
             Checkbox(
                 checked = onlyWithCCTV,
                 onCheckedChange = onCCTVCheckedChange,
-                modifier = Modifier.testTag("CCTVCheckbox"))
+                modifier = Modifier.testTag("CCTVCheckbox"),
+                colors = getCheckBoxColors(ColorLevel.PRIMARY))
             Spacer(modifier = Modifier.width(4.dp))
             Text(
                 text = stringResource(R.string.list_screen_display_only_cctv),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.testTag("CCTVCheckboxLabel"))
           }
     }
@@ -301,7 +304,6 @@ fun FilterSection(
             text = title,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.clickable(onClick = onToggle).padding(8.dp).fillMaxWidth(),
-            color = MaterialTheme.colorScheme.primary,
             testTag = title)
 
         if (isExpanded) {
@@ -333,7 +335,9 @@ fun SpotCard(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically) {
           ActionCard(
-              text = if (initialIsPinned) "Remove pin" else "Pin parking spot",
+              text =
+                  if (initialIsPinned) stringResource(R.string.remove_pin)
+                  else stringResource(R.string.pin_parking_spot),
               icon = Icons.Default.PushPin,
               backgroundColor =
                   if (initialIsPinned) Color.Red.copy(alpha = 0.7f) else Color.LightGray,
@@ -343,13 +347,13 @@ fun SpotCard(
                       .testTag(if (initialIsPinned) "UnpinActionCard" else "PinActionCard"))
           if (isFavorite) {
             ActionCard(
-                text = "Already in favorites",
+                text = stringResource(R.string.already_in_favorites),
                 icon = Icons.Default.Star,
                 backgroundColor = Color.Gray,
                 modifier = Modifier.fillMaxHeight().weight(1f).testTag("AlreadyFavoriteActionCard"))
           } else {
             ActionCard(
-                text = "Add to favorites",
+                text = stringResource(R.string.add_to_favorites),
                 icon = Icons.Default.Star,
                 backgroundColor = Color.Yellow,
                 modifier = Modifier.fillMaxHeight().weight(1f).testTag("AddToFavoriteActionCard"))
@@ -377,11 +381,15 @@ fun SpotCard(
                             }
                           } else if (!userSignedIn.value) {
                             Toast.makeText(
-                                    context, "Please sign in to add favorites", Toast.LENGTH_SHORT)
+                                    context,
+                                    context.getString(R.string.sign_in_to_add_favorites),
+                                    Toast.LENGTH_SHORT)
                                 .show()
                           } else if (isFavorite) {
                             Toast.makeText(
-                                    context, "Parking is already in favorites", Toast.LENGTH_SHORT)
+                                    context,
+                                    context.getString(R.string.already_in_favorites_toast),
+                                    Toast.LENGTH_SHORT)
                                 .show()
                           }
                         }
@@ -414,7 +422,6 @@ fun SpotCard(
                             parking.optName?.let { if (it.length > 35) it.take(32) + "..." else it }
                                 ?: stringResource(R.string.default_parking_name),
                         style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
                         testTag = "ParkingName")
                     Text(
                         text =
@@ -422,7 +429,6 @@ fun SpotCard(
                                 stringResource(R.string.distance_m).format(distance * 1000)
                             else stringResource(R.string.distance_km).format(distance),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface,
                         testTag = "ParkingDistance")
                   }
 
@@ -430,10 +436,7 @@ fun SpotCard(
               Spacer(modifier = Modifier.height(4.dp))
               if (parking.nbReviews > 0) {
                 Row {
-                  ScoreStars(
-                      parking.avgScore,
-                      scale = 0.8f,
-                      starColor = MaterialTheme.colorScheme.onSurface)
+                  ScoreStars(parking.avgScore, scale = 0.8f)
                   Spacer(modifier = Modifier.width(8.dp))
                   Text(
                       text =

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -267,7 +268,6 @@ fun FilterSection(
       }
 }
 
-
 @Composable
 fun SpotCard(
     navigationActions: NavigationActions,
@@ -276,6 +276,7 @@ fun SpotCard(
     distance: Double
 ) {
     var offsetX by remember { mutableStateOf(0f) }
+    val maxSwipeDistance = 150.dp // Half of the card's width in dp
 
     Box(
         modifier = Modifier
@@ -317,16 +318,16 @@ fun SpotCard(
                 .pointerInput(Unit) {
                     detectHorizontalDragGestures(
                         onDragEnd = {
-                            if (offsetX > 100) {
+                            if (offsetX > maxSwipeDistance.toPx() / 2) {
                                 // Swipe right action
-                            } else if (offsetX < -100) {
+                            } else if (offsetX < -maxSwipeDistance.toPx() / 2) {
                                 // Swipe left action
                             }
                             offsetX = 0f
                         }
                     ) { change, dragAmount ->
                         change.consume()
-                        offsetX += dragAmount
+                        offsetX = (offsetX + dragAmount).coerceIn(-maxSwipeDistance.toPx(), maxSwipeDistance.toPx())
                     }
                 }
                 .clickable(

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -83,7 +84,7 @@ fun SpotListScreen(
 
     val userPosition by mapViewModel.userPosition.collectAsState()
 
-    var pinnedParkings by remember { mutableStateOf(setOf<String>()) }
+    var pinnedParkings by rememberSaveable { mutableStateOf(setOf<String>()) }
     val handlePinStatusChanged = { parkingId: String, isPinned: Boolean ->
         pinnedParkings = if (isPinned) {
             pinnedParkings + parkingId

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -23,10 +24,13 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -39,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
@@ -262,6 +267,7 @@ fun FilterSection(
       }
 }
 
+
 @Composable
 fun SpotCard(
     navigationActions: NavigationActions,
@@ -271,85 +277,136 @@ fun SpotCard(
 ) {
     var offsetX by remember { mutableStateOf(0f) }
 
-    Card(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(120.dp)
             .padding(4.dp)
-            .offset { IntOffset(offsetX.roundToInt(), 0) }
-            .pointerInput(Unit) {
-                detectHorizontalDragGestures(
-                    onDragEnd = {
-                        // Handle the end of the drag to trigger actions
-                        if (offsetX > 100) {
-                            // Swipe right action (e.g., add to favorites)
-                            // Reset offset
-                        } else if (offsetX < -100) {
-                            // Swipe left action (e.g., pin to top)
-                            // Reset offset
-                        }
-                        offsetX = 0f
-                    }
-                ) { change, dragAmount ->
-                    change.consume()
-                    offsetX += dragAmount
-                }
-            }
-            .clickable(
-                onClick = {
-                    parkingViewModel.selectParking(parking)
-                    navigationActions.navigateTo(Screen.CARD)
-                }
-            )
-            .testTag("SpotListItem"),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag("SpotCardContent")) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = parking.optName?.let { if (it.length > 35) it.take(32) + "..." else it }
-                            ?: stringResource(R.string.default_parking_name),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        testTag = "ParkingName"
-                    )
-                    Text(
-                        text = if (distance < 1) stringResource(R.string.distance_m).format(distance * 1000)
-                        else stringResource(R.string.distance_km).format(distance),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        testTag = "ParkingDistance"
-                    )
-                }
+        // Background actions
+        Row(
+            modifier = Modifier
+                .fillMaxSize(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ActionCard(
+                text = "Pin parking spot",
+                icon = Icons.Default.PushPin,
+                backgroundColor = Color.LightGray,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+            )
+            ActionCard(
+                text = "Add to favorites",
+                icon = Icons.Default.Star,
+                backgroundColor = Color.Yellow,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+            )
+        }
 
-                // Rating
-                Spacer(modifier = Modifier.height(4.dp))
-                if (parking.nbReviews > 0) {
-                    Row {
-                        ScoreStars(parking.avgScore, scale = 0.8f)
-                        Spacer(modifier = Modifier.width(8.dp))
+        // Main card
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .offset { IntOffset(offsetX.roundToInt(), 0) }
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = {
+                            if (offsetX > 100) {
+                                // Swipe right action
+                            } else if (offsetX < -100) {
+                                // Swipe left action
+                            }
+                            offsetX = 0f
+                        }
+                    ) { change, dragAmount ->
+                        change.consume()
+                        offsetX += dragAmount
+                    }
+                }
+                .clickable(
+                    onClick = {
+                        parkingViewModel.selectParking(parking)
+                        navigationActions.navigateTo(Screen.CARD)
+                    }
+                )
+                .testTag("SpotListItem"),
+            colors = CardDefaults.cardColors(containerColor = Color.White)
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag("SpotCardContent")) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
                         Text(
-                            text = pluralStringResource(R.plurals.reviews_count, count = parking.nbReviews)
-                                .format(parking.nbReviews),
+                            text = parking.optName?.let { if (it.length > 35) it.take(32) + "..." else it }
+                                ?: stringResource(R.string.default_parking_name),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = Color.Black,
+                            testTag = "ParkingName"
+                        )
+                        Text(
+                            text = if (distance < 1) stringResource(R.string.distance_m).format(distance * 1000)
+                            else stringResource(R.string.distance_km).format(distance),
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
-                            testTag = "ParkingNbReviews"
+                            color = Color.Black,
+                            testTag = "ParkingDistance"
                         )
                     }
-                } else {
-                    Text(
-                        text = stringResource(R.string.no_reviews),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
-                        testTag = "ParkingNoReviews"
-                    )
+
+                    // Rating
+                    Spacer(modifier = Modifier.height(4.dp))
+                    if (parking.nbReviews > 0) {
+                        Row {
+                            ScoreStars(parking.avgScore, scale = 0.8f)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = pluralStringResource(R.plurals.reviews_count, count = parking.nbReviews)
+                                    .format(parking.nbReviews),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Black.copy(alpha = 0.8f),
+                                testTag = "ParkingNbReviews"
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = stringResource(R.string.no_reviews),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Black.copy(alpha = 0.8f),
+                            testTag = "ParkingNoReviews"
+                        )
+                    }
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun ActionCard(
+    text: String,
+    icon: ImageVector,
+    backgroundColor: Color,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(backgroundColor)
+            .padding(8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(icon, contentDescription = null, tint = Color.Black)
+            Text(text, color = Color.Black)
         }
     }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -104,9 +104,17 @@ fun ParkingDetailsScreen(
                                     if (isFavorite) {
                                       userViewModel.removeFavoriteParkingFromSelectedUser(
                                           selectedParking.uid)
+                                      Toast.makeText(
+                                              context,
+                                              "Removed From Favorites!",
+                                              Toast.LENGTH_SHORT)
+                                          .show()
                                     } else {
                                       userViewModel.addFavoriteParkingToSelectedUser(
                                           selectedParking.uid)
+                                      Toast.makeText(
+                                              context, "Added To Favorites!", Toast.LENGTH_SHORT)
+                                          .show()
                                     }
                                     userViewModel.getSelectedUserFavoriteParking()
                                   } else {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.ui.profile
 
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -67,6 +68,7 @@ fun ViewProfileScreen(
   var lastName by remember { mutableStateOf(userState?.details?.lastName ?: "") }
   var username by remember { mutableStateOf(userState?.public?.username ?: "") }
   var profilePictureUrl by remember { mutableStateOf(userState?.public?.profilePictureUrl ?: "") }
+  val context = LocalContext.current
 
   val imagePickerLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
@@ -84,6 +86,7 @@ fun ViewProfileScreen(
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
           authenticator.SignOutButton(Modifier.padding(10.dp).align(Alignment.TopEnd)) {
             userViewModel.setCurrentUser(null)
+            Toast.makeText(context, "You're signed out!", Toast.LENGTH_SHORT).show()
             navigationActions.navigateTo(TopLevelDestinations.AUTH)
           }
 
@@ -237,7 +240,6 @@ private fun DisplayProfileContent(
       onClick = {},
       isEditable = false,
       modifier = Modifier.testTag("ProfileImage"))
-
   Spacer(modifier = Modifier.height(8.dp))
 
   Text(
@@ -347,6 +349,7 @@ private fun FavoriteParkingsSection(userViewModel: UserViewModel) {
 @Composable
 private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Unit) {
   var showConfirmDialog by remember { mutableStateOf(false) }
+  val context = LocalContext.current
 
   Card(modifier = Modifier.size(120.dp).padding(8.dp), shape = MaterialTheme.shapes.medium) {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -384,6 +387,7 @@ private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Un
               onClick = {
                 onRemove()
                 showConfirmDialog = false
+                Toast.makeText(context, "Removed from Favorites!", Toast.LENGTH_SHORT).show()
               }) {
                 Text(
                     stringResource(

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -49,6 +50,9 @@ fun ReviewScreen(
     reviewViewModel: ReviewViewModel,
     userViewModel: UserViewModel
 ) {
+  val configuration = LocalConfiguration.current
+  val scaleFactor =
+      configuration.screenWidthDp / 160f // Adjust the divisor based on your preferred scaling
 
   val selectedParking =
       parkingViewModel.selectedParking.collectAsState().value
@@ -72,44 +76,40 @@ fun ReviewScreen(
   }
   var textValue by remember { mutableStateOf(if (ownerHasReviewed) matchingReview?.text!! else "") }
 
-  val context = LocalContext.current // Get the current context
+  val context = LocalContext.current
 
   Scaffold(
       topBar = {
         TopAppBar(
             navigationActions = navigationActions,
-            if (ownerHasReviewed) stringResource(R.string.review_screen_title_edit_review)
-            else stringResource(R.string.review_screen_title_new_review))
+            title =
+                if (ownerHasReviewed) stringResource(R.string.review_screen_title_edit_review)
+                else stringResource(R.string.review_screen_title_new_review))
       }) { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
-              ScoreStars(sliderValue.toDouble(), scale = 2.5f)
-              // Display the experience text based on the slider value
+              ScoreStars(sliderValue.toDouble(), scale = scaleFactor) // Use dynamic scale factor
               Text(
                   text =
                       when (sliderValue) {
-                        in 1f..2f -> stringResource(R.string.review_screen_poor_review)
-                        in 2f..3f -> stringResource(R.string.review_screen_bad_review)
-                        3f -> stringResource(R.string.review_screen_average_review)
-                        in 3.5f..4f -> stringResource(R.string.review_screen_good_review)
-                        in 4.5f..5f -> stringResource(R.string.review_screen_great_review)
+                        in 0f..1f -> stringResource(R.string.review_screen_terrible_review)
+                        in 1f..2f -> stringResource(R.string.review_screen_bad_review)
+                        in 2f..3f -> stringResource(R.string.review_screen_average_review)
+                        in 3f..4f -> stringResource(R.string.review_screen_good_review)
+                        in 4f..5f -> stringResource(R.string.review_screen_great_review)
                         else -> ""
                       },
                   style = MaterialTheme.typography.bodyLarge,
                   modifier = Modifier.padding(top = 8.dp),
                   testTag = "ExperienceText")
 
-              // Slider with step granularity of 0.5
-              Text(
-                  text = "Rating: ${sliderValue.toDouble()}",
-                  style = MaterialTheme.typography.bodyLarge)
               Slider(
                   value = sliderValue,
                   onValueChange = { newValue -> sliderValue = newValue },
                   valueRange = 0f..5f,
-                  steps = 9, // Steps for granularity of 0.5 between 0 and 5
+                  steps = 9,
                   modifier = Modifier.padding(16.dp).testTag("Slider"))
 
               Spacer(modifier = Modifier.height(16.dp))
@@ -125,12 +125,10 @@ fun ReviewScreen(
 
               Spacer(modifier = Modifier.height(16.dp))
 
-              // Add Review Button
               Button(
                   text = stringResource(R.string.review_screen_submit_button),
                   onClick = {
                     Toast.makeText(context, "Review Added!", Toast.LENGTH_SHORT).show()
-                    // to avoid problematic castings
                     val sliderToValue = (sliderValue * 100).toInt() / 100.0
 
                     if (!ownerHasReviewed) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBar.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.TopAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.sp
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.Typography
 
@@ -26,11 +28,15 @@ import com.github.se.cyrcle.ui.theme.Typography
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun TopAppBar(navigationActions: NavigationActions, title: String, testTag: String = "TopAppBar") {
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp
+  val scaledFontSize = (screenWidth * 0.05).sp // Adjust the scaling factor as needed
+
   CenterAlignedTopAppBar(
       title = {
         Text(
             text = title,
-            style = Typography.titleLarge,
+            style = Typography.titleLarge.copy(fontSize = scaledFontSize),
             color = Color.White,
             modifier = Modifier.testTag("${testTag}Title"))
       },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,15 @@
         <item quantity="one">(1 review)</item>
         <item quantity="other">(%d reviews)</item>
     </plurals>
+    <string name="pinned_spots">Pinned Spots</string>
+    <string name="all_spots">All Spots</string>
+    <string name="remove_pin">Remove pin</string>
+    <string name="pin_parking_spot">Pin parking spot</string>
+    <string name="already_in_favorites">Already in favorites</string>
+    <string name="add_to_favorites">Add to favorites</string>
+    <string name="already_in_favorites_toast">Parking is already in favorites</string>
+    <string name="sign_in_to_add_favorites">Please sign in to add favorites</string>
+    <string name="filter">Filter</string>
 
     <!-- Error Messages -->
     <string name="input_min_characters">Minimum %1$d characters required (current: %2$d)</string>
@@ -53,7 +62,6 @@
     <string name="sign_in_failed_toast">Login failed!</string>
     <string name="sign_in_guest_button">Continue as Guest</string>
     <string name="sign_in_google_button">Sign in with Google</string>
-    <string name="sign_in_to_add_favorites">Please sign in to add favorites</string>
 
     <!-- Card Screen -->
     <string name="card_screen_description">Description of %s</string>
@@ -80,7 +88,6 @@
     <string name="list_screen_rating">Rating: %.1f</string>
     <string name="list_screen_display_only_cctv">Only display parkings with CCTV camera</string>
     <string name="all_parkings_radius">All parkings in a radius of \n %1$d m</string>
-
 
     <!-- Zoom Controls -->
     <string name="zoom_in">Zoom In</string>


### PR DESCRIPTION
Content of this PR :
The user can swipe on a card to add it quickly as favorite or pin it above all other cards

How and Why :
By swiping left, the user can add quickly a parking spot to his favorites. Had there not been this feature, the user would have to click on the card and add it to his favorites from the parking detail screen, which takes more time and might make him lose track of where he was in the list. An unsigned user can still see this feature but will only see on swipe a message advertising the benefits of signing in, like having your own favorite parking spots.
By swiping right, the user can pin a parking spot. This will launch the card on top of the list in a different section.
Of course, there is also the option to unpin an already pinned card. This pin feature can help a user to come back to a parking spot later without having to look back for it in the big messy list later on, and also to not have to necessarily add it to favorites if he's interested but not that interested.
~~The pin is non-persistent, so if you switch screens it will unpin. If the team wants it to become persistent, this would have to wait for another sprint or two because it requires changes in the userViewModel in my opinion.~~
Actually, the pin is now persistent. It was the result of the necessity to fix the pin's behavior.

TestReport : 
![image](https://github.com/user-attachments/assets/785e6dba-4f4a-453b-9ab2-c0a2932671ac)

Closes #164 
