### PR TITLE
Refactor profile screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
@@ -1,43 +1,29 @@
 package com.github.se.cyrcle.ui.profile
 
-import androidx.activity.compose.setContent
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import com.github.se.cyrcle.MainActivity
-import com.github.se.cyrcle.model.user.UserViewModel
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 
-@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
 class CreateProfileScreenTest {
 
-  @get:Rule(order = 0) val hiltRule = HiltAndroidRule(this)
-
-  @get:Rule(order = 1) val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var mockNavigationActions: NavigationActions
-  private lateinit var userViewModel: UserViewModel
 
   @Before
   fun setUp() {
-    hiltRule.inject()
-
     mockNavigationActions = mock(NavigationActions::class.java)
 
-    userViewModel =
-        UserViewModel(
-            composeTestRule.activity.userRepository, composeTestRule.activity.parkingRepository)
-
-    composeTestRule.activity.setContent {
-      CreateProfileScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { CreateProfileScreen(mockNavigationActions) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/EditProfileComponentTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/EditProfileComponentTest.kt
@@ -1,0 +1,73 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.model.user.TestInstancesUser
+import com.github.se.cyrcle.ui.theme.atoms.Button
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EditProfileComponentTest {
+
+  @Composable
+  private fun SaveButton() {
+    Button(text = "Save", onClick = {}, testTag = "SaveButton")
+  }
+
+  @Composable
+  private fun CancelButton() {
+    Button(text = "Cancel", onClick = {}, testTag = "CancelButton")
+  }
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun testNullEditProfileComponent() {
+    composeTestRule.setContent { EditProfileComponent(null, { SaveButton() }, { CancelButton() }) }
+
+    composeTestRule.onNodeWithTag("NullUserText").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("ProfileImage").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("FirstNameField").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("LastNameField").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("UsernameField").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("SaveButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("CancelButton").assertDoesNotExist()
+  }
+
+  @Test
+  fun testEditProfileComponent() {
+    val user = TestInstancesUser.user1
+
+    composeTestRule.setContent { EditProfileComponent(user, { SaveButton() }, { CancelButton() }) }
+
+    composeTestRule.onNodeWithTag("NullUserText").assertDoesNotExist()
+
+    composeTestRule.onNodeWithTag("ProfileImage").assertIsDisplayed().assertHasClickAction()
+
+    composeTestRule
+        .onNodeWithTag("FirstNameField")
+        .assertIsDisplayed()
+        .assertTextContains(user.details?.firstName ?: "")
+
+    composeTestRule
+        .onNodeWithTag("LastNameField")
+        .assertIsDisplayed()
+        .assertTextContains(user.details?.lastName ?: "")
+
+    composeTestRule
+        .onNodeWithTag("UsernameField")
+        .assertIsDisplayed()
+        .assertTextContains(user.public.username)
+
+    composeTestRule.onNodeWithTag("SaveButton", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CancelButton", useUnmergedTree = true).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileImageComponentTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileImageComponentTest.kt
@@ -1,0 +1,63 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProfileImageComponentTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun testImageEditable() {
+    composeTestRule.setContent {
+      ProfileImageComponent(url = "https://example.com", onClick = {}, isEditable = true)
+    }
+
+    composeTestRule
+        .onNodeWithTag("EditProfileImageIcon", useUnmergedTree = true)
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ProfileImage", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("EmptyProfileImage", useUnmergedTree = true).assertDoesNotExist()
+  }
+
+  @Test
+  fun testEmptyImageEditable() {
+    composeTestRule.setContent { ProfileImageComponent(url = "", onClick = {}, isEditable = true) }
+
+    composeTestRule
+        .onNodeWithTag("EditProfileImageIcon", useUnmergedTree = true)
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag("RealProfileImage", useUnmergedTree = true).assertDoesNotExist()
+    composeTestRule.onNodeWithTag("EmptyProfileImage", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun testEmptyImage() {
+    composeTestRule.setContent { ProfileImageComponent(url = "", onClick = {}, isEditable = false) }
+
+    composeTestRule
+        .onNodeWithTag("EditProfileImageIcon", useUnmergedTree = true)
+        .assertDoesNotExist()
+    composeTestRule.onNodeWithTag("RealProfileImage", useUnmergedTree = true).assertDoesNotExist()
+    composeTestRule.onNodeWithTag("EmptyProfileImage", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun testImage() {
+    composeTestRule.setContent {
+      ProfileImageComponent(url = "https://example.com", onClick = {}, isEditable = false)
+    }
+
+    composeTestRule
+        .onNodeWithTag("EditProfileImageIcon", useUnmergedTree = true)
+        .assertDoesNotExist()
+    composeTestRule.onNodeWithTag("RealProfileImage", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("EmptyProfileImage", useUnmergedTree = true).assertDoesNotExist()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -1,7 +1,20 @@
 package com.github.se.cyrcle.ui.profile
 
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.AuthenticatorMock
 import com.github.se.cyrcle.di.mocks.MockImageRepository

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -8,7 +8,6 @@ import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingRepositoryFirestore
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.mapbox.maps.extension.style.expressions.dsl.generated.get
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
-import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.theme.atoms.Button
@@ -24,9 +23,7 @@ import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
 @Composable
-fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
-  val screenTitle = stringResource(R.string.profile_screen_title)
-
+fun CreateProfileScreen(navigationActions: NavigationActions) {
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("CreateProfileScreen"),
       bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.PROFILE) },
@@ -38,18 +35,22 @@ fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: Use
           horizontalAlignment = Alignment.CenterHorizontally,
       ) {
         Text(
-            "You need to be signed-in to modify your profile",
+            stringResource(R.string.profile_screen_invite_to_sign_in),
             style = MaterialTheme.typography.titleLarge)
+
         Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            "Sign in now to add new spots, share reviews, and help fellow cyclists find the perfect parking space.")
+
+        Text(stringResource(R.string.profile_screen_give_reasons_to_sign_in))
+
         Spacer(modifier = Modifier.height(8.dp))
+
         Button(
             text = "Go back to sign in",
             onClick = {
               // navigate to the route to not clear backstack
               navigationActions.navigateTo(Route.AUTH)
             })
+
         Spacer(modifier = Modifier.height(200.dp))
       }
     }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
@@ -1,0 +1,70 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.ui.theme.atoms.Text
+
+/**
+ * Display the profile content of the user. This composable is a component meant to be used within
+ * other screens
+ *
+ * @param user The user to display the profile content for.
+ * @param extras Extra composables to add under the displayed information.
+ */
+@Composable
+fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
+  if (user == null) {
+    Text("User is not signed in, should not happen")
+    return
+  }
+
+  val firstName = user.details?.firstName ?: ""
+  val lastName = user.details?.lastName ?: ""
+  val username = user.public.username
+  val profilePictureUrl = user.public.profilePictureUrl
+
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = firstName,
+            style = MaterialTheme.typography.headlineMedium,
+            testTag = "DisplayFirstName")
+
+        Text(
+            text = lastName,
+            style = MaterialTheme.typography.headlineMedium,
+            testTag = "DisplayLastName")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ProfileImageComponent(
+            url = profilePictureUrl,
+            onClick = {},
+            isEditable = false,
+            modifier = Modifier.testTag("ProfileImage"))
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(R.string.view_profile_screen_display_username, username),
+            style = MaterialTheme.typography.bodyMedium,
+            testTag = "DisplayUsername")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        extras()
+      }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
@@ -26,7 +26,7 @@ import com.github.se.cyrcle.ui.theme.atoms.Text
 @Composable
 fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
   if (user == null) {
-    Text("User is not signed in, should not happen")
+    Text(stringResource(R.string.profile_is_null), Modifier.testTag("NullUserText"))
     return
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -97,12 +97,12 @@ fun EditProfileComponent(
         Spacer(modifier = Modifier.height(16.dp))
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          cancelButton()
+
           saveButton(
               User(
                   UserPublic(user.public.userId, username, profilePictureUrl),
                   UserDetails(firstName, lastName, user.details!!.email)))
-
-          cancelButton()
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -41,7 +41,7 @@ fun EditProfileComponent(
     cancelButton: @Composable () -> Unit
 ) {
   if (user == null) {
-    Text("User is not signed in, should not happen", Modifier.testTag("NullUserText"))
+    Text(stringResource(R.string.profile_is_null), Modifier.testTag("NullUserText"))
     return
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -1,0 +1,108 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.model.user.UserDetails
+import com.github.se.cyrcle.model.user.UserPublic
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
+import com.github.se.cyrcle.ui.theme.atoms.Text
+
+/**
+ * Edit the profile content of the user. This composable is a component meant to be used within
+ * other screens
+ *
+ * @param user The user to edit the profile content for.
+ * @param saveButton The save button to display.
+ * @param cancelButton The cancel button to display.
+ */
+@Composable
+fun EditProfileComponent(
+    user: User?,
+    saveButton: @Composable (User) -> Unit,
+    cancelButton: @Composable () -> Unit
+) {
+  if (user == null) {
+    Text("User is not signed in, should not happen", Modifier.testTag("NullUserText"))
+    return
+  }
+
+  var username by remember { mutableStateOf(user.public.username) }
+  var firstName by remember { mutableStateOf(user.details!!.firstName) }
+  var lastName by remember { mutableStateOf(user.details!!.lastName) }
+  var profilePictureUrl by remember { mutableStateOf(user.public.profilePictureUrl) }
+
+  val imagePickerLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { profilePictureUrl = it.toString() }
+      }
+
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        ProfileImageComponent(
+            url = profilePictureUrl,
+            onClick = { imagePickerLauncher.launch("image/*") },
+            isEditable = true,
+            modifier = Modifier.testTag("ProfileImage"))
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ConditionCheckingInputText(
+            value = firstName,
+            onValueChange = { firstName = it },
+            label = stringResource(R.string.view_profile_screen_first_name_label),
+            minCharacters = FIRST_NAME_MIN_LENGTH,
+            maxCharacters = FIRST_NAME_MAX_LENGTH,
+            testTag = "FirstNameField")
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        ConditionCheckingInputText(
+            value = lastName,
+            onValueChange = { lastName = it },
+            label = stringResource(R.string.view_profile_screen_last_name_label),
+            minCharacters = LAST_NAME_MIN_LENGTH,
+            maxCharacters = LAST_NAME_MAX_LENGTH,
+            testTag = "LastNameField")
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        ConditionCheckingInputText(
+            value = username,
+            onValueChange = { username = it },
+            label = stringResource(R.string.view_profile_screen_username_label),
+            minCharacters = USERNAME_MIN_LENGTH,
+            maxCharacters = USERNAME_MAX_LENGTH,
+            testTag = "UsernameField")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          saveButton(
+              User(
+                  UserPublic(user.public.userId, username, profilePictureUrl),
+                  UserDetails(firstName, lastName, user.details!!.email)))
+
+          cancelButton()
+        }
+      }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileImageComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileImageComponent.kt
@@ -1,0 +1,84 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import coil.transform.CircleCropTransformation
+import com.github.se.cyrcle.R
+
+@Composable
+fun ProfileImageComponent(
+    url: String,
+    onClick: () -> Unit,
+    isEditable: Boolean,
+    modifier: Modifier = Modifier
+) {
+  Box(
+      modifier =
+          modifier
+              .testTag("ProfileImage")
+              .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)) {
+        if (url.isBlank()) {
+          Box(
+              modifier =
+                  Modifier.size(120.dp)
+                      .clip(CircleShape)
+                      .background(MaterialTheme.colorScheme.primaryContainer),
+              contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription =
+                        stringResource(R.string.view_profile_screen_default_profile_picture),
+                    modifier = Modifier.size(60.dp).testTag("EmptyProfileImage"),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer)
+              }
+        } else {
+          Image(
+              painter =
+                  rememberAsyncImagePainter(
+                      ImageRequest.Builder(LocalContext.current)
+                          .data(url)
+                          .apply { transformations(CircleCropTransformation()) }
+                          .build()),
+              contentDescription = stringResource(R.string.view_profile_screen_profile_picture),
+              modifier = Modifier.size(120.dp).clip(CircleShape).testTag("RealProfileImage"),
+              contentScale = ContentScale.Crop)
+        }
+
+        if (isEditable) {
+          Box(
+              modifier =
+                  Modifier.size(120.dp)
+                      .clip(CircleShape)
+                      .background(Color.Black.copy(alpha = 0.3f)),
+              contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Filled.Edit,
+                    contentDescription =
+                        stringResource(R.string.view_profile_screen_edit_profile_picture),
+                    tint = Color.White,
+                    modifier = Modifier.size(40.dp).testTag("EditProfileImageIcon"))
+              }
+        }
+      }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -16,5 +16,5 @@ fun ProfileScreen(
   val isSignedIn by userViewModel.isSignedIn.collectAsState(false)
 
   if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, authenticator)
-  else CreateProfileScreen(navigationActions, userViewModel)
+  else CreateProfileScreen(navigationActions)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -1,19 +1,11 @@
 package com.github.se.cyrcle.ui.profile
 
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -24,16 +16,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
-import coil.transform.CircleCropTransformation
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.user.UserViewModel
@@ -45,7 +31,6 @@ import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.Red
 import com.github.se.cyrcle.ui.theme.atoms.Button
-import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
@@ -62,18 +47,15 @@ fun ViewProfileScreen(
     userViewModel: UserViewModel,
     authenticator: Authenticator
 ) {
+  fun areInputsValid(firstName: String, lastName: String, username: String): Boolean {
+    return firstName.length in FIRST_NAME_MIN_LENGTH..FIRST_NAME_MAX_LENGTH &&
+        lastName.length in LAST_NAME_MIN_LENGTH..LAST_NAME_MAX_LENGTH &&
+        username.length in USERNAME_MIN_LENGTH..USERNAME_MAX_LENGTH
+  }
+
+  val context = LocalContext.current
   val userState by userViewModel.currentUser.collectAsState()
   var isEditing by remember { mutableStateOf(false) }
-  var firstName by remember { mutableStateOf(userState?.details?.firstName ?: "") }
-  var lastName by remember { mutableStateOf(userState?.details?.lastName ?: "") }
-  var username by remember { mutableStateOf(userState?.public?.username ?: "") }
-  var profilePictureUrl by remember { mutableStateOf(userState?.public?.profilePictureUrl ?: "") }
-  val context = LocalContext.current
-
-  val imagePickerLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let { profilePictureUrl = it.toString() }
-      }
 
   Scaffold(
       modifier = Modifier.testTag("ViewProfileScreen"),
@@ -90,223 +72,43 @@ fun ViewProfileScreen(
             navigationActions.navigateTo(TopLevelDestinations.AUTH)
           }
 
-          Column(
-              modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
-              horizontalAlignment = Alignment.CenterHorizontally) {
-                if (isEditing) {
-                  EditProfileContent(
-                      firstName = firstName,
-                      lastName = lastName,
-                      username = username,
-                      profilePictureUrl = profilePictureUrl,
-                      onFirstNameChange = { firstName = it },
-                      onLastNameChange = { lastName = it },
-                      onUsernameChange = { username = it },
-                      onImageClick = { imagePickerLauncher.launch("image/*") },
-                      onSave = {
-                        userViewModel.updateUser(
-                            userState?.copy(
-                                public =
-                                    userState
-                                        ?.public!!
-                                        .copy(
-                                            username = username,
-                                            profilePictureUrl = profilePictureUrl),
-                                details =
-                                    userState
-                                        ?.details
-                                        ?.copy(firstName = firstName, lastName = lastName))
-                                ?: return@EditProfileContent)
-                        userViewModel.getUserById(userState?.public!!.userId)
+          if (isEditing) {
+            EditProfileComponent(
+                user = userState,
+                saveButton = {
+                  Button(
+                      text = stringResource(R.string.view_profile_screen_save_button),
+                      onClick = {
+                        userViewModel.updateUser(it)
+                        userViewModel.getUserById(it.public.userId)
                         isEditing = false
                       },
-                      onCancel = {
-                        firstName = userState?.details?.firstName ?: ""
-                        lastName = userState?.details?.lastName ?: ""
-                        username = userState?.public!!.username
-                        profilePictureUrl = userState?.public!!.profilePictureUrl
-                        isEditing = false
-                      })
-                } else {
-                  DisplayProfileContent(
-                      firstName = firstName,
-                      lastName = lastName,
-                      username = username,
-                      profilePictureUrl = profilePictureUrl,
-                      onEditClick = { isEditing = true })
+                      colorLevel = ColorLevel.PRIMARY,
+                      enabled =
+                          areInputsValid(
+                              it.details!!.lastName, it.details.firstName, it.public.username),
+                      testTag = "SaveButton")
+                },
+                cancelButton = {
+                  Button(
+                      text = stringResource(R.string.view_profile_screen_cancel_button),
+                      onClick = { isEditing = false },
+                      colorLevel = ColorLevel.SECONDARY,
+                      testTag = "CancelButton")
+                })
+          } else {
+            DisplayProfileComponent(userState) {
+              Button(
+                  text = stringResource(R.string.view_profile_screen_modify_profile_button),
+                  onClick = { isEditing = true },
+                  colorLevel = ColorLevel.TERTIARY,
+                  testTag = "EditButton")
 
-                  Spacer(modifier = Modifier.height(24.dp))
+              Spacer(modifier = Modifier.height(24.dp))
 
-                  FavoriteParkingsSection(userViewModel)
-                }
-              }
-        }
-      }
-}
-
-@Composable
-private fun EditProfileContent(
-    firstName: String,
-    lastName: String,
-    username: String,
-    profilePictureUrl: String,
-    onFirstNameChange: (String) -> Unit,
-    onLastNameChange: (String) -> Unit,
-    onUsernameChange: (String) -> Unit,
-    onImageClick: () -> Unit,
-    onSave: () -> Unit,
-    onCancel: () -> Unit
-) {
-  ProfileImage(
-      url = profilePictureUrl,
-      onClick = onImageClick,
-      isEditable = true,
-      modifier = Modifier.testTag("ProfileImage"))
-
-  Spacer(modifier = Modifier.height(24.dp))
-
-  ConditionCheckingInputText(
-      value = firstName,
-      onValueChange = onFirstNameChange,
-      label = stringResource(R.string.view_profile_screen_first_name_label),
-      minCharacters = FIRST_NAME_MIN_LENGTH,
-      maxCharacters = FIRST_NAME_MAX_LENGTH,
-      testTag = "FirstNameField")
-
-  Spacer(modifier = Modifier.height(8.dp))
-
-  ConditionCheckingInputText(
-      value = lastName,
-      onValueChange = onLastNameChange,
-      label = stringResource(R.string.view_profile_screen_last_name_label),
-      minCharacters = LAST_NAME_MIN_LENGTH,
-      maxCharacters = LAST_NAME_MAX_LENGTH,
-      testTag = "LastNameField")
-
-  Spacer(modifier = Modifier.height(8.dp))
-
-  ConditionCheckingInputText(
-      value = username,
-      onValueChange = onUsernameChange,
-      label = stringResource(R.string.view_profile_screen_username_label),
-      minCharacters = USERNAME_MIN_LENGTH,
-      maxCharacters = USERNAME_MAX_LENGTH,
-      testTag = "UsernameField")
-
-  Spacer(modifier = Modifier.height(16.dp))
-
-  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-    Button(
-        text = stringResource(R.string.view_profile_screen_save_button),
-        onClick = onSave,
-        colorLevel = ColorLevel.PRIMARY,
-        enabled = areInputsValid(firstName, lastName, username),
-        testTag = "SaveButton")
-
-    Button(
-        text = stringResource(R.string.view_profile_screen_cancel_button),
-        onClick = onCancel,
-        colorLevel = ColorLevel.SECONDARY,
-        testTag = "CancelButton")
-  }
-}
-
-fun areInputsValid(firstName: String, lastName: String, username: String): Boolean {
-  return firstName.length in FIRST_NAME_MIN_LENGTH..FIRST_NAME_MAX_LENGTH &&
-      lastName.length in LAST_NAME_MIN_LENGTH..LAST_NAME_MAX_LENGTH &&
-      username.length in USERNAME_MIN_LENGTH..USERNAME_MAX_LENGTH
-}
-
-@Composable
-private fun DisplayProfileContent(
-    firstName: String,
-    lastName: String,
-    username: String,
-    profilePictureUrl: String,
-    onEditClick: () -> Unit
-) {
-  Text(
-      text = firstName,
-      style = MaterialTheme.typography.headlineMedium,
-      testTag = "DisplayFirstName")
-
-  Text(
-      text = lastName, style = MaterialTheme.typography.headlineMedium, testTag = "DisplayLastName")
-
-  Spacer(modifier = Modifier.height(16.dp))
-
-  ProfileImage(
-      url = profilePictureUrl,
-      onClick = {},
-      isEditable = false,
-      modifier = Modifier.testTag("ProfileImage"))
-  Spacer(modifier = Modifier.height(8.dp))
-
-  Text(
-      text = stringResource(R.string.view_profile_screen_display_username, username),
-      style = MaterialTheme.typography.bodyMedium,
-      testTag = "DisplayUsername")
-
-  Spacer(modifier = Modifier.height(16.dp))
-
-  Button(
-      text = stringResource(R.string.view_profile_screen_modify_profile_button),
-      onClick = onEditClick,
-      colorLevel = ColorLevel.TERTIARY,
-      testTag = "EditButton")
-}
-
-@Composable
-private fun ProfileImage(
-    url: String,
-    onClick: () -> Unit,
-    isEditable: Boolean,
-    modifier: Modifier = Modifier
-) {
-  Box(
-      modifier =
-          modifier.then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)) {
-        if (url.isBlank()) {
-          Box(
-              modifier =
-                  Modifier.size(120.dp)
-                      .clip(CircleShape)
-                      .background(MaterialTheme.colorScheme.primaryContainer),
-              contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector = Icons.Filled.Person,
-                    contentDescription =
-                        stringResource(R.string.view_profile_screen_default_profile_picture),
-                    modifier = Modifier.size(60.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer)
-              }
-        } else {
-          Image(
-              painter =
-                  rememberAsyncImagePainter(
-                      ImageRequest.Builder(LocalContext.current)
-                          .data(url)
-                          .apply { transformations(CircleCropTransformation()) }
-                          .build()),
-              contentDescription = stringResource(R.string.view_profile_screen_profile_picture),
-              modifier = Modifier.size(120.dp).clip(CircleShape),
-              contentScale = ContentScale.Crop)
-        }
-
-        if (isEditable) {
-          Box(
-              modifier =
-                  Modifier.size(120.dp)
-                      .clip(CircleShape)
-                      .background(Color.Black.copy(alpha = 0.3f)),
-              contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector = Icons.Filled.Edit,
-                    contentDescription =
-                        stringResource(R.string.view_profile_screen_edit_profile_picture),
-                    tint = Color.White,
-                    modifier = Modifier.size(40.dp))
-              }
+              FavoriteParkingsSection(userViewModel)
+            }
+          }
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -70,7 +70,7 @@ fun ViewProfileScreen(
   val userState by userViewModel.currentUser.collectAsState()
   var isEditing by remember { mutableStateOf(false) }
 
-  val signOutToastTest = stringResource(R.string.view_profile_on_sign_out_toast)
+  val signOutToastText = stringResource(R.string.view_profile_on_sign_out_toast)
 
   Scaffold(
       modifier = Modifier.testTag("ViewProfileScreen"),
@@ -83,7 +83,7 @@ fun ViewProfileScreen(
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
           authenticator.SignOutButton(Modifier.padding(10.dp).align(Alignment.TopEnd)) {
             userViewModel.setCurrentUser(null)
-            Toast.makeText(context, signOutToastTest, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, signOutToastText, Toast.LENGTH_SHORT).show()
             navigationActions.navigateTo(TopLevelDestinations.AUTH)
           }
 
@@ -166,9 +166,6 @@ private fun FavoriteParkingsSection(userViewModel: UserViewModel) {
 @Composable
 private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Unit) {
   var showConfirmDialog by remember { mutableStateOf(false) }
-  val context = LocalContext.current
-
-  val onFavParkingRemovalText = stringResource(R.string.view_profile_on_fav_parking_removal_toast)
 
   Card(modifier = Modifier.size(120.dp).padding(8.dp), shape = MaterialTheme.shapes.medium) {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -206,7 +203,6 @@ private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Un
               onClick = {
                 onRemove()
                 showConfirmDialog = false
-                Toast.makeText(context, onFavParkingRemovalText, Toast.LENGTH_SHORT).show()
               }) {
                 Text(
                     stringResource(

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -1,7 +1,14 @@
 package com.github.se.cyrcle.ui.profile
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -13,7 +20,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TextButton
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -57,6 +70,8 @@ fun ViewProfileScreen(
   val userState by userViewModel.currentUser.collectAsState()
   var isEditing by remember { mutableStateOf(false) }
 
+  val signOutToastTest = stringResource(R.string.view_profile_on_sign_out_toast)
+
   Scaffold(
       modifier = Modifier.testTag("ViewProfileScreen"),
       bottomBar = {
@@ -68,7 +83,7 @@ fun ViewProfileScreen(
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
           authenticator.SignOutButton(Modifier.padding(10.dp).align(Alignment.TopEnd)) {
             userViewModel.setCurrentUser(null)
-            Toast.makeText(context, "You're signed out!", Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, signOutToastTest, Toast.LENGTH_SHORT).show()
             navigationActions.navigateTo(TopLevelDestinations.AUTH)
           }
 
@@ -153,6 +168,8 @@ private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Un
   var showConfirmDialog by remember { mutableStateOf(false) }
   val context = LocalContext.current
 
+  val onFavParkingRemovalText = stringResource(R.string.view_profile_on_fav_parking_removal_toast)
+
   Card(modifier = Modifier.size(120.dp).padding(8.dp), shape = MaterialTheme.shapes.medium) {
     Box(modifier = Modifier.fillMaxSize()) {
       Text(
@@ -189,7 +206,7 @@ private fun FavoriteParkingCard(parking: Parking, index: Int, onRemove: () -> Un
               onClick = {
                 onRemove()
                 showConfirmDialog = false
-                Toast.makeText(context, "Removed from Favorites!", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, onFavParkingRemovalText, Toast.LENGTH_SHORT).show()
               }) {
                 Text(
                     stringResource(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,10 +97,15 @@
     <string name="map_screen_capacity">Capacity is %s</string>
     <string name="map_screen_mode_switch_label">Advanced</string>
 
+    <!-- Profile Commons -->
+    <string name="profile_account_already_exists">Your account is already linked, please try with another email</string>
+    <string name="profile_is_null">User is not signed in, should not happen</string>
+
     <!-- Create Profile Screen -->
     <string name="profile_screen_title">Create your profile</string>
     <string name="profile_screen_finish_sign_in_indication">Finish by signing in with Google to link your e-mail</string>
-    <string name="profile_screen_account_already_exists">Your account is already linked, please try with another email</string>
+    <string name="profile_screen_invite_to_sign_in">You need to be signed-in to modify your profile</string>
+    <string name="profile_screen_give_reasons_to_sign_in">"Sign in now to add new spots, share reviews, and help fellow cyclists find the perfect parking space."</string>
     <!-- View Profile Screen -->
     <string name="view_profile_screen_first_name_label">First Name</string>
     <string name="view_profile_screen_last_name_label">Last Name</string>
@@ -119,6 +124,9 @@
     <string name="view_profile_screen_remove_favorite_dialog_message">Are you sure you want to remove %s from your favorites?</string>
     <string name="view_profile_screen_remove_favorite_dialog_action_button">Remove</string>
     <string name="view_profile_screen_remove_favorite_dialog_cancel_button">Cancel</string>
+    <string name="view_profile_on_sign_out_toast">You\'re signed out!</string>
+    <string name="view_profile_on_fav_parking_removal_toast">Removed from Favorites!</string>
+
 
     <!-- All Reviews Screen -->
     <string name="all_review_title">All Reviews For %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,8 @@
 
     <!-- Create Profile Screen -->
     <string name="profile_screen_title">Create your profile</string>
+    <string name="profile_screen_finish_sign_in_indication">Finish by signing in with Google to link your e-mail</string>
+    <string name="profile_screen_account_already_exists">Your account is already linked, please try with another email</string>
     <!-- View Profile Screen -->
     <string name="view_profile_screen_first_name_label">First Name</string>
     <string name="view_profile_screen_last_name_label">Last Name</string>


### PR DESCRIPTION
### What is this PR?
This PR refactors the `profile` package, "extracts" and modularises the common components used in the `EditProfileScreen` and `ViewProfileScreen`.

### Why?
This is done in order to reduce boiler plate code when editing profiles and thus could be re-used for the later PR of creating an account screen.  

### Test coverage:
![image](https://github.com/user-attachments/assets/41a44d37-f69d-49ae-83dc-25f3773535c0)

Closes #247