### PR TITLE
Favorite Icon Action In ParkingDetailScreen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.ui.parkingDetails
 
-import android.util.Log
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
@@ -25,9 +24,6 @@ import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.review.ReviewRepository
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.TestInstancesUser
-import com.github.se.cyrcle.model.user.User
-import com.github.se.cyrcle.model.user.UserDetails
-import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -74,8 +70,6 @@ class ParkingDetailsScreenTest {
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PARKING_DETAILS)
   }
 
-
-
   @Test
   fun favoriteIconVisibleWhenNotSignedInAndDoesNothing() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
@@ -93,7 +87,6 @@ class ParkingDetailsScreenTest {
 
   @Test
   fun addToFavoritesWhenSignedIn() {
-
 
     parkingViewModel.selectParking(TestInstancesParking.parking3)
     userViewModel.addUser(TestInstancesUser.user1)
@@ -133,7 +126,6 @@ class ParkingDetailsScreenTest {
     // Should now show outline icon
     composeTestRule.onNodeWithTag("BlackOutlinedFavoriteIcon").assertIsDisplayed()
   }
-
 
   @Test
   fun displayAllComponents() {

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -174,7 +174,7 @@ class MainActivityTest {
       composeTestRule.onNodeWithTag("RowCapacityRack").assertIsDisplayed()
       composeTestRule.onNodeWithTag("RowProtectionPrice").assertIsDisplayed()
       composeTestRule.onNodeWithTag("RowSecurity").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("ButtonsColumn").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("ButtonsColumn").performScrollTo().assertIsDisplayed()
       composeTestRule.onNodeWithTag("ShowInMapButton").assertIsDisplayed().assertHasClickAction()
       composeTestRule
           .onNodeWithTag("ReportButton")

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -1,7 +1,6 @@
 package com.github.se.cyrcle.ui.parkingDetails
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -57,312 +56,253 @@ fun ParkingDetailsScreen(
     parkingViewModel: ParkingViewModel,
     userViewModel: UserViewModel
 ) {
-    val selectedParking =
-        parkingViewModel.selectedParking.collectAsState().value
-            ?: return Text(stringResource(R.string.no_selected_parking_error))
-    val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
-    val scrollState = rememberScrollState()
-    val context = LocalContext.current
+  val selectedParking =
+      parkingViewModel.selectedParking.collectAsState().value
+          ?: return Text(stringResource(R.string.no_selected_parking_error))
+  val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
+  val scrollState = rememberScrollState()
+  val context = LocalContext.current
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                navigationActions,
-                stringResource(R.string.card_screen_description)
-                    .format(selectedParking.optName ?: stringResource(R.string.default_parking_name)))
-        },
-        modifier = Modifier.testTag("ParkingDetailsScreen")
-    ) { padding ->
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            navigationActions,
+            stringResource(R.string.card_screen_description)
+                .format(selectedParking.optName ?: stringResource(R.string.default_parking_name)))
+      },
+      modifier = Modifier.testTag("ParkingDetailsScreen")) { padding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(32.dp)
-                .verticalScroll(scrollState)
-                .testTag("ParkingDetailsColumn")
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
-                    .testTag("FavoriteIconContainer"),
-                contentAlignment = Alignment.TopEnd
-            ) {
-                val isFavorite = if (userSignedIn.value) {
-                    userViewModel.favoriteParkings.collectAsState().value.contains(selectedParking)
-                } else {
-                    false
-                }
-
-                Icon(
-                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Outlined.FavoriteBorder,
-                    contentDescription = "Favorite",
-                    tint = if (isFavorite) Red else Black,
-                    modifier = Modifier
-                        .testTag(if (isFavorite) "RedFilledFavoriteIcon" else "BlackOutlinedFavoriteIcon")
-                        .clickable {
-                            if (userSignedIn.value) {
-                                if (isFavorite) {
-                                    userViewModel.removeFavoriteParkingFromSelectedUser(selectedParking.uid)
-                                } else {
-                                    userViewModel.addFavoriteParkingToSelectedUser(selectedParking.uid)
-                                }
-                                userViewModel.getSelectedUserFavoriteParking()
-                            } else {
-                                Toast.makeText(
-                                    context,
-                                    "Please sign in to add favorites",
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            }
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .padding(32.dp)
+                    .verticalScroll(scrollState)
+                    .testTag("ParkingDetailsColumn")) {
+              Box(
+                  modifier = Modifier.fillMaxWidth().height(48.dp).testTag("FavoriteIconContainer"),
+                  contentAlignment = Alignment.TopEnd) {
+                    val isFavorite =
+                        if (userSignedIn.value) {
+                          userViewModel.favoriteParkings
+                              .collectAsState()
+                              .value
+                              .contains(selectedParking)
+                        } else {
+                          false
                         }
-                )
-            }
 
-            // Reviews
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-                    .testTag("AverageRatingRow"),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                if (selectedParking.nbReviews > 0) {
-                    Row {
+                    Icon(
+                        imageVector =
+                            if (isFavorite) Icons.Default.Favorite
+                            else Icons.Outlined.FavoriteBorder,
+                        contentDescription = "Favorite",
+                        tint = if (isFavorite) Red else Black,
+                        modifier =
+                            Modifier.testTag(
+                                    if (isFavorite) "RedFilledFavoriteIcon"
+                                    else "BlackOutlinedFavoriteIcon")
+                                .clickable {
+                                  if (userSignedIn.value) {
+                                    if (isFavorite) {
+                                      userViewModel.removeFavoriteParkingFromSelectedUser(
+                                          selectedParking.uid)
+                                    } else {
+                                      userViewModel.addFavoriteParkingToSelectedUser(
+                                          selectedParking.uid)
+                                    }
+                                    userViewModel.getSelectedUserFavoriteParking()
+                                  } else {
+                                    Toast.makeText(
+                                            context,
+                                            "Please sign in to add favorites",
+                                            Toast.LENGTH_SHORT)
+                                        .show()
+                                  }
+                                })
+                  }
+
+              // Reviews
+              Row(
+                  modifier =
+                      Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("AverageRatingRow"),
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.SpaceBetween) {
+                    if (selectedParking.nbReviews > 0) {
+                      Row {
                         ScoreStars(
                             selectedParking.avgScore,
                             scale = 0.8f,
-                            text = pluralStringResource(
-                                R.plurals.reviews_count,
-                                count = selectedParking.nbReviews
-                            ).format(selectedParking.nbReviews)
-                        )
+                            text =
+                                pluralStringResource(
+                                        R.plurals.reviews_count, count = selectedParking.nbReviews)
+                                    .format(selectedParking.nbReviews))
+                      }
+                    } else {
+                      Text(
+                          text = stringResource(R.string.no_reviews),
+                          style = MaterialTheme.typography.bodyMedium,
+                          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                          testTag = "ParkingNoReviews")
                     }
-                } else {
                     Text(
-                        text = stringResource(R.string.no_reviews),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
-                        testTag = "ParkingNoReviews"
-                    )
-                }
-                Text(
-                    text = stringResource(R.string.card_screen_see_review),
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        textDecoration = TextDecoration.Underline
-                    ),
-                    color = MaterialTheme.colorScheme.primary,
-                    testTag = "SeeAllReviewsText",
-                    modifier = Modifier.clickable { navigationActions.navigateTo(Screen.ALL_REVIEWS) }
-                )
-            }
+                        text = stringResource(R.string.card_screen_see_review),
+                        style =
+                            MaterialTheme.typography.bodyMedium.copy(
+                                textDecoration = TextDecoration.Underline),
+                        color = MaterialTheme.colorScheme.primary,
+                        testTag = "SeeAllReviewsText",
+                        modifier =
+                            Modifier.clickable { navigationActions.navigateTo(Screen.ALL_REVIEWS) })
+                  }
 
-            Spacer(modifier = Modifier.height(16.dp))
+              Spacer(modifier = Modifier.height(16.dp))
 
-            // Images
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("ImagesRow"),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                if (selectedParking.images.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.card_screen_no_image),
-                        color = MaterialTheme.colorScheme.onSurface,
-                        style = MaterialTheme.typography.bodyMedium,
-                        testTag = "NoImageText"
-                    )
-                    IconButton(
-                        icon = Icons.Outlined.AddAPhoto,
-                        contentDescription = "Add Image",
-                        onClick = {
+              // Images
+              Row(
+                  modifier = Modifier.fillMaxWidth().testTag("ImagesRow"),
+                  horizontalArrangement = Arrangement.spacedBy(8.dp),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    if (selectedParking.images.isEmpty()) {
+                      Text(
+                          text = stringResource(R.string.card_screen_no_image),
+                          color = MaterialTheme.colorScheme.onSurface,
+                          style = MaterialTheme.typography.bodyMedium,
+                          testTag = "NoImageText")
+                      IconButton(
+                          icon = Icons.Outlined.AddAPhoto,
+                          contentDescription = "Add Image",
+                          onClick = {
                             Toast.makeText(
-                                context,
-                                "A feature to add images will be added later",
-                                Toast.LENGTH_LONG
-                            ).show()
-                        },
-                        enabled = userSignedIn.value,
-                        testTag = "AddImageIconButton",
-                        modifier = Modifier
-                            .padding(start = 8.dp)
-                            .height(32.dp)
-                            .fillMaxWidth()
-                    )
-                } else {
-                    LazyRow(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .testTag("ParkingImagesRow"),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        items(selectedParking.images.size) { index ->
-                            AsyncImage(
-                                model = selectedParking.images[index],
-                                contentDescription = "Image $index",
-                                modifier = Modifier
-                                    .size(170.dp)
-                                    .padding(4.dp)
-                                    .testTag("ParkingImage$index"),
-                                contentScale = ContentScale.Crop
-                            )
+                                    context,
+                                    "A feature to add images will be added later",
+                                    Toast.LENGTH_LONG)
+                                .show()
+                          },
+                          enabled = userSignedIn.value,
+                          testTag = "AddImageIconButton",
+                          modifier = Modifier.padding(start = 8.dp).height(32.dp).fillMaxWidth())
+                    } else {
+                      LazyRow(
+                          modifier = Modifier.fillMaxWidth().testTag("ParkingImagesRow"),
+                          horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            items(selectedParking.images.size) { index ->
+                              AsyncImage(
+                                  model = selectedParking.images[index],
+                                  contentDescription = "Image $index",
+                                  modifier =
+                                      Modifier.size(170.dp)
+                                          .padding(4.dp)
+                                          .testTag("ParkingImage$index"),
+                                  contentScale = ContentScale.Crop)
+                            }
+                          }
+                    }
+                  }
+
+              // Information
+              Column(
+                  modifier =
+                      Modifier.fillMaxWidth().padding(vertical = 32.dp).testTag("InfoColumn"),
+                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().testTag("RowCapacityRack"),
+                        horizontalArrangement = Arrangement.SpaceBetween) {
+                          Column(modifier = Modifier.weight(1f).testTag("CapacityColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_capacity),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text = selectedParking.capacity.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                          Column(modifier = Modifier.weight(1f).testTag("RackTypeColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_rack_type),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text = selectedParking.rackType.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
                         }
-                    }
-                }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth().testTag("RowProtectionPrice"),
+                        horizontalArrangement = Arrangement.SpaceBetween) {
+                          Column(modifier = Modifier.weight(1f).testTag("ProtectionColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_protection),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text = selectedParking.protection.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                          Column(modifier = Modifier.weight(1f).testTag("PriceColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_price),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            val price = selectedParking.price
+                            Text(
+                                text =
+                                    if (price == 0.0) stringResource(R.string.free) else "$price",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                        }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth().testTag("RowSecurity"),
+                        horizontalArrangement = Arrangement.SpaceBetween) {
+                          Column(modifier = Modifier.weight(1f).testTag("SecurityColumn")) {
+                            Text(
+                                text = stringResource(R.string.card_screen_surveillance),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground)
+                            Text(
+                                text =
+                                    if (selectedParking.hasSecurity) stringResource(R.string.yes)
+                                    else stringResource(R.string.no),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface)
+                          }
+                        }
+                  }
+
+              Column(
+                  modifier = Modifier.fillMaxWidth().testTag("ButtonsColumn"),
+                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Button(
+                        text = stringResource(R.string.card_screen_show_map),
+                        onClick = {
+                          Toast.makeText(
+                                  context,
+                                  "A feature to show the parking on the map will be added later",
+                                  Toast.LENGTH_LONG)
+                              .show()
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colorLevel = ColorLevel.PRIMARY,
+                        testTag = "ShowInMapButton")
+
+                    Button(
+                        text = stringResource(R.string.card_screen_report),
+                        onClick = {
+                          Toast.makeText(
+                                  context,
+                                  "A report system will be added to the app later",
+                                  Toast.LENGTH_LONG)
+                              .show()
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colorLevel = ColorLevel.ERROR,
+                        testTag = "ReportButton")
+                  }
             }
-
-            // Information
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 32.dp)
-                    .testTag("InfoColumn"),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("RowCapacityRack"),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .testTag("CapacityColumn")
-                    ) {
-                        Text(
-                            text = stringResource(R.string.card_screen_capacity),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                        Text(
-                            text = selectedParking.capacity.description,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .testTag("RackTypeColumn")
-                    ) {
-                        Text(
-                            text = stringResource(R.string.card_screen_rack_type),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                        Text(
-                            text = selectedParking.rackType.description,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("RowProtectionPrice"),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .testTag("ProtectionColumn")
-                    ) {
-                        Text(
-                            text = stringResource(R.string.card_screen_protection),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                        Text(
-                            text = selectedParking.protection.description,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .testTag("PriceColumn")
-                    ) {
-                        Text(
-                            text = stringResource(R.string.card_screen_price),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                        val price = selectedParking.price
-                        Text(
-                            text = if (price == 0.0) stringResource(R.string.free) else "$price",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("RowSecurity"),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .testTag("SecurityColumn")
-                    ) {
-                        Text(
-                            text = stringResource(R.string.card_screen_surveillance),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                        Text(
-                            text = if (selectedParking.hasSecurity) stringResource(R.string.yes)
-                            else stringResource(R.string.no),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("ButtonsColumn"),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                Button(
-                    text = stringResource(R.string.card_screen_show_map),
-                    onClick = {
-                        Toast.makeText(
-                            context,
-                            "A feature to show the parking on the map will be added later",
-                            Toast.LENGTH_LONG
-                        ).show()
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    colorLevel = ColorLevel.PRIMARY,
-                    testTag = "ShowInMapButton"
-                )
-
-                Button(
-                    text = stringResource(R.string.card_screen_report),
-                    onClick = {
-                        Toast.makeText(
-                            context,
-                            "A report system will be added to the app later",
-                            Toast.LENGTH_LONG
-                        ).show()
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    colorLevel = ColorLevel.ERROR,
-                    testTag = "ReportButton"
-                )
-            }
-        }
-    }
+      }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -82,14 +82,12 @@ fun ParkingDetailsScreen(
                   modifier = Modifier.fillMaxWidth().height(48.dp).testTag("FavoriteIconContainer"),
                   contentAlignment = Alignment.TopEnd) {
                     val isFavorite =
-                        if (userSignedIn.value) {
+                        userSignedIn.value &&
                           userViewModel.favoriteParkings
                               .collectAsState()
                               .value
                               .contains(selectedParking)
-                        } else {
-                          false
-                        }
+
 
                     Icon(
                         imageVector =

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.cyrcle.ui.parkingDetails
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.AddAPhoto
@@ -54,29 +57,35 @@ fun ParkingDetailsScreen(
     parkingViewModel: ParkingViewModel,
     userViewModel: UserViewModel
 ) {
-  val selectedParking =
-      parkingViewModel.selectedParking.collectAsState().value
-          ?: return Text(stringResource(R.string.no_selected_parking_error))
-  val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
+    val selectedParking =
+        parkingViewModel.selectedParking.collectAsState().value
+            ?: return Text(stringResource(R.string.no_selected_parking_error))
+    val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
+    val scrollState = rememberScrollState()
+    val context = LocalContext.current
 
-  val context = LocalContext.current
-
-  Scaffold(
-      topBar = {
-        TopAppBar(
-            navigationActions,
-            stringResource(R.string.card_screen_description)
-                .format(selectedParking.optName ?: stringResource(R.string.default_parking_name)))
-      },
-      modifier = Modifier.testTag("ParkingDetailsScreen")) { padding ->
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationActions,
+                stringResource(R.string.card_screen_description)
+                    .format(selectedParking.optName ?: stringResource(R.string.default_parking_name)))
+        },
+        modifier = Modifier.testTag("ParkingDetailsScreen")
+    ) { padding ->
         Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .padding(32.dp)
-                    .testTag("ParkingDetailsColumn")) {
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(32.dp)
+                .verticalScroll(scrollState)
+                .testTag("ParkingDetailsColumn")
+        ) {
             Box(
-                modifier = Modifier.fillMaxWidth().height(48.dp).testTag("FavoriteIconContainer"),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .testTag("FavoriteIconContainer"),
                 contentAlignment = Alignment.TopEnd
             ) {
                 val isFavorite = if (userSignedIn.value) {
@@ -109,189 +118,251 @@ fun ParkingDetailsScreen(
                         }
                 )
             }
-              // Reviews
-              Row(
-                  modifier =
-                      Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("AverageRatingRow"),
-                  verticalAlignment = Alignment.CenterVertically,
-                  horizontalArrangement = Arrangement.SpaceBetween) {
-                    if (selectedParking.nbReviews > 0) {
-                      Row {
+
+            // Reviews
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .testTag("AverageRatingRow"),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                if (selectedParking.nbReviews > 0) {
+                    Row {
                         ScoreStars(
                             selectedParking.avgScore,
                             scale = 0.8f,
-                            text =
-                                pluralStringResource(
-                                        R.plurals.reviews_count, count = selectedParking.nbReviews)
-                                    .format(selectedParking.nbReviews))
-                      }
-                    } else {
-                      Text(
-                          text = stringResource(R.string.no_reviews),
-                          style = MaterialTheme.typography.bodyMedium,
-                          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
-                          testTag = "ParkingNoReviews")
+                            text = pluralStringResource(
+                                R.plurals.reviews_count,
+                                count = selectedParking.nbReviews
+                            ).format(selectedParking.nbReviews)
+                        )
                     }
+                } else {
                     Text(
-                        text = stringResource(R.string.card_screen_see_review),
-                        style =
-                            MaterialTheme.typography.bodyMedium.copy(
-                                textDecoration = TextDecoration.Underline),
-                        color = MaterialTheme.colorScheme.primary,
-                        testTag = "SeeAllReviewsText",
-                        modifier =
-                            Modifier.clickable { navigationActions.navigateTo(Screen.ALL_REVIEWS) })
-                  }
-
-              Spacer(modifier = Modifier.height(16.dp))
-              // Images
-              Row(
-                  modifier = Modifier.fillMaxWidth().testTag("ImagesRow"),
-                  horizontalArrangement = Arrangement.spacedBy(8.dp),
-                  verticalAlignment = Alignment.CenterVertically) {
-                    if (selectedParking.images.isEmpty()) {
-                      Text(
-                          text = stringResource(R.string.card_screen_no_image),
-                          color = MaterialTheme.colorScheme.onSurface,
-                          style = MaterialTheme.typography.bodyMedium,
-                          testTag = "NoImageText")
-                      IconButton(
-                          icon = Icons.Outlined.AddAPhoto,
-                          contentDescription = "Add Image",
-                          onClick = {
-                            // Temporary toast. Will be replaced by an image picker
-                            Toast.makeText(
-                                    context,
-                                    "A feature to add images will be added later",
-                                    Toast.LENGTH_LONG)
-                                .show()
-                          },
-                          enabled = userSignedIn.value,
-                          testTag = "AddImageIconButton",
-                          modifier = Modifier.padding(start = 8.dp).height(32.dp).fillMaxWidth())
-                    } else {
-                      LazyRow(
-                          modifier = Modifier.fillMaxWidth().testTag("ParkingImagesRow"),
-                          horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            items(selectedParking.images.size) { index ->
-                              AsyncImage(
-                                  model = selectedParking.images[index],
-                                  contentDescription = "Image $index",
-                                  modifier =
-                                      Modifier.size(170.dp)
-                                          .padding(4.dp)
-                                          .testTag("ParkingImage$index"),
-                                  contentScale = ContentScale.Crop)
-                            }
-                          }
-                    }
-                  }
-
-              // Information
-              Column(
-                  modifier =
-                      Modifier.fillMaxWidth().padding(vertical = 32.dp).testTag("InfoColumn"),
-                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().testTag("RowCapacityRack"),
-                        horizontalArrangement = Arrangement.SpaceBetween) {
-                          Column(modifier = Modifier.weight(1f).testTag("CapacityColumn")) {
-                            Text(
-                                text = stringResource(R.string.card_screen_capacity),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onBackground)
-                            Text(
-                                text = selectedParking.capacity.description,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface)
-                          }
-                          Column(modifier = Modifier.weight(1f).testTag("RackTypeColumn")) {
-                            Text(
-                                text = stringResource(R.string.card_screen_rack_type),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onBackground)
-                            Text(
-                                text = selectedParking.rackType.description,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface)
-                          }
-                        }
-                    Row(
-                        modifier = Modifier.fillMaxWidth().testTag("RowProtectionPrice"),
-                        horizontalArrangement = Arrangement.SpaceBetween) {
-                          Column(modifier = Modifier.weight(1f).testTag("ProtectionColumn")) {
-                            Text(
-                                text = stringResource(R.string.card_screen_protection),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onBackground)
-                            Text(
-                                text = selectedParking.protection.description,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface)
-                          }
-                          Column(modifier = Modifier.weight(1f).testTag("PriceColumn")) {
-                            Text(
-                                text = stringResource(R.string.card_screen_price),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onBackground)
-                            val price = selectedParking.price
-                            Text(
-                                text =
-                                    if (price == 0.0) stringResource(R.string.free) else "$price",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface)
-                          }
-                        }
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth().testTag("RowSecurity"),
-                        horizontalArrangement = Arrangement.SpaceBetween) {
-                          Column(modifier = Modifier.weight(1f).testTag("SecurityColumn")) {
-                            Text(
-                                text = stringResource(R.string.card_screen_surveillance),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onBackground)
-                            Text(
-                                text =
-                                    if (selectedParking.hasSecurity) stringResource(R.string.yes)
-                                    else stringResource(R.string.no),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface)
-                          }
-                        }
-                  }
-
-              Column(
-                  modifier = Modifier.fillMaxWidth().testTag("ButtonsColumn"),
-                  verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    Button(
-                        text = stringResource(R.string.card_screen_show_map),
-                        onClick = {
-                          // Temporary toast. Will redirect to the map screen later
-                          Toast.makeText(
-                                  context,
-                                  "A feature to show the parking on the map will be added later",
-                                  Toast.LENGTH_LONG)
-                              .show()
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        colorLevel = ColorLevel.PRIMARY,
-                        testTag = "ShowInMapButton")
-
-                    Button(
-                        text = stringResource(R.string.card_screen_report),
-                        onClick = {
-                          // Temporary toast. Will be replaced by a report system
-                          Toast.makeText(
-                                  context,
-                                  "A report system will be added to the app later",
-                                  Toast.LENGTH_LONG)
-                              .show()
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        colorLevel = ColorLevel.ERROR,
-                        testTag = "ReportButton")
-                  }
+                        text = stringResource(R.string.no_reviews),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                        testTag = "ParkingNoReviews"
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.card_screen_see_review),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    color = MaterialTheme.colorScheme.primary,
+                    testTag = "SeeAllReviewsText",
+                    modifier = Modifier.clickable { navigationActions.navigateTo(Screen.ALL_REVIEWS) }
+                )
             }
-      }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Images
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("ImagesRow"),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (selectedParking.images.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.card_screen_no_image),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.bodyMedium,
+                        testTag = "NoImageText"
+                    )
+                    IconButton(
+                        icon = Icons.Outlined.AddAPhoto,
+                        contentDescription = "Add Image",
+                        onClick = {
+                            Toast.makeText(
+                                context,
+                                "A feature to add images will be added later",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        },
+                        enabled = userSignedIn.value,
+                        testTag = "AddImageIconButton",
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .height(32.dp)
+                            .fillMaxWidth()
+                    )
+                } else {
+                    LazyRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("ParkingImagesRow"),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(selectedParking.images.size) { index ->
+                            AsyncImage(
+                                model = selectedParking.images[index],
+                                contentDescription = "Image $index",
+                                modifier = Modifier
+                                    .size(170.dp)
+                                    .padding(4.dp)
+                                    .testTag("ParkingImage$index"),
+                                contentScale = ContentScale.Crop
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Information
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 32.dp)
+                    .testTag("InfoColumn"),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("RowCapacityRack"),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("CapacityColumn")
+                    ) {
+                        Text(
+                            text = stringResource(R.string.card_screen_capacity),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                        Text(
+                            text = selectedParking.capacity.description,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("RackTypeColumn")
+                    ) {
+                        Text(
+                            text = stringResource(R.string.card_screen_rack_type),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                        Text(
+                            text = selectedParking.rackType.description,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("RowProtectionPrice"),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("ProtectionColumn")
+                    ) {
+                        Text(
+                            text = stringResource(R.string.card_screen_protection),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                        Text(
+                            text = selectedParking.protection.description,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("PriceColumn")
+                    ) {
+                        Text(
+                            text = stringResource(R.string.card_screen_price),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                        val price = selectedParking.price
+                        Text(
+                            text = if (price == 0.0) stringResource(R.string.free) else "$price",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("RowSecurity"),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("SecurityColumn")
+                    ) {
+                        Text(
+                            text = stringResource(R.string.card_screen_surveillance),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                        Text(
+                            text = if (selectedParking.hasSecurity) stringResource(R.string.yes)
+                            else stringResource(R.string.no),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("ButtonsColumn"),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Button(
+                    text = stringResource(R.string.card_screen_show_map),
+                    onClick = {
+                        Toast.makeText(
+                            context,
+                            "A feature to show the parking on the map will be added later",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colorLevel = ColorLevel.PRIMARY,
+                    testTag = "ShowInMapButton"
+                )
+
+                Button(
+                    text = stringResource(R.string.card_screen_report),
+                    onClick = {
+                        Toast.makeText(
+                            context,
+                            "A report system will be added to the app later",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colorLevel = ColorLevel.ERROR,
+                    testTag = "ReportButton"
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -83,11 +83,10 @@ fun ParkingDetailsScreen(
                   contentAlignment = Alignment.TopEnd) {
                     val isFavorite =
                         userSignedIn.value &&
-                          userViewModel.favoriteParkings
-                              .collectAsState()
-                              .value
-                              .contains(selectedParking)
-
+                            userViewModel.favoriteParkings
+                                .collectAsState()
+                                .value
+                                .contains(selectedParking)
 
                     Icon(
                         imageVector =

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,10 +14,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.AddAPhoto
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -36,7 +38,9 @@ import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
+import com.github.se.cyrcle.ui.theme.Black
 import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.Red
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.IconButton
 import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
@@ -70,8 +74,41 @@ fun ParkingDetailsScreen(
                 Modifier.fillMaxSize()
                     .padding(padding)
                     .padding(32.dp)
-                    .verticalScroll(rememberScrollState())
                     .testTag("ParkingDetailsColumn")) {
+            Box(
+                modifier = Modifier.fillMaxWidth().height(48.dp).testTag("FavoriteIconContainer"),
+                contentAlignment = Alignment.TopEnd
+            ) {
+                val isFavorite = if (userSignedIn.value) {
+                    userViewModel.favoriteParkings.collectAsState().value.contains(selectedParking)
+                } else {
+                    false
+                }
+
+                Icon(
+                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Outlined.FavoriteBorder,
+                    contentDescription = "Favorite",
+                    tint = if (isFavorite) Red else Black,
+                    modifier = Modifier
+                        .testTag(if (isFavorite) "RedFilledFavoriteIcon" else "BlackOutlinedFavoriteIcon")
+                        .clickable {
+                            if (userSignedIn.value) {
+                                if (isFavorite) {
+                                    userViewModel.removeFavoriteParkingFromSelectedUser(selectedParking.uid)
+                                } else {
+                                    userViewModel.addFavoriteParkingToSelectedUser(selectedParking.uid)
+                                }
+                                userViewModel.getSelectedUserFavoriteParking()
+                            } else {
+                                Toast.makeText(
+                                    context,
+                                    "Please sign in to add favorites",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                )
+            }
               // Reviews
               Row(
                   modifier =

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -62,6 +62,7 @@ fun ParkingDetailsScreen(
   val userSignedIn = userViewModel.isSignedIn.collectAsState(false)
   val scrollState = rememberScrollState()
   val context = LocalContext.current
+  val toastMessage = stringResource(R.string.sign_in_to_add_favorites)
 
   Scaffold(
       topBar = {
@@ -109,11 +110,7 @@ fun ParkingDetailsScreen(
                                     }
                                     userViewModel.getSelectedUserFavoriteParking()
                                   } else {
-                                    Toast.makeText(
-                                            context,
-                                            "Please sign in to add favorites",
-                                            Toast.LENGTH_SHORT)
-                                        .show()
+                                    Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
                                   }
                                 })
                   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -42,6 +42,7 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.Red
 import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
@@ -359,10 +360,10 @@ private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Un
           modifier =
               Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
             Icon(
-                imageVector = Icons.Filled.Star,
+                imageVector = Icons.Default.Favorite,
                 contentDescription =
                     stringResource(R.string.view_profile_screen_remove_from_favorite),
-                tint = Color(0xFFFFD700),
+                tint = Red,
                 modifier = Modifier.size(20.dp))
           }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="sign_in_successful_toast">Login successful!</string>
     <string name="sign_in_failed_toast">Login failed!</string>
     <string name="sign_in_guest_button">Continue as Guest</string>
+    <string name="sign_in_to_add_favorites">Please sign in to add favorites</string>
     <string name="sign_in_google_button">Sign in with Google</string>
 
     <!-- Card Screen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,8 +52,8 @@
     <string name="sign_in_successful_toast">Login successful!</string>
     <string name="sign_in_failed_toast">Login failed!</string>
     <string name="sign_in_guest_button">Continue as Guest</string>
-    <string name="sign_in_to_add_favorites">Please sign in to add favorites</string>
     <string name="sign_in_google_button">Sign in with Google</string>
+    <string name="sign_in_to_add_favorites">Please sign in to add favorites</string>
 
     <!-- Card Screen -->
     <string name="card_screen_description">Description of %s</string>


### PR DESCRIPTION
Content of this PR : 
This small PR adds the possibility for a user to add a parking to his list of favorite spots via the ParkingDetailScreen.

How and why : 
This is the first way to add a parking spot to the favorites, the second one will hopefully come with my next PR in the list screen.
By clicking on the heart icon on the top right of the screen, the user can add or remove the parking from his preferences.
When the heart is empty and outlined in black, it means the parking is not yet in the favorites.
On the other hand, when the heart is filled in red, it means the parking is already in the favorites.
Obviously, the user can add or remove that parking from his favorites.
A user who is not yet signed in will still see the empty black heart but wont be able to use it, instead that guest user will get a message inviting him to register.

Test Report : 
<img width="892" alt="image" src="https://github.com/user-attachments/assets/9ec2b555-5f75-4cc4-bcdf-5d81cbb51f49">


Closes #161 