### PR TITLE
Prepare the user data class for pictures

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/user/TestInstancesUser.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/TestInstancesUser.kt
@@ -4,11 +4,7 @@ object TestInstancesUser {
 
   val user1 =
       User(
-          public =
-              UserPublic(
-                  userId = "user1",
-                  username = "john_doe",
-                  profilePictureUrl = "https://example.com/profile/john_doe.jpg"),
+          public = UserPublic(userId = "user1", username = "john_doe"),
           details =
               UserDetails(
                   firstName = "John",
@@ -19,7 +15,7 @@ object TestInstancesUser {
 
   val newUser =
       User(
-          public = UserPublic(userId = "usr", username = "new_user", profilePictureUrl = ""),
+          public = UserPublic(userId = "usr", username = "new_user"),
           details =
               UserDetails(
                   firstName = "New",
@@ -34,7 +30,7 @@ object TestInstancesUser {
               UserPublic(
                   userId = "usr",
                   username = "updated_user",
-                  profilePictureUrl = "https://example.com/profile.png"),
+              ),
           details =
               UserDetails(
                   firstName = "Updated",

--- a/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
@@ -5,13 +5,13 @@ package com.github.se.cyrcle.model.user
  *
  * @property userId The unique identifier of the user.
  * @property username The username of the user.
- * @property profilePictureUrl The path to the profile picture of the user on the cloud storage.
- *   (Not implemented)
+ * @property profilePictureCloudPath The path to the profile picture of the user on the cloud
+ *   storage. (Not implemented)
  */
 data class UserPublic(
     val userId: String,
     val username: String,
-    val profilePictureUrl: String = "",
+    val profilePictureCloudPath: String = "",
     // val accountCreationDate: Timestamp? = null,
     // val numberOfContributedSpots: Int = 0,
     // val userReputationScore: Int = 0
@@ -36,9 +36,26 @@ data class UserDetails(
 )
 
 /**
+ * For information that are only relevant to the session and won't be stored in the database
+ *
+ * @property profilePictureUrl The URL of the profile picture
+ * @property profilePictureUri The URI of the profile picture,(local path on the device)
+ */
+data class LocalSession(
+    val profilePictureUrl: String? = "",
+    val profilePictureUri: String? = "",
+)
+
+/**
  * Data class representing a user.
  *
  * @property public Public information of the user.
  * @property details Private information of the user.
+ * @property localSession Information that are only relevant to the session and won't be stored in
+ *   the database
  */
-data class User(val public: UserPublic, val details: UserDetails?)
+data class User(
+    val public: UserPublic,
+    val details: UserDetails?,
+    val localSession: LocalSession? = null
+)

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
@@ -33,7 +33,7 @@ fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
   val firstName = user.details?.firstName ?: ""
   val lastName = user.details?.lastName ?: ""
   val username = user.public.username
-  val profilePictureUrl = user.public.profilePictureUrl
+  val profilePictureUri = user.localSession?.profilePictureUri ?: ""
 
   Column(
       modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
@@ -51,7 +51,7 @@ fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
         Spacer(modifier = Modifier.height(16.dp))
 
         ProfileImageComponent(
-            url = profilePictureUrl,
+            url = profilePictureUri,
             onClick = {},
             isEditable = false,
             modifier = Modifier.testTag("ProfileImage"))

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -20,9 +20,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.user.LocalSession
 import com.github.se.cyrcle.model.user.User
-import com.github.se.cyrcle.model.user.UserDetails
-import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 
@@ -48,18 +47,18 @@ fun EditProfileComponent(
   var username by remember { mutableStateOf(user.public.username) }
   var firstName by remember { mutableStateOf(user.details!!.firstName) }
   var lastName by remember { mutableStateOf(user.details!!.lastName) }
-  var profilePictureUrl by remember { mutableStateOf(user.public.profilePictureUrl) }
+  var profilePictureUri by remember { mutableStateOf(user.localSession?.profilePictureUri) }
 
   val imagePickerLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let { profilePictureUrl = it.toString() }
+        uri?.let { profilePictureUri = it.toString() }
       }
 
   Column(
       modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
       horizontalAlignment = Alignment.CenterHorizontally) {
         ProfileImageComponent(
-            url = profilePictureUrl,
+            url = profilePictureUri,
             onClick = { imagePickerLauncher.launch("image/*") },
             isEditable = true,
             modifier = Modifier.testTag("ProfileImage"))
@@ -100,9 +99,11 @@ fun EditProfileComponent(
           cancelButton()
 
           saveButton(
-              User(
-                  UserPublic(user.public.userId, username, profilePictureUrl),
-                  UserDetails(firstName, lastName, user.details!!.email)))
+              // Use .copy to not lose the locas session and avoid re-fetching the user from db.
+              user.copy(
+                  public = user.public.copy(username = username, profilePictureCloudPath = ""),
+                  details = user.details?.copy(firstName = firstName, lastName = lastName),
+                  localSession = LocalSession(profilePictureUri = profilePictureUri)))
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -101,9 +101,9 @@ fun EditProfileComponent(
           saveButton(
               // Use .copy to not lose the locas session and avoid re-fetching the user from db.
               user.copy(
-                  public = user.public.copy(username = username, profilePictureCloudPath = ""),
-                  details = user.details?.copy(firstName = firstName, lastName = lastName),
-                  localSession = LocalSession(profilePictureUri = profilePictureUri)))
+                  user.public.copy(username = username, profilePictureCloudPath = ""),
+                  user.details?.copy(firstName = firstName, lastName = lastName),
+                  LocalSession(profilePictureUri = profilePictureUri)))
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileImageComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileImageComponent.kt
@@ -28,7 +28,7 @@ import com.github.se.cyrcle.R
 
 @Composable
 fun ProfileImageComponent(
-    url: String,
+    url: String?,
     onClick: () -> Unit,
     isEditable: Boolean,
     modifier: Modifier = Modifier
@@ -38,7 +38,7 @@ fun ProfileImageComponent(
           modifier
               .testTag("ProfileImage")
               .then(if (isEditable) Modifier.clickable(onClick = onClick) else Modifier)) {
-        if (url.isBlank()) {
+        if (url.isNullOrBlank()) {
           Box(
               modifier =
                   Modifier.size(120.dp)

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -95,7 +95,8 @@ fun ViewProfileScreen(
                       text = stringResource(R.string.view_profile_screen_save_button),
                       onClick = {
                         userViewModel.updateUser(it)
-                        userViewModel.getUserById(it.public.userId)
+                        // don't call getUserByID or the localSession is overwritten.
+                        userViewModel.setCurrentUser(it)
                         isEditing = false
                       },
                       colorLevel = ColorLevel.PRIMARY,


### PR DESCRIPTION
_closes #250_

## What
This PR prepares the user data so that we will be able to download and upload picture :

## How
You can find a graph below that summarize the new user data class, but I'll quickly describe the changes: 

- The public URL has been modified to be a  public cloud path (i.e "ProfilePictures/axwez.jpg")
- The URL is not stored in the public part of the user but in a new part called session
- The session part of the user Data class holds informations that don't need to be backed-up.
- The session part also hold the URI (the local path on the user device) 
Used when he selected the picture to pass it to the backend and also to preview the picture before sending it to the cloud.

_A graph of the structure of the user data class_
<img width="305" alt="image" src="https://github.com/user-attachments/assets/22ea6eea-9175-4985-afd5-c33cc54a5777">

## Why 
One field to hold the 3 objects  (Uri, Url, cloud path) was not enough, since they are clearly different even if they are used to display pictures, this is easier to maintain and understand 

-- -
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f5372cfe-1677-4144-8aaa-c4527b26e151">

