### PR TITLE
Feature add parking details navigation

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.AuthenticatorMock
+import com.github.se.cyrcle.di.mocks.MockImageRepository
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
@@ -25,6 +26,7 @@ class ProfileScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  private lateinit var imageRepository: MockImageRepository
   private lateinit var userRepository: UserRepository
   private lateinit var parkingRepository: ParkingRepository
   private lateinit var userViewModel: UserViewModel
@@ -36,9 +38,11 @@ class ProfileScreenTest {
   fun setUp() {
     mockNavigationActions = mock(NavigationActions::class.java)
 
+    imageRepository = MockImageRepository()
     userRepository = MockUserRepository()
     parkingRepository = MockParkingRepository()
     userViewModel = UserViewModel(userRepository, parkingRepository)
+    parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
 
     composeTestRule.setContent {
       ProfileScreen(mockNavigationActions, userViewModel, parkingViewModel, AuthenticatorMock())

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -9,6 +9,7 @@ import com.github.se.cyrcle.di.mocks.AuthenticatorMock
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
+import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
@@ -27,6 +28,7 @@ class ProfileScreenTest {
   private lateinit var userRepository: UserRepository
   private lateinit var parkingRepository: ParkingRepository
   private lateinit var userViewModel: UserViewModel
+  private lateinit var parkingViewModel: ParkingViewModel
 
   private lateinit var mockNavigationActions: NavigationActions
 
@@ -39,7 +41,7 @@ class ProfileScreenTest {
     userViewModel = UserViewModel(userRepository, parkingRepository)
 
     composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, userViewModel, AuthenticatorMock())
+      ProfileScreen(mockNavigationActions, userViewModel, parkingViewModel, AuthenticatorMock())
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -63,9 +63,9 @@ class ViewProfileScreenTest {
     mockImageRepository = MockImageRepository()
 
     val user =
-        User(
-            UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
-            UserDetails("Jane", "Smith", "jane.smith@example.com"))
+      User(
+        UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
+        UserDetails("Jane", "Smith", "jane.smith@example.com"))
 
     userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
@@ -88,10 +88,10 @@ class ViewProfileScreenTest {
 
     composeTestRule.setContent {
       ViewProfileScreen(
-          navigationActions = mockNavigationActions,
-          userViewModel = userViewModel,
-          parkingViewModel = parkingViewModel,
-          AuthenticatorMock())
+        navigationActions = mockNavigationActions,
+        userViewModel = userViewModel,
+        parkingViewModel = parkingViewModel,
+        AuthenticatorMock())
     }
   }
 
@@ -210,13 +210,9 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").onChildren().assertCountEquals(3)
-    // Use ParkingItemText with useUnmergedTree
-    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
-      .assertTextEquals("Rue de la paix")
-    composeTestRule.onNodeWithTag("ParkingItemText_1", useUnmergedTree = true)
-      .assertTextEquals("Rude épais")
-    composeTestRule.onNodeWithTag("ParkingItemText_2", useUnmergedTree = true)
-      .assertTextEquals("Rue du pet")
+    composeTestRule.onNodeWithTag("ParkingItem_0", useUnmergedTree = true).assertTextContains("Rue de la paix")
+    composeTestRule.onNodeWithTag("ParkingItem_1", useUnmergedTree = true).assertTextContains("Rude épais")
+    composeTestRule.onNodeWithTag("ParkingItem_2", useUnmergedTree = true).assertTextContains("Rue du pet")
   }
 
   @Test
@@ -228,8 +224,8 @@ class ViewProfileScreenTest {
 
     composeTestRule.onNodeWithText("Remove favorite").assertIsDisplayed()
     composeTestRule
-        .onNodeWithText("Are you sure you want to remove Rue de la paix from your favorites?")
-        .assertIsDisplayed()
+      .onNodeWithText("Are you sure you want to remove Rue de la paix from your favorites?")
+      .assertIsDisplayed()
   }
 
   @Test
@@ -245,23 +241,23 @@ class ViewProfileScreenTest {
     composeTestRule.waitForIdle()
 
     // Verify the specific parking is removed from favorites
-    // Don't use useUnmergedTree when checking for non-existence
-    composeTestRule.onNodeWithTag("ParkingItemText_0")
-      .assertDoesNotExist()
+    composeTestRule.onNodeWithText("Rue de la paix").assertDoesNotExist()
   }
 
   @Test
   fun testCancelRemoveFavoriteParking() {
     composeTestRule.waitForIdle()
 
+    // Click the star icon to show the confirmation dialog
     composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
     composeTestRule.waitForIdle()
 
+    // Cancel removal
     composeTestRule.onNodeWithText("Cancel").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
-      .assertTextEquals("Rue de la paix")
+    // Verify the specific parking is still in favorites
+    composeTestRule.onNodeWithText("Rue de la paix").assertIsDisplayed()
   }
 
   @Test
@@ -293,23 +289,22 @@ class ViewProfileScreenTest {
   fun testRemoveFavoriteParkingsAndCheckIndexes() {
     composeTestRule.waitForIdle()
 
+    // Remove the middle parking
     composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
-      .assertTextEquals("Rue de la paix")
-    composeTestRule.onNodeWithTag("ParkingItemText_1", useUnmergedTree = true)
-      .assertTextEquals("Rue du pet")
+    composeTestRule.onNodeWithText("Rue de la paix").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Rue du pet").assertIsDisplayed()
 
+    // Remove the third parking (which is now second)
     composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
-      .assertTextEquals("Rue de la paix")
+    composeTestRule.onNodeWithText("Rue de la paix").assertIsDisplayed()
   }
 
   @Test
@@ -327,18 +322,18 @@ class ViewProfileScreenTest {
     composeTestRule.waitForIdle()
 
     val parking4 =
-        Parking(
-            "Test_spot_4",
-            "Roulade P",
-            "Wazzup beijing",
-            Location(Point.fromLngLat(7.19, 47.19)),
-            listOf(
-                "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
-            ParkingCapacity.LARGE,
-            ParkingRackType.TWO_TIER,
-            ParkingProtection.COVERED,
-            0.0,
-            true)
+      Parking(
+        "Test_spot_4",
+        "Roulade P",
+        "Wazzup beijing",
+        Location(Point.fromLngLat(7.19, 47.19)),
+        listOf(
+          "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
+        ParkingCapacity.LARGE,
+        ParkingRackType.TWO_TIER,
+        ParkingProtection.COVERED,
+        0.0,
+        true)
 
     parkingViewModel.addParking(parking4)
     userViewModel.addFavoriteParkingToSelectedUser(parking4.uid)
@@ -349,8 +344,8 @@ class ViewProfileScreenTest {
 
     composeTestRule.waitForIdle()
     composeTestRule
-        .onNodeWithTag("FavoriteParkingList")
-        .performScrollToNode(hasTestTag("FavoriteToggle_3"))
+      .onNodeWithTag("FavoriteParkingList")
+      .performScrollToNode(hasTestTag("FavoriteToggle_3"))
     composeTestRule.onNodeWithTag("FavoriteToggle_3").assertIsDisplayed()
   }
 
@@ -385,34 +380,10 @@ class ViewProfileScreenTest {
   fun testNavigateToParkingDetailsOnClick() {
     composeTestRule.waitForIdle()
 
-    // Click on the first parking card
-    composeTestRule.onNodeWithTag("ParkingItem_0").performClick()
+    composeTestRule.onNodeWithTag("ParkingItem_0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
 
-    // Verify that the parking was selected and navigation occurred
     verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
   }
 
-  @Test
-  fun testParkingCardStructure() {
-    composeTestRule.waitForIdle()
-
-    // Verify the card exists and is clickable
-    composeTestRule.onNodeWithTag("ParkingItem_0")
-      .assertExists()
-      .assertHasClickAction()
-
-    // Verify the content container exists (using useUnmergedTree)
-    composeTestRule.onNodeWithTag("ParkingItemContent_0", useUnmergedTree = true)
-      .assertExists()
-
-    // Verify the text content exists and has correct text
-    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
-      .assertExists()
-      .assertTextEquals("Rue de la paix")
-
-    // Verify the favorite toggle exists
-    composeTestRule.onNodeWithTag("FavoriteToggle_0")
-      .assertExists()
-  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -63,9 +63,9 @@ class ViewProfileScreenTest {
     mockImageRepository = MockImageRepository()
 
     val user =
-      User(
-        UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
-        UserDetails("Jane", "Smith", "jane.smith@example.com"))
+        User(
+            UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
+            UserDetails("Jane", "Smith", "jane.smith@example.com"))
 
     userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
@@ -88,10 +88,10 @@ class ViewProfileScreenTest {
 
     composeTestRule.setContent {
       ViewProfileScreen(
-        navigationActions = mockNavigationActions,
-        userViewModel = userViewModel,
-        parkingViewModel = parkingViewModel,
-        AuthenticatorMock())
+          navigationActions = mockNavigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel,
+          AuthenticatorMock())
     }
   }
 
@@ -210,9 +210,15 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").onChildren().assertCountEquals(3)
-    composeTestRule.onNodeWithTag("ParkingItem_0", useUnmergedTree = true).assertTextContains("Rue de la paix")
-    composeTestRule.onNodeWithTag("ParkingItem_1", useUnmergedTree = true).assertTextContains("Rude épais")
-    composeTestRule.onNodeWithTag("ParkingItem_2", useUnmergedTree = true).assertTextContains("Rue du pet")
+    composeTestRule
+        .onNodeWithTag("ParkingItem_0", useUnmergedTree = true)
+        .assertTextContains("Rue de la paix")
+    composeTestRule
+        .onNodeWithTag("ParkingItem_1", useUnmergedTree = true)
+        .assertTextContains("Rude épais")
+    composeTestRule
+        .onNodeWithTag("ParkingItem_2", useUnmergedTree = true)
+        .assertTextContains("Rue du pet")
   }
 
   @Test
@@ -224,8 +230,8 @@ class ViewProfileScreenTest {
 
     composeTestRule.onNodeWithText("Remove favorite").assertIsDisplayed()
     composeTestRule
-      .onNodeWithText("Are you sure you want to remove Rue de la paix from your favorites?")
-      .assertIsDisplayed()
+        .onNodeWithText("Are you sure you want to remove Rue de la paix from your favorites?")
+        .assertIsDisplayed()
   }
 
   @Test
@@ -322,18 +328,18 @@ class ViewProfileScreenTest {
     composeTestRule.waitForIdle()
 
     val parking4 =
-      Parking(
-        "Test_spot_4",
-        "Roulade P",
-        "Wazzup beijing",
-        Location(Point.fromLngLat(7.19, 47.19)),
-        listOf(
-          "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
-        ParkingCapacity.LARGE,
-        ParkingRackType.TWO_TIER,
-        ParkingProtection.COVERED,
-        0.0,
-        true)
+        Parking(
+            "Test_spot_4",
+            "Roulade P",
+            "Wazzup beijing",
+            Location(Point.fromLngLat(7.19, 47.19)),
+            listOf(
+                "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
+            ParkingCapacity.LARGE,
+            ParkingRackType.TWO_TIER,
+            ParkingProtection.COVERED,
+            0.0,
+            true)
 
     parkingViewModel.addParking(parking4)
     userViewModel.addFavoriteParkingToSelectedUser(parking4.uid)
@@ -344,8 +350,8 @@ class ViewProfileScreenTest {
 
     composeTestRule.waitForIdle()
     composeTestRule
-      .onNodeWithTag("FavoriteParkingList")
-      .performScrollToNode(hasTestTag("FavoriteToggle_3"))
+        .onNodeWithTag("FavoriteParkingList")
+        .performScrollToNode(hasTestTag("FavoriteToggle_3"))
     composeTestRule.onNodeWithTag("FavoriteToggle_3").assertIsDisplayed()
   }
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -1,20 +1,7 @@
 package com.github.se.cyrcle.ui.profile
 
-import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertHasNoClickAction
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChildren
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
-import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.AuthenticatorMock
 import com.github.se.cyrcle.di.mocks.MockImageRepository
@@ -63,21 +50,21 @@ class ViewProfileScreenTest {
     mockImageRepository = MockImageRepository()
 
     val user =
-      User(
-        UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
-        UserDetails("Jane", "Smith", "jane.smith@example.com"))
+        User(
+            UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
+            UserDetails("Jane", "Smith", "jane.smith@example.com"))
 
     userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
 
-    userViewModel.signIn(user)
+    userViewModel.addUser(user)
 
     // parking1 already added by whoever created parkingviewmodelmock on instanciation
     parkingViewModel.addParking(TestInstancesParking.parking2)
     parkingViewModel.addParking(TestInstancesParking.parking3)
 
     // Fetch the user
-    userViewModel.setCurrentUserById("1")
+    userViewModel.getUserById("1")
 
     // Add favorite parkings
     userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
@@ -88,35 +75,22 @@ class ViewProfileScreenTest {
 
     composeTestRule.setContent {
       ViewProfileScreen(
-        navigationActions = mockNavigationActions,
-        userViewModel = userViewModel,
-        parkingViewModel = parkingViewModel,
-        AuthenticatorMock())
+          navigationActions = mockNavigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel,
+          AuthenticatorMock())
     }
   }
 
   @Test
-  fun testSignOutApproval() {
+  fun testSignOut() {
     composeTestRule.waitForIdle()
 
     composeTestRule.onNodeWithTag("SignOutButton").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("SignOutDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("SignOutDialogConfirmButton").assertIsDisplayed().performClick()
+    assert(userViewModel.currentUser.value == null)
     verify(mockNavigationActions).navigateTo(TopLevelDestinations.AUTH)
-  }
-
-  @Test
-  fun testSignOutRefuse() {
-    composeTestRule.waitForIdle()
-
-    composeTestRule.onNodeWithTag("SignOutButton").performClick()
-    composeTestRule.waitForIdle()
-
-    composeTestRule.onNodeWithTag("SignOutDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("SignOutDialogCancelButton").assertIsDisplayed().performClick()
-    composeTestRule.onNodeWithTag("SignOutButton").assertIsDisplayed()
   }
 
   @Test
@@ -210,9 +184,13 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").onChildren().assertCountEquals(3)
-    composeTestRule.onNodeWithTag("ParkingItem_0", useUnmergedTree = true).assertTextContains("Rue de la paix")
-    composeTestRule.onNodeWithTag("ParkingItem_1", useUnmergedTree = true).assertTextContains("Rude épais")
-    composeTestRule.onNodeWithTag("ParkingItem_2", useUnmergedTree = true).assertTextContains("Rue du pet")
+    // Use ParkingItemText with useUnmergedTree
+    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
+      .assertTextEquals("Rue de la paix")
+    composeTestRule.onNodeWithTag("ParkingItemText_1", useUnmergedTree = true)
+      .assertTextEquals("Rude épais")
+    composeTestRule.onNodeWithTag("ParkingItemText_2", useUnmergedTree = true)
+      .assertTextEquals("Rue du pet")
   }
 
   @Test
@@ -224,8 +202,8 @@ class ViewProfileScreenTest {
 
     composeTestRule.onNodeWithText("Remove favorite").assertIsDisplayed()
     composeTestRule
-      .onNodeWithText("Are you sure you want to remove Rue de la paix from your favorites?")
-      .assertIsDisplayed()
+        .onNodeWithText("Are you sure you want to remove Rue de la paix from your favorites?")
+        .assertIsDisplayed()
   }
 
   @Test
@@ -241,23 +219,23 @@ class ViewProfileScreenTest {
     composeTestRule.waitForIdle()
 
     // Verify the specific parking is removed from favorites
-    composeTestRule.onNodeWithText("Rue de la paix").assertDoesNotExist()
+    // Don't use useUnmergedTree when checking for non-existence
+    composeTestRule.onNodeWithTag("ParkingItemText_0")
+      .assertDoesNotExist()
   }
 
   @Test
   fun testCancelRemoveFavoriteParking() {
     composeTestRule.waitForIdle()
 
-    // Click the star icon to show the confirmation dialog
     composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
     composeTestRule.waitForIdle()
 
-    // Cancel removal
     composeTestRule.onNodeWithText("Cancel").performClick()
     composeTestRule.waitForIdle()
 
-    // Verify the specific parking is still in favorites
-    composeTestRule.onNodeWithText("Rue de la paix").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
+      .assertTextEquals("Rue de la paix")
   }
 
   @Test
@@ -289,22 +267,23 @@ class ViewProfileScreenTest {
   fun testRemoveFavoriteParkingsAndCheckIndexes() {
     composeTestRule.waitForIdle()
 
-    // Remove the middle parking
     composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithText("Rue de la paix").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Rue du pet").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
+      .assertTextEquals("Rue de la paix")
+    composeTestRule.onNodeWithTag("ParkingItemText_1", useUnmergedTree = true)
+      .assertTextEquals("Rue du pet")
 
-    // Remove the third parking (which is now second)
     composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithText("Rue de la paix").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
+      .assertTextEquals("Rue de la paix")
   }
 
   @Test
@@ -322,18 +301,18 @@ class ViewProfileScreenTest {
     composeTestRule.waitForIdle()
 
     val parking4 =
-      Parking(
-        "Test_spot_4",
-        "Roulade P",
-        "Wazzup beijing",
-        Location(Point.fromLngLat(7.19, 47.19)),
-        listOf(
-          "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
-        ParkingCapacity.LARGE,
-        ParkingRackType.TWO_TIER,
-        ParkingProtection.COVERED,
-        0.0,
-        true)
+        Parking(
+            "Test_spot_4",
+            "Roulade P",
+            "Wazzup beijing",
+            Location(Point.fromLngLat(7.19, 47.19)),
+            listOf(
+                "https://upload.wikimedia.org/wikipedia/commons/7/78/%22G%C3%A4nsemarkt%22_in_Amance_-_panoramio.jpg"),
+            ParkingCapacity.LARGE,
+            ParkingRackType.TWO_TIER,
+            ParkingProtection.COVERED,
+            0.0,
+            true)
 
     parkingViewModel.addParking(parking4)
     userViewModel.addFavoriteParkingToSelectedUser(parking4.uid)
@@ -344,8 +323,8 @@ class ViewProfileScreenTest {
 
     composeTestRule.waitForIdle()
     composeTestRule
-      .onNodeWithTag("FavoriteParkingList")
-      .performScrollToNode(hasTestTag("FavoriteToggle_3"))
+        .onNodeWithTag("FavoriteParkingList")
+        .performScrollToNode(hasTestTag("FavoriteToggle_3"))
     composeTestRule.onNodeWithTag("FavoriteToggle_3").assertIsDisplayed()
   }
 
@@ -380,10 +359,34 @@ class ViewProfileScreenTest {
   fun testNavigateToParkingDetailsOnClick() {
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("ParkingItem_0", useUnmergedTree = true).performClick()
+    // Click on the first parking card
+    composeTestRule.onNodeWithTag("ParkingItem_0").performClick()
     composeTestRule.waitForIdle()
 
+    // Verify that the parking was selected and navigation occurred
     verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
   }
 
+  @Test
+  fun testParkingCardStructure() {
+    composeTestRule.waitForIdle()
+
+    // Verify the card exists and is clickable
+    composeTestRule.onNodeWithTag("ParkingItem_0")
+      .assertExists()
+      .assertHasClickAction()
+
+    // Verify the content container exists (using useUnmergedTree)
+    composeTestRule.onNodeWithTag("ParkingItemContent_0", useUnmergedTree = true)
+      .assertExists()
+
+    // Verify the text content exists and has correct text
+    composeTestRule.onNodeWithTag("ParkingItemText_0", useUnmergedTree = true)
+      .assertExists()
+      .assertTextEquals("Rue de la paix")
+
+    // Verify the favorite toggle exists
+    composeTestRule.onNodeWithTag("FavoriteToggle_0")
+      .assertExists()
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -96,7 +96,7 @@ fun CyrcleNavHost(
         route = Route.VIEW_PROFILE,
     ) {
       composable(Screen.VIEW_PROFILE) {
-        ProfileScreen(navigationActions, userViewModel, authenticator)
+        ProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
       }
     }
   }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -1,5 +1,4 @@
-package com.github.se.cyrcle
-
+import android.app.Activity
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -10,9 +9,7 @@ import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
-import com.github.se.cyrcle.permission.PermissionHandler
 import com.github.se.cyrcle.ui.addParking.attributes.AttributesPicker
-import com.github.se.cyrcle.ui.addParking.attributes.RackTypeHelpScreen
 import com.github.se.cyrcle.ui.addParking.location.LocationPicker
 import com.github.se.cyrcle.ui.authentication.Authenticator
 import com.github.se.cyrcle.ui.authentication.SignInScreen
@@ -22,7 +19,6 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.parkingDetails.ParkingDetailsScreen
-import com.github.se.cyrcle.ui.profile.CreateProfileScreen
 import com.github.se.cyrcle.ui.profile.ProfileScreen
 import com.github.se.cyrcle.ui.review.AllReviewsScreen
 import com.github.se.cyrcle.ui.review.ReviewScreen
@@ -37,7 +33,7 @@ fun CyrcleNavHost(
     mapViewModel: MapViewModel,
     addressViewModel: AddressViewModel,
     authenticator: Authenticator,
-    permissionHandler: PermissionHandler
+    activity: Activity
 ) {
   NavHost(navController = navController, startDestination = Route.AUTH) {
     navigation(
@@ -45,9 +41,6 @@ fun CyrcleNavHost(
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(authenticator, navigationActions, userViewModel) }
-      composable(Screen.CREATE_PROFILE) {
-        CreateProfileScreen(navigationActions, authenticator, userViewModel)
-      }
     }
 
     navigation(
@@ -79,7 +72,7 @@ fun CyrcleNavHost(
     ) {
       composable(Screen.MAP) {
         MapScreen(
-            navigationActions, parkingViewModel, userViewModel, mapViewModel, permissionHandler)
+            navigationActions, parkingViewModel, userViewModel, mapViewModel, activity = activity)
       }
     }
 
@@ -88,16 +81,13 @@ fun CyrcleNavHost(
       composable(Screen.ATTRIBUTES_PICKER) {
         AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
       }
-      composable(Screen.RACK_INFO) { RackTypeHelpScreen(navigationActions) }
     }
 
     navigation(
-        startDestination = Screen.VIEW_PROFILE,
-        route = Route.VIEW_PROFILE,
+        startDestination = Screen.PROFILE,
+        route = Route.PROFILE,
     ) {
-      composable(Screen.VIEW_PROFILE) {
-        ProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
-      }
+      composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -1,4 +1,5 @@
-import android.app.Activity
+package com.github.se.cyrcle
+
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -9,7 +10,9 @@ import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
+import com.github.se.cyrcle.permission.PermissionHandler
 import com.github.se.cyrcle.ui.addParking.attributes.AttributesPicker
+import com.github.se.cyrcle.ui.addParking.attributes.RackTypeHelpScreen
 import com.github.se.cyrcle.ui.addParking.location.LocationPicker
 import com.github.se.cyrcle.ui.authentication.Authenticator
 import com.github.se.cyrcle.ui.authentication.SignInScreen
@@ -19,6 +22,7 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.parkingDetails.ParkingDetailsScreen
+import com.github.se.cyrcle.ui.profile.CreateProfileScreen
 import com.github.se.cyrcle.ui.profile.ProfileScreen
 import com.github.se.cyrcle.ui.review.AllReviewsScreen
 import com.github.se.cyrcle.ui.review.ReviewScreen
@@ -33,7 +37,7 @@ fun CyrcleNavHost(
     mapViewModel: MapViewModel,
     addressViewModel: AddressViewModel,
     authenticator: Authenticator,
-    activity: Activity
+    permissionHandler: PermissionHandler
 ) {
   NavHost(navController = navController, startDestination = Route.AUTH) {
     navigation(
@@ -41,6 +45,9 @@ fun CyrcleNavHost(
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(authenticator, navigationActions, userViewModel) }
+      composable(Screen.CREATE_PROFILE) {
+        CreateProfileScreen(navigationActions, authenticator, userViewModel)
+      }
     }
 
     navigation(
@@ -72,7 +79,7 @@ fun CyrcleNavHost(
     ) {
       composable(Screen.MAP) {
         MapScreen(
-            navigationActions, parkingViewModel, userViewModel, mapViewModel, activity = activity)
+            navigationActions, parkingViewModel, userViewModel, mapViewModel, permissionHandler)
       }
     }
 
@@ -81,13 +88,16 @@ fun CyrcleNavHost(
       composable(Screen.ATTRIBUTES_PICKER) {
         AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
       }
+      composable(Screen.RACK_INFO) { RackTypeHelpScreen(navigationActions) }
     }
 
     navigation(
-        startDestination = Screen.PROFILE,
-        route = Route.PROFILE,
+        startDestination = Screen.VIEW_PROFILE,
+        route = Route.VIEW_PROFILE,
     ) {
-      composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator) }
+      composable(Screen.VIEW_PROFILE) {
+        ProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -3,6 +3,7 @@ package com.github.se.cyrcle.ui.profile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.authentication.Authenticator
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -11,10 +12,11 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 fun ProfileScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
+    parkingViewModel: ParkingViewModel,
     authenticator: Authenticator
 ) {
   val isSignedIn by userViewModel.isSignedIn.collectAsState(false)
 
-  if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, authenticator)
+  if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
   else InviteToAuthScreen(navigationActions)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -17,6 +17,7 @@ fun ProfileScreen(
 ) {
   val isSignedIn by userViewModel.isSignedIn.collectAsState(false)
 
-  if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, parkingViewModel,  authenticator)
+  if (isSignedIn)
+      ViewProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
   else CreateProfileScreen(navigationActions, authenticator, userViewModel)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -18,5 +18,5 @@ fun ProfileScreen(
   val isSignedIn by userViewModel.isSignedIn.collectAsState(false)
 
   if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, parkingViewModel,  authenticator)
-  else CreateProfileScreen(navigationActions, userViewModel)
+  else CreateProfileScreen(navigationActions, authenticator, userViewModel)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -19,5 +19,5 @@ fun ProfileScreen(
 
   if (isSignedIn)
       ViewProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
-  else CreateProfileScreen(navigationActions, authenticator, userViewModel)
+  else InviteToAuthScreen(navigationActions)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -17,6 +17,6 @@ fun ProfileScreen(
 ) {
   val isSignedIn by userViewModel.isSignedIn.collectAsState(false)
 
-  if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, parkingViewModel, authenticator)
-  else InviteToAuthScreen(navigationActions)
+  if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, parkingViewModel,  authenticator)
+  else CreateProfileScreen(navigationActions, userViewModel)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -161,10 +161,7 @@ fun ViewProfileScreen(
 
               Spacer(modifier = Modifier.height(24.dp))
 
-              FavoriteParkingsSection(
-                  userViewModel,
-                  parkingViewModel,
-                  navigationActions)
+              FavoriteParkingsSection(userViewModel, parkingViewModel, navigationActions)
             }
           }
         }
@@ -175,7 +172,8 @@ fun ViewProfileScreen(
 private fun FavoriteParkingsSection(
     userViewModel: UserViewModel,
     parkingViewModel: ParkingViewModel,
-    navigationActions: NavigationActions) {
+    navigationActions: NavigationActions
+) {
   val favoriteParkings = userViewModel.favoriteParkings.collectAsState().value
 
   LaunchedEffect(Unit) { userViewModel.getSelectedUserFavoriteParking() }
@@ -212,35 +210,46 @@ private fun FavoriteParkingsSection(
 }
 
 @Composable
-private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Unit, parkingViewModel: ParkingViewModel, navigationActions: NavigationActions) {
+private fun FavoriteParkingCard(
+    parking: Parking,
+    index: Int,
+    onRemove: () -> Unit,
+    parkingViewModel: ParkingViewModel,
+    navigationActions: NavigationActions
+) {
   var showConfirmDialog by remember { mutableStateOf(false) }
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-  Card(modifier = Modifier.size(120.dp).padding(8.dp).clickable(
-      onClick = {
-          parkingViewModel.selectParking(parking)
-          navigationActions.navigateTo(Screen.PARKING_DETAILS)
+  Card(
+      modifier =
+          Modifier.size(120.dp)
+              .padding(8.dp)
+              .clickable(
+                  onClick = {
+                    parkingViewModel.selectParking(parking)
+                    navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                  }),
+      shape = MaterialTheme.shapes.medium) {
+        Box(modifier = Modifier.fillMaxSize()) {
+          Text(
+              text = parking.optName ?: "",
+              style = MaterialTheme.typography.bodySmall,
+              modifier =
+                  Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
+
+          IconButton(
+              onClick = { showConfirmDialog = true },
+              modifier =
+                  Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
+                Icon(
+                    imageVector = Icons.Default.Favorite,
+                    contentDescription =
+                        stringResource(R.string.view_profile_screen_remove_from_favorite),
+                    tint = Red,
+                    modifier = Modifier.size(20.dp))
+              }
+        }
       }
-  ), shape = MaterialTheme.shapes.medium) {
-    Box(modifier = Modifier.fillMaxSize()) {
-      Text(
-          text = parking.optName ?: "",
-          style = MaterialTheme.typography.bodySmall,
-          modifier = Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
-
-      IconButton(
-          onClick = { showConfirmDialog = true },
-          modifier =
-              Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
-            Icon(
-                imageVector = Icons.Default.Favorite,
-                contentDescription =
-                    stringResource(R.string.view_profile_screen_remove_from_favorite),
-                tint = Red,
-                modifier = Modifier.size(20.dp))
-          }
-    }
-  }
 
   if (showConfirmDialog) {
     AlertDialog(
@@ -257,7 +266,7 @@ private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Un
               onClick = {
                 onRemove()
                 showConfirmDialog = false
-                  Toast.makeText(context, "Removed from Favorites!", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "Removed from Favorites!", Toast.LENGTH_SHORT).show()
               }) {
                 Text(
                     stringResource(


### PR DESCRIPTION
Content of the PR:
This trivial PR simply adds the possibility to navigate from the favorite parking card in the user's profile screen to its detail's screen. The favorite parking cards are now clickable and send you to the selected parking's detail screen. There is also a small test added to check this behaviour. Nothing much but still an essential feature.

Future ideas : 
I think the favorite parking cards need more than just the names on it.
In a future sprint, I would like to add either a few useful information about the parking, or the possibility to add personal notes beneath the names.