### PR TITLE
Profile pictures are persistent

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
@@ -8,8 +8,10 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.AuthenticatorMock
+import com.github.se.cyrcle.di.mocks.MockImageRepository
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
+import com.github.se.cyrcle.model.image.ImageRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
@@ -34,7 +36,7 @@ class SignInTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var userRepository: UserRepository
   private lateinit var parkingRepository: ParkingRepository
-
+  private lateinit var imageRepository: ImageRepository
   private lateinit var userViewModel: UserViewModel
 
   @Before
@@ -43,7 +45,8 @@ class SignInTest {
 
     userRepository = MockUserRepository()
     parkingRepository = MockParkingRepository()
-    userViewModel = UserViewModel(userRepository, parkingRepository)
+    imageRepository = MockImageRepository()
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
 
     val mockAuthenticator = AuthenticatorMock()
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -81,8 +81,8 @@ class ListScreenTest {
     // parking1 already in
     parkingViewModel.addParking(TestInstancesParking.parking2)
     parkingViewModel.addParking(TestInstancesParking.parking3)
-    userViewModel.addUser(user)
-    userViewModel.getUserById(user.public.userId)
+    userViewModel.signIn(user)
+    userViewModel.setCurrentUserById(user.public.userId)
     userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)
     userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking2.uid)
     userViewModel.getSelectedUserFavoriteParking()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -111,8 +111,8 @@ class ParkingDetailsScreenTest {
   fun addToFavoritesWhenSignedIn() {
 
     parkingViewModel.selectParking(TestInstancesParking.parking3)
-    userViewModel.addUser(TestInstancesUser.user1)
-    userViewModel.getUserById(TestInstancesUser.user1.public.userId)
+    userViewModel.signIn(TestInstancesUser.user1)
+    userViewModel.setCurrentUserById(TestInstancesUser.user1.public.userId)
     userViewModel.getSelectedUserFavoriteParking()
 
     composeTestRule.setContent {
@@ -131,8 +131,8 @@ class ParkingDetailsScreenTest {
   @Test
   fun removeFromFavoritesWhenSignedIn() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
-    userViewModel.addUser(TestInstancesUser.user1)
-    userViewModel.getUserById(TestInstancesUser.user1.public.userId)
+    userViewModel.signIn(TestInstancesUser.user1)
+    userViewModel.setCurrentUserById(TestInstancesUser.user1.public.userId)
     userViewModel.getSelectedUserFavoriteParking()
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -69,14 +69,14 @@ class ViewProfileScreenTest {
     userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
     parkingViewModel = ParkingViewModel(mockImageRepository, mockParkingRepository)
 
-    userViewModel.addUser(user)
+    userViewModel.signIn(user)
 
     // parking1 already added by whoever created parkingviewmodelmock on instanciation
     parkingViewModel.addParking(TestInstancesParking.parking2)
     parkingViewModel.addParking(TestInstancesParking.parking3)
 
     // Fetch the user
-    userViewModel.getUserById("1")
+    userViewModel.setCurrentUserById("1")
 
     // Add favorite parkings
     userViewModel.addFavoriteParkingToSelectedUser(TestInstancesParking.parking1.uid)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <!-- Permission of MapBox to access Coarse Location of the user -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+
 
     <application
         android:name=".CyrcleApp"

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -50,7 +50,7 @@ class MainActivity : ComponentActivity() {
     permissionsHandler.initHandler(this@MainActivity)
 
     val reviewViewModel = ReviewViewModel(reviewRepository)
-    val userViewModel = UserViewModel(userRepository, parkingRepository)
+    val userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
     val parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
     val mapViewModel = MapViewModel()
     val addressViewModel = AddressViewModel(addressRepository)

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -126,7 +126,7 @@ class UserViewModel(
     // First update the user object in the view model.
     setCurrentUser(user)
     // Then update the user object in the database
-    if (user.localSession?.profilePictureUri == null || context == null) {
+    if (user.localSession?.profilePictureUri.isNullOrBlank() || context == null) {
       userRepository.updateUser(
           user,
           onSuccess = { Log.d("UserViewModel", "User updated in the database") },

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.map
 class UserViewModel(
     private val userRepository: UserRepository,
     private val parkingRepository: ParkingRepository,
-    private val imageRepository: ImageRepository
+    private val imageRepository: ImageRepository? = null
 ) : ViewModel() {
 
   private val _currentUser = MutableStateFlow<User?>(null)
@@ -34,7 +34,7 @@ class UserViewModel(
    *
    * @param user the user to set as the current user
    */
-  private fun setCurrentUser(user: User?) {
+  fun setCurrentUser(user: User?) {
     Log.d("UserViewModel", "Setting the current user in viewmodel : $user")
     _currentUser.value = user
   }
@@ -98,7 +98,7 @@ class UserViewModel(
   fun signIn(user: User) {
     // Set the user in the viewmodel even if it's incomplete as we need the ID to match to call
     // updateUser()
-    setCurrentUser(user)
+    // setCurrentUser(user)
     userRepository.addUser(
         user,
         onSuccess = { getUserById(user.public.userId) { setCurrentUser(it) } },
@@ -190,6 +190,10 @@ class UserViewModel(
    * path
    */
   private fun uploadProfilePicture(context: Context) {
+    if (imageRepository == null) {
+      Log.e("UserViewModel", "ImageRepository is null")
+      return
+    }
     val user = currentUser.value ?: return
     val fileUri = user.localSession?.profilePictureUri ?: return
     val destinationPath = "profile_pictures/${user.public.userId}"
@@ -216,6 +220,10 @@ class UserViewModel(
    * @param onSuccess the callback to call with the updated user
    */
   private fun transformPathToUrl(user: User, onSuccess: (User) -> Unit, onFailure: () -> Unit) {
+    if (imageRepository == null) {
+      Log.e("UserViewModel", "ImageRepository is null")
+      return
+    }
     val cloudPath = user.public.profilePictureCloudPath
     if (cloudPath.isBlank()) {
       Log.d("UserViewModel", "No image to fetch for user")

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -1,13 +1,17 @@
 package com.github.se.cyrcle.model.user
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.github.se.cyrcle.model.image.ImageRepository
+import com.github.se.cyrcle.model.image.ImageRepositoryCloudStorage
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingRepositoryFirestore
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +19,8 @@ import kotlinx.coroutines.flow.map
 
 class UserViewModel(
     private val userRepository: UserRepository,
-    private val parkingRepository: ParkingRepository
+    private val parkingRepository: ParkingRepository,
+    private val imageRepository: ImageRepository
 ) : ViewModel() {
 
   private val _currentUser = MutableStateFlow<User?>(null)
@@ -29,19 +34,25 @@ class UserViewModel(
    *
    * @param user the user to set as the current user
    */
-  fun setCurrentUser(user: User?) {
+  private fun setCurrentUser(user: User?) {
+    Log.d("UserViewModel", "Setting the current user in viewmodel : $user")
     _currentUser.value = user
   }
 
   private val _favoriteParkings = MutableStateFlow<List<Parking>>(emptyList())
   val favoriteParkings: StateFlow<List<Parking>> = _favoriteParkings
 
+  /** Signs out the current user by setting the state to null */
+  fun signOut() {
+    setCurrentUser(null)
+  }
+
   /**
-   * Gets a user by ID from the Firestore database and sets it as the current user.
+   * Set the current user by fetching the user from the Firestore database with the given ID.
    *
    * @param userId the ID of the user to get
    */
-  fun getUserById(userId: String) {
+  fun setCurrentUserById(userId: String) {
     userRepository.getUserById(
         userId,
         onSuccess = { setCurrentUser(it) },
@@ -54,15 +65,22 @@ class UserViewModel(
   }
 
   /**
-   * Gets a user by ID from the Firestore database and calls the onSuccess callback with the user.
+   * Gets a user by ID from the Firestore database.. Fetches the profile picture url from the cloud
+   * storage and updates the user object with before calling the callback.
    *
    * @param userId the ID of the user to get
    * @param onSuccess the callback to call with the user
    */
   fun getUserById(userId: String, onSuccess: (User) -> Unit) {
+    Log.d("UserViewModel", "Getting the current user by ID: $userId")
     userRepository.getUserById(
         userId,
-        onSuccess = { onSuccess(it) },
+        onSuccess = {
+          transformPathToUrl(
+              it,
+              onSuccess = onSuccess,
+              onFailure = { Log.e("UserViewModel", "Failed to transform path to url") })
+        },
         onFailure = { exception ->
           Log.e(
               "com.github.se.cyrcle.model.user.UserViewModel",
@@ -72,20 +90,18 @@ class UserViewModel(
   }
 
   /**
-   * Adds a user to the Firestore database.
+   * Sign in a User : If he doesn't have an account on the database, it will create a new user. If
+   * he does we retrieve the user from the database and set it as the current user.
    *
    * @param user the user to add
    */
-  fun addUser(user: User) {
+  fun signIn(user: User) {
+    // Set the user in the viewmodel even if it's incomplete as we need the ID to match to call
+    // updateUser()
+    setCurrentUser(user)
     userRepository.addUser(
         user,
-        onSuccess = {
-          // set the current user by fetching the user from the database
-          // can't use the user object passed in because it doesn't have the full details of the
-          // user if the user is not a new user.
-          userRepository.getUserById(
-              user.public.userId, onSuccess = { setCurrentUser(it) }, onFailure = {})
-        },
+        onSuccess = { getUserById(user.public.userId) { setCurrentUser(it) } },
         onFailure = { exception ->
           Log.e(
               "com.github.se.cyrcle.model.user.UserViewModel",
@@ -95,20 +111,35 @@ class UserViewModel(
   }
 
   /**
-   * Updates a user in the Firestore database.
+   * Updates a user in the Firestore database. If a user has Uri for the profile picture, it will
+   * upload the image to the cloud storage and then delete the Uri.
    *
    * @param user the user to update
    */
-  fun updateUser(user: User) {
-    userRepository.updateUser(
-        user,
-        onSuccess = { Log.d("UserViewModel", "User updated") },
-        onFailure = { exception ->
-          Log.e(
-              "com.github.se.cyrcle.model.user.UserViewModel",
-              "Failed to update user: ${user.public.userId}",
-              exception)
-        })
+  fun updateUser(user: User, context: Context? = null) {
+    if (user.public.userId != currentUser.value?.public?.userId) {
+      Log.e("UserViewModel", "Trying to update a user that is not the current user")
+      return
+    }
+
+    Log.d("UserViewModel", "Updating user: $user")
+    // First update the user object in the view model.
+    setCurrentUser(user)
+    // Then update the user object in the database
+    if (user.localSession?.profilePictureUri == null || context == null) {
+      userRepository.updateUser(
+          user,
+          onSuccess = { Log.d("UserViewModel", "User updated in the database") },
+          onFailure = { exception ->
+            Log.e(
+                "com.github.se.cyrcle.model.user.UserViewModel",
+                "Failed to update user: ${user.public.userId}",
+                exception)
+          })
+    } else {
+      Log.d("UserViewModel", "User has a profile picture to upload")
+      uploadProfilePicture(context)
+    }
   }
 
   /**
@@ -153,6 +184,60 @@ class UserViewModel(
     }
   }
 
+  /**
+   * Upload the picture to the cloud storage update the user object in the database with the cloud
+   * path created. update the user object in the viewmodel with the url of the image and the cloud
+   * path
+   */
+  private fun uploadProfilePicture(context: Context) {
+    val user = currentUser.value ?: return
+    val fileUri = user.localSession?.profilePictureUri ?: return
+    val destinationPath = "profile_pictures/${user.public.userId}"
+    imageRepository.uploadImage(
+        context = context,
+        fileUri = fileUri,
+        destinationPath = destinationPath,
+        onSuccess = { url ->
+          Log.d("UserViewModel", "Image uploaded successfully to $url")
+          val updatedUser =
+              user.copy(
+                  public = user.public.copy(profilePictureCloudPath = destinationPath),
+                  localSession =
+                      user.localSession.copy(profilePictureUri = null, profilePictureUrl = url))
+          updateUser(updatedUser)
+        },
+        onFailure = { Log.e("UserViewModel", "Failed to upload image") })
+  }
+
+  /**
+   * Updates the user object with the profile picture url fetched from the repo.
+   *
+   * @param user the user object to update (doesn't have to be the current user)
+   * @param onSuccess the callback to call with the updated user
+   */
+  private fun transformPathToUrl(user: User, onSuccess: (User) -> Unit, onFailure: () -> Unit) {
+    val cloudPath = user.public.profilePictureCloudPath
+    if (cloudPath.isBlank()) {
+      Log.d("UserViewModel", "No image to fetch for user")
+      onSuccess(user) // No image to fetch
+      return
+    }
+
+    Log.d("UserViewModel", "Getting the url for the image at $cloudPath")
+    imageRepository.getUrl(
+        cloudPath,
+        onSuccess = { url ->
+          Log.d("UserViewModel", "Got the url for the image: $url")
+          val updatedUser =
+              user.copy(
+                  localSession =
+                      user.localSession?.copy(profilePictureUrl = url)
+                          ?: LocalSession(profilePictureUrl = url))
+          onSuccess(updatedUser)
+        },
+        onFailure = onFailure)
+  }
+
   companion object {
     val Factory: ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {
@@ -161,7 +246,9 @@ class UserViewModel(
             return UserViewModel(
                 UserRepositoryFirestore(
                     FirebaseFirestore.getInstance(), FirebaseAuth.getInstance()),
-                ParkingRepositoryFirestore(FirebaseFirestore.getInstance()))
+                ParkingRepositoryFirestore(FirebaseFirestore.getInstance()),
+                ImageRepositoryCloudStorage(
+                    FirebaseAuth.getInstance(), FirebaseStorage.getInstance()))
                 as T
           }
         }

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -204,8 +204,17 @@ class UserViewModel(
       Log.e("UserViewModel", "ImageRepository is null, should not upload image")
       return
     }
-    val user = currentUser.value ?: return
-    val fileUri = user.localSession?.profilePictureUri ?: return
+    if (currentUser.value == null) {
+      Log.e("UserViewModel", "Current user is null, should not upload image")
+      return
+    }
+    if (currentUser.value?.localSession?.profilePictureUri == null) {
+      Log.e("UserViewModel", "Profile picture uri is null, should not upload image")
+      return
+    }
+
+    val user = currentUser.value!!
+    val fileUri = user.localSession!!.profilePictureUri!!
     val destinationPath = "profile_pictures/${user.public.userId}"
     imageRepository.uploadImage(
         context = context,

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -46,7 +46,7 @@ fun SignInScreen(
 
     // TODO add checks if user is already exists
 
-    userViewModel.addUser(user)
+    userViewModel.signIn(user)
     navigationActions.navigateTo(TopLevelDestinations.MAP)
   }
   val onAuthFailure = { e: Exception ->

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
@@ -33,7 +33,7 @@ fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
   val firstName = user.details?.firstName ?: ""
   val lastName = user.details?.lastName ?: ""
   val username = user.public.username
-  val profilePictureUri = user.localSession?.profilePictureUri ?: ""
+  val profilePictureUrl = user.localSession?.profilePictureUrl ?: ""
 
   Column(
       modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
@@ -51,7 +51,7 @@ fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
         Spacer(modifier = Modifier.height(16.dp))
 
         ProfileImageComponent(
-            url = profilePictureUri,
+            url = profilePictureUrl,
             onClick = {},
             isEditable = false,
             modifier = Modifier.testTag("ProfileImage"))

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -48,17 +48,21 @@ fun EditProfileComponent(
   var firstName by remember { mutableStateOf(user.details!!.firstName) }
   var lastName by remember { mutableStateOf(user.details!!.lastName) }
   var profilePictureUri by remember { mutableStateOf(user.localSession?.profilePictureUri) }
+  val profilePictureUrl by remember { mutableStateOf(user.localSession?.profilePictureUrl) }
+  // To display the local profile picture when the user changes it, and hasn't uploaded (saved) it
+  var hasTemporarilyChangedProfilePicture by remember { mutableStateOf(false) }
 
   val imagePickerLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         uri?.let { profilePictureUri = it.toString() }
+        hasTemporarilyChangedProfilePicture = true
       }
 
   Column(
       modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
       horizontalAlignment = Alignment.CenterHorizontally) {
         ProfileImageComponent(
-            url = profilePictureUri,
+            url = if (hasTemporarilyChangedProfilePicture) profilePictureUri else profilePictureUrl,
             onClick = { imagePickerLauncher.launch("image/*") },
             isEditable = true,
             modifier = Modifier.testTag("ProfileImage"))

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.user.LocalSession
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
@@ -106,7 +107,8 @@ fun EditProfileComponent(
               user.copy(
                   user.public.copy(username = username),
                   user.details?.copy(firstName = firstName, lastName = lastName),
-                  user.localSession?.copy(profilePictureUri = profilePictureUri)))
+                  user.localSession?.copy(profilePictureUri = profilePictureUri)
+                      ?: LocalSession(profilePictureUri = profilePictureUri)))
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
-import com.github.se.cyrcle.model.user.LocalSession
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
@@ -103,11 +102,11 @@ fun EditProfileComponent(
           cancelButton()
 
           saveButton(
-              // Use .copy to not lose the locas session and avoid re-fetching the user from db.
+              // Use .copy to not lose the local session and avoid re-fetching the user from db.
               user.copy(
-                  user.public.copy(username = username, profilePictureCloudPath = ""),
+                  user.public.copy(username = username),
                   user.details?.copy(firstName = firstName, lastName = lastName),
-                  LocalSession(profilePictureUri = profilePictureUri)))
+                  user.localSession?.copy(profilePictureUri = profilePictureUri)))
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -82,7 +82,7 @@ fun ViewProfileScreen(
       }) { innerPadding ->
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
           authenticator.SignOutButton(Modifier.padding(10.dp).align(Alignment.TopEnd)) {
-            userViewModel.setCurrentUser(null)
+            userViewModel.signOut()
             Toast.makeText(context, signOutToastText, Toast.LENGTH_SHORT).show()
             navigationActions.navigateTo(TopLevelDestinations.AUTH)
           }
@@ -94,9 +94,9 @@ fun ViewProfileScreen(
                   Button(
                       text = stringResource(R.string.view_profile_screen_save_button),
                       onClick = {
-                        userViewModel.updateUser(it)
-                        // don't call getUserByID or the localSession is overwritten.
-                        userViewModel.setCurrentUser(it)
+                        // take care of updating the viewmodel as well as the database
+                        userViewModel.updateUser(it, context)
+
                         isEditing = false
                       },
                       colorLevel = ColorLevel.PRIMARY,

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.runtime.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -37,8 +37,8 @@ class UserViewModelTest {
   }
 
   @Test
-  fun addUserTest() {
-    userViewModel.addUser(TestInstancesUser.user1)
+  fun signInTest() {
+    userViewModel.signIn(TestInstancesUser.user1)
     // Check if the user was added to the repository
     verify(userRepository).addUser(eq(TestInstancesUser.user1), any(), any())
   }
@@ -52,8 +52,8 @@ class UserViewModelTest {
   }
 
   @Test
-  fun getUserByIdTest() {
-    userViewModel.getUserById("user1")
+  fun setCurrentUserByIdTest() {
+    userViewModel.setCurrentUserById("user1")
 
     // Check if the user was fetched from the repository
     verify(userRepository).getUserById(eq("user1"), any(), any())
@@ -66,7 +66,7 @@ class UserViewModelTest {
       val onSuccess = invocation.arguments[1] as (User) -> Unit
       onSuccess(TestInstancesUser.user1)
     }
-    userViewModel.getUserById("user1") { assert(it == TestInstancesUser.user1) }
+    userViewModel.setCurrentUserById("user1") { assert(it == TestInstancesUser.user1) }
     verify(userRepository).getUserById(eq("user1"), any(), any())
   }
 

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.user
 
+import com.github.se.cyrcle.model.image.ImageRepository
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.TestInstancesParking
@@ -21,12 +22,13 @@ class UserViewModelTest {
 
   @Mock private lateinit var userRepository: UserRepository
   @Mock private lateinit var parkingRepository: ParkingRepository
+  @Mock private lateinit var imageRepository: ImageRepository
   private lateinit var userViewModel: UserViewModel
 
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
-    userViewModel = UserViewModel(userRepository, parkingRepository)
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
   }
 
   @Test
@@ -66,12 +68,13 @@ class UserViewModelTest {
       val onSuccess = invocation.arguments[1] as (User) -> Unit
       onSuccess(TestInstancesUser.user1)
     }
-    userViewModel.setCurrentUserById("user1") { assert(it == TestInstancesUser.user1) }
+    userViewModel.getUserById("user1") { assert(it == TestInstancesUser.user1) }
     verify(userRepository).getUserById(eq("user1"), any(), any())
   }
 
   @Test
   fun updateUserTest() {
+    userViewModel.setCurrentUser(TestInstancesUser.user1)
     userViewModel.updateUser(TestInstancesUser.user1)
 
     // Check if the user was updated in the repository


### PR DESCRIPTION
_closes #253 #254_
**Important note** : Delete your user document on firestore before testing this PR

## What
The user's profile picture is send to a database, making it persistent, and retrieve on log-in to be displayed.

### How
_The viewmodel had to be changed, to send request to the image repository, the changes are quite complex, so the easiest way to understand what is happening is to look at the graphs I prepared for the wiki_  : 

On sign-in : 
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/0e3e5a9c-a35f-4282-bfac-86d6fcc0b57e">

On modify profile : 
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/81bbe963-80d8-4cbb-b87f-7a59f8adc428">

### Major changes
- A new function in the viewmodel `uploadPicture` is called only when `updatesUser` detects an URI has been set in the updatedUser
- A new function `transferPathToUrl` is called when we want to fetch the profile picture of a user, or our own profile pictures on login, it is called inside `getUserById(user, onSuccess)`

### Minor changes :
- The function of the viewmodel `getUserById(user: User)` that actually set the current user has been renamed to `setCurrentUserById() `
- `AddUser` has been renamed into `signIn` to better reflect what it does .
-  A SignOut function has been introduced instead of calling `setCurrentUser(null)` (In preperation for making `setCurrentUser(null)` null
-  The `userviewmodel` can be constructed without an `ImageRepository` and won't handle picture interactions this is for backward compability with the test. 

PS: I left the debugging log because they are really useful here to understand what happens and will probably be useful in the future. 
-- -
![image](https://github.com/user-attachments/assets/fdd17d1b-86d9-4f54-a547-014426919029)
