### PR TITLE
Feature CreateProfileScreen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/AuthenticatorMock.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/AuthenticatorMock.kt
@@ -9,12 +9,18 @@ import javax.inject.Inject
 
 class AuthenticatorMock @Inject constructor() : Authenticator {
 
+  // This is a public attribute since it can be used as a parameter
+  // in tests to make the authenticator fail
+  var testUser: User? = TestInstancesUser.user1
+
   @Composable
   override fun AuthenticateButton(
       onAuthComplete: (User) -> Unit,
       onAuthError: (Exception) -> Unit
   ) {
-    Authenticator.DefaultAuthenticateButton { onAuthComplete(TestInstancesUser.user1) }
+    Authenticator.DefaultAuthenticateButton {
+      if (testUser == null) onAuthError(Exception("User not found")) else onAuthComplete(testUser!!)
+    }
   }
 
   @Composable

--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
@@ -6,7 +6,8 @@ import javax.inject.Inject
 
 class MockUserRepository @Inject constructor() : UserRepository {
   private var uid = 0
-  private val users = mutableListOf<User>()
+  private val _users = mutableListOf<User>()
+  val users: List<User> = _users
 
   override fun onSignIn(onSuccess: () -> Unit) {
     onSuccess()
@@ -21,30 +22,30 @@ class MockUserRepository @Inject constructor() : UserRepository {
       onSuccess: (User) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (userId == "" || users.none { it.public.userId == userId })
+    if (userId == "" || _users.none { it.public.userId == userId })
         onFailure(Exception("Error getting user"))
-    else onSuccess(users.find { it.public.userId == userId }!!)
+    else onSuccess(_users.find { it.public.userId == userId }!!)
   }
 
   override fun getAllUsers(onSuccess: (List<User>) -> Unit, onFailure: (Exception) -> Unit) {
-    if (users.none { it.public.userId == "" }) onSuccess(users)
+    if (_users.none { it.public.userId == "" }) onSuccess(_users)
     else onFailure(Exception("Error getting users"))
   }
 
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     if (user.public.userId == "") onFailure(Exception("Error adding user"))
     else {
-      users.add(user)
+      _users.add(user)
       onSuccess()
     }
   }
 
   override fun updateUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    if (user.public.userId == "" || users.none { it.public.userId == user.public.userId })
+    if (user.public.userId == "" || _users.none { it.public.userId == user.public.userId })
         onFailure(Exception("Error updating user"))
     else {
-      users.remove(users.find { it.public.userId == user.public.userId })
-      users.add(user)
+      _users.remove(_users.find { it.public.userId == user.public.userId })
+      _users.add(user)
       onSuccess()
     }
   }
@@ -54,10 +55,10 @@ class MockUserRepository @Inject constructor() : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (userId == "" || users.none { it.public.userId == userId })
+    if (userId == "" || _users.none { it.public.userId == userId })
         onFailure(Exception("Error deleting user"))
     else {
-      users.remove(users.find { it.public.userId == userId })
+      _users.remove(_users.find { it.public.userId == userId })
       onSuccess()
     }
   }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.ui.addParking
 
-import CyrcleNavHost
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
@@ -14,6 +13,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.CyrcleNavHost
 import com.github.se.cyrcle.di.mocks.AuthenticatorMock
 import com.github.se.cyrcle.di.mocks.MockPermissionHandler
 import com.github.se.cyrcle.model.address.AddressViewModel

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
@@ -23,7 +23,7 @@ class CreateProfileScreenTest {
   fun setUp() {
     mockNavigationActions = mock(NavigationActions::class.java)
 
-    composeTestRule.setContent { CreateProfileScreen(mockNavigationActions) }
+    composeTestRule.setContent { InviteToAuthScreen(mockNavigationActions) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
@@ -1,16 +1,25 @@
 package com.github.se.cyrcle.ui.profile
 
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.di.mocks.AuthenticatorMock
+import com.github.se.cyrcle.di.mocks.MockParkingRepository
+import com.github.se.cyrcle.di.mocks.MockUserRepository
+import com.github.se.cyrcle.model.user.TestInstancesUser
+import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 
 @RunWith(AndroidJUnit4::class)
 class CreateProfileScreenTest {
@@ -18,20 +27,86 @@ class CreateProfileScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var mockAuthenticator: AuthenticatorMock
+  private lateinit var userViewModel: UserViewModel
+
+  private lateinit var mockUserRepository: MockUserRepository
+  private lateinit var mockParkingRepository: MockParkingRepository
 
   @Before
   fun setUp() {
     mockNavigationActions = mock(NavigationActions::class.java)
+    mockAuthenticator = AuthenticatorMock()
 
-    composeTestRule.setContent { InviteToAuthScreen(mockNavigationActions) }
+    mockUserRepository = MockUserRepository()
+    mockParkingRepository = MockParkingRepository()
+    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+
+    composeTestRule.setContent {
+      CreateProfileScreen(mockNavigationActions, mockAuthenticator, userViewModel)
+    }
   }
 
   @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testInitialDisplay() {
-    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("CreateProfileScreen"))
+  fun testCreateProfileScreenSuccess() {
+    val testUser = TestInstancesUser.user1
+    composeTestRule
+        .onNodeWithTag("FirstNameField")
+        .assertIsDisplayed()
+        .performTextInput(testUser.details!!.firstName)
 
-    // Verify initial display mode elements
-    composeTestRule.onNodeWithTag("CreateProfileScreen").assertExists()
+    composeTestRule
+        .onNodeWithTag("LastNameField")
+        .assertIsDisplayed()
+        .performTextInput(testUser.details!!.lastName)
+
+    composeTestRule
+        .onNodeWithTag("UsernameField")
+        .assertIsDisplayed()
+        .performTextInput(testUser.public.username)
+
+    composeTestRule.onNodeWithTag("AuthenticateButton", useUnmergedTree = true).performClick()
+
+    verify(mockNavigationActions).navigateTo(TopLevelDestinations.MAP)
+
+    assert(
+        mockUserRepository.users.any {
+          it.public.userId == testUser.public.userId &&
+              it.details!!.firstName == testUser.details!!.firstName &&
+              it.details!!.lastName == testUser.details!!.lastName &&
+              it.public.username == testUser.public.username
+        })
+  }
+
+  @Test
+  fun testCreateProfileUserAuthFails() {
+    val testUser = TestInstancesUser.newUser
+    mockAuthenticator.testUser = null
+
+    composeTestRule
+        .onNodeWithTag("FirstNameField")
+        .assertIsDisplayed()
+        .performTextInput(testUser.details!!.firstName)
+
+    composeTestRule
+        .onNodeWithTag("LastNameField")
+        .assertIsDisplayed()
+        .performTextInput(testUser.details!!.lastName)
+
+    composeTestRule
+        .onNodeWithTag("UsernameField")
+        .assertIsDisplayed()
+        .performTextInput(testUser.public.username)
+
+    composeTestRule.onNodeWithTag("AuthenticateButton", useUnmergedTree = true).performClick()
+
+    verifyNoInteractions(mockNavigationActions)
+    assert(
+        mockUserRepository.users.none {
+          it.public.userId == testUser.public.userId &&
+              it.details!!.firstName == testUser.details!!.firstName &&
+              it.details!!.lastName == testUser.details!!.lastName &&
+              it.public.username == testUser.public.username
+        })
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/EditProfileComponentTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/EditProfileComponentTest.kt
@@ -77,7 +77,7 @@ class EditProfileComponentTest {
     val user = TestInstancesUser.user1
 
     composeTestRule.setContent {
-      EditProfileComponent(user, { SaveButton() }, { CancelButton() }, true)
+      EditProfileComponent(user, { SaveButton() }, { CancelButton() }, verticalButtonDisplay = true)
     }
 
     composeTestRule.onNodeWithTag("NullUserText").assertDoesNotExist()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/EditProfileComponentTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/EditProfileComponentTest.kt
@@ -43,7 +43,7 @@ class EditProfileComponentTest {
   }
 
   @Test
-  fun testEditProfileComponent() {
+  fun testEditProfileComponentHorizontalButtons() {
     val user = TestInstancesUser.user1
 
     composeTestRule.setContent { EditProfileComponent(user, { SaveButton() }, { CancelButton() }) }
@@ -67,6 +67,39 @@ class EditProfileComponentTest {
         .assertIsDisplayed()
         .assertTextContains(user.public.username)
 
+    composeTestRule.onNodeWithTag("EditComponentButtonRow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("SaveButton", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CancelButton", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun testEditProfileComponentVerticalButtons() {
+    val user = TestInstancesUser.user1
+
+    composeTestRule.setContent {
+      EditProfileComponent(user, { SaveButton() }, { CancelButton() }, true)
+    }
+
+    composeTestRule.onNodeWithTag("NullUserText").assertDoesNotExist()
+
+    composeTestRule.onNodeWithTag("ProfileImage").assertIsDisplayed().assertHasClickAction()
+
+    composeTestRule
+        .onNodeWithTag("FirstNameField")
+        .assertIsDisplayed()
+        .assertTextContains(user.details?.firstName ?: "")
+
+    composeTestRule
+        .onNodeWithTag("LastNameField")
+        .assertIsDisplayed()
+        .assertTextContains(user.details?.lastName ?: "")
+
+    composeTestRule
+        .onNodeWithTag("UsernameField")
+        .assertIsDisplayed()
+        .assertTextContains(user.public.username)
+
+    composeTestRule.onNodeWithTag("EditComponentButtonRow").assertDoesNotExist()
     composeTestRule.onNodeWithTag("SaveButton", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithTag("CancelButton", useUnmergedTree = true).assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/InviteToAuthScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/InviteToAuthScreenTest.kt
@@ -1,0 +1,37 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+
+@RunWith(AndroidJUnit4::class)
+class InviteToAuthScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var mockNavigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    mockNavigationActions = mock(NavigationActions::class.java)
+
+    composeTestRule.setContent { InviteToAuthScreen(mockNavigationActions) }
+  }
+
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testInitialDisplay() {
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("CreateProfileScreen"))
+
+    // Verify initial display mode elements
+    composeTestRule.onNodeWithTag("CreateProfileScreen").assertExists()
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -1,3 +1,5 @@
+package com.github.se.cyrcle
+
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -19,6 +21,7 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.parkingDetails.ParkingDetailsScreen
+import com.github.se.cyrcle.ui.profile.CreateProfileScreen
 import com.github.se.cyrcle.ui.profile.ProfileScreen
 import com.github.se.cyrcle.ui.review.AllReviewsScreen
 import com.github.se.cyrcle.ui.review.ReviewScreen
@@ -41,6 +44,9 @@ fun CyrcleNavHost(
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(authenticator, navigationActions, userViewModel) }
+      composable(Screen.CREATE_PROFILE) {
+        CreateProfileScreen(navigationActions, authenticator, userViewModel)
+      }
     }
 
     navigation(
@@ -84,10 +90,12 @@ fun CyrcleNavHost(
     }
 
     navigation(
-        startDestination = Screen.PROFILE,
-        route = Route.PROFILE,
+        startDestination = Screen.VIEW_PROFILE,
+        route = Route.VIEW_PROFILE,
     ) {
-      composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel, authenticator) }
+      composable(Screen.VIEW_PROFILE) {
+        ProfileScreen(navigationActions, userViewModel, authenticator)
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle
 
-import CyrcleNavHost
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/Authenticator.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/Authenticator.kt
@@ -76,7 +76,7 @@ interface Authenticator {
           shape = RoundedCornerShape(50),
           border = BorderStroke(1.dp, Color.LightGray),
           modifier =
-              Modifier.padding(16.dp)
+              Modifier.padding(start = 16.dp, end = 16.dp)
                   .height(48.dp) // Adjust height as needed
                   .testTag("AuthenticateButton")) {
             Row(
@@ -113,7 +113,7 @@ interface Authenticator {
           colorLevel = ColorLevel.TERTIARY,
           modifier =
               modifier
-                  .padding(16.dp)
+                  .padding(start = 16.dp, end = 16.dp)
                   .border(BorderStroke(1.dp, Color.LightGray), RoundedCornerShape(50))
                   .height(48.dp),
           testTag = "AnonymousLoginButton")

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/Authenticator.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/Authenticator.kt
@@ -110,7 +110,7 @@ interface Authenticator {
       com.github.se.cyrcle.ui.theme.atoms.Button(
           text = stringResource(R.string.sign_in_guest_button),
           onClick = onClick,
-          colorLevel = ColorLevel.PRIMARY,
+          colorLevel = ColorLevel.TERTIARY,
           modifier =
               modifier
                   .padding(16.dp)

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -2,7 +2,9 @@ package com.github.se.cyrcle.ui.authentication
 
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,11 +12,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -26,7 +31,10 @@ import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
+import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.google.android.gms.common.api.ApiException
 
@@ -80,12 +88,20 @@ fun SignInScreen(
           Image(
               painter = painterResource(id = R.drawable.app_logo_name),
               contentDescription = "App Logo",
-              modifier = Modifier.size(275.dp))
-
-          Spacer(modifier = Modifier.height(20.dp))
+              modifier = Modifier.size(250.dp))
 
           // Authenticate With Google Button
           authenticator.AuthenticateButton(onAuthComplete, onAuthFailure)
+
+          Button(
+              text = "Create an account",
+              colorLevel = ColorLevel.SECONDARY,
+              modifier =
+                  Modifier.padding(16.dp)
+                      .border(BorderStroke(1.dp, Color.LightGray), RoundedCornerShape(50))
+                      .height(48.dp)
+                      .width(250.dp),
+              onClick = { navigationActions.navigateTo(Screen.CREATE_PROFILE) })
 
           // Anonymous Login Button
           authenticator.SignInAnonymouslyButton(

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -12,20 +12,25 @@ object Route {
   const val LIST = "List"
   const val MAP = "Map"
   const val ADD_SPOTS = "Add Spots"
-  const val PROFILE = "Profile"
+  const val VIEW_PROFILE = "Profile"
   const val REVIEW = "Review"
 }
 
 object Screen {
-  const val AUTH = "Auth Screen"
   const val LIST = "List Screen"
+
   const val MAP = "Map Screen"
+
   const val PARKING_DETAILS = "Parking Details Screen"
   const val ADD_REVIEW = "Add Review Screen"
+  const val ALL_REVIEWS = "All Reviews"
+
   const val LOCATION_PICKER = "Location Picker Screen"
   const val ATTRIBUTES_PICKER = "Attributes Picker Screen"
-  const val PROFILE = "Profile Screen"
-  const val ALL_REVIEWS = "All Reviews"
+
+  const val AUTH = "Auth Screen"
+  const val VIEW_PROFILE = "Profile Screen"
+  const val CREATE_PROFILE = "Create Profile"
 }
 
 /**
@@ -47,7 +52,7 @@ object TopLevelDestinations {
       TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.LocationOn, textId = Route.MAP)
   val PROFILE =
       TopLevelDestination(
-          route = Route.PROFILE, icon = Icons.Outlined.Person, textId = Route.PROFILE)
+          route = Route.VIEW_PROFILE, icon = Icons.Outlined.Person, textId = Route.VIEW_PROFILE)
 }
 
 /** List of top level destinations in the app. */

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -38,7 +38,7 @@ fun CreateProfileScreen(
     val user =
         userAttempt.copy(public = userAttempt.public.copy(userId = userAuthenticated.public.userId))
 
-    userViewModel.addUser(user)
+    userViewModel.signIn(user)
 
     Toast.makeText(context, validationToastText, Toast.LENGTH_SHORT).show()
     navigationActions.navigateTo(TopLevelDestinations.MAP)

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -2,12 +2,15 @@ package com.github.se.cyrcle.ui.profile
 
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserDetails
 import com.github.se.cyrcle.model.user.UserPublic
@@ -15,8 +18,8 @@ import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.authentication.Authenticator
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
-import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 @Composable
 fun CreateProfileScreen(
@@ -27,35 +30,41 @@ fun CreateProfileScreen(
   val context = LocalContext.current
   val defaultUser = User(UserPublic("", ""), UserDetails())
 
+  val validationToastText = stringResource(R.string.create_profile_validation_toast)
+  val errorToastText = stringResource(R.string.create_profile_error_toast)
+
   // Uses the Auth UID as userID for our new user
   val authCompleteCallback = { userAttempt: User, userAuthenticated: User ->
     val user =
         userAttempt.copy(public = userAttempt.public.copy(userId = userAuthenticated.public.userId))
+
     userViewModel.addUser(user)
-    Toast.makeText(context, "Profile created successfully!", Toast.LENGTH_SHORT).show()
+
+    Toast.makeText(context, validationToastText, Toast.LENGTH_SHORT).show()
     navigationActions.navigateTo(TopLevelDestinations.MAP)
   }
 
   val authErrorCallback = { e: Exception ->
     Log.d("CreateProfileScreen", "Error authenticating: $e")
-    Toast.makeText(context, "Error during authentication...", Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, errorToastText, Toast.LENGTH_SHORT).show()
   }
 
-  EditProfileComponent(
-      defaultUser,
-      verticalButtonDisplay = true,
-      saveButton = { userAttempt: User ->
-        Text(
-            "To complete account creation,\n please authenticate with Google to link your email.",
-            style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Bold))
-        authenticator.AuthenticateButton(
-            onAuthComplete = { authCompleteCallback(userAttempt, it) },
-            onAuthError = authErrorCallback)
-      },
-      cancelButton = {
-        Button(
-            "Cancel",
-            modifier = Modifier.testTag("CancelButton"),
-            onClick = { navigationActions.goBack() })
-      })
+  Scaffold(
+      topBar = {
+        TopAppBar(navigationActions, stringResource(R.string.create_profile_screen_title))
+      }) { padding ->
+        EditProfileComponent(
+            defaultUser,
+            verticalButtonDisplay = true,
+            modifier = Modifier.padding(padding),
+            saveButton = { userAttempt: User ->
+              Text(
+                  stringResource(R.string.create_profile_sign_in_explanation),
+                  style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Bold))
+              authenticator.AuthenticateButton(
+                  onAuthComplete = { authCompleteCallback(userAttempt, it) },
+                  onAuthError = authErrorCallback)
+            },
+            cancelButton = {})
+      }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserDetails
@@ -60,6 +61,7 @@ fun CreateProfileScreen(
             saveButton = { userAttempt: User ->
               Text(
                   stringResource(R.string.create_profile_sign_in_explanation),
+                  modifier = Modifier.padding(bottom = 5.dp),
                   style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Bold))
               authenticator.AuthenticateButton(
                   onAuthComplete = { authCompleteCallback(userAttempt, it) },

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserDetails
@@ -50,5 +52,10 @@ fun CreateProfileScreen(
             onAuthComplete = { authCompleteCallback(userAttempt, it) },
             onAuthError = authErrorCallback)
       },
-      cancelButton = { Button("Cancel", onClick = { navigationActions.goBack() }) })
+      cancelButton = {
+        Button(
+            "Cancel",
+            modifier = Modifier.testTag("CancelButton"),
+            onClick = { navigationActions.goBack() })
+      })
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -20,8 +20,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
-import com.github.se.cyrcle.model.user.LocalSession
 import com.github.se.cyrcle.model.user.User
+import com.github.se.cyrcle.model.user.UserDetails
+import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 
@@ -112,10 +113,12 @@ fun EditProfileComponent(
           saveButton(copyUser(user))
           cancelButton()
         } else {
-          Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            cancelButton()
-            saveButton(copyUser(user))
-          }
+          Row(
+              modifier = Modifier.testTag("EditComponentButtonRow"),
+              horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                cancelButton()
+                saveButton(copyUser(user))
+              }
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -39,6 +39,7 @@ fun EditProfileComponent(
     user: User?,
     saveButton: @Composable (User) -> Unit,
     cancelButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
     verticalButtonDisplay: Boolean = false
 ) {
   if (user == null) {
@@ -69,7 +70,7 @@ fun EditProfileComponent(
       }
 
   Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
+      modifier = modifier.fillMaxSize().padding(top = 15.dp).testTag("ProfileContent"),
       horizontalAlignment = Alignment.CenterHorizontally) {
         ProfileImageComponent(
             url = if (hasTemporarilyChangedProfilePicture) profilePictureUri else profilePictureUrl,

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -20,9 +20,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.user.LocalSession
 import com.github.se.cyrcle.model.user.User
-import com.github.se.cyrcle.model.user.UserDetails
-import com.github.se.cyrcle.model.user.UserPublic
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 
@@ -57,10 +56,11 @@ fun EditProfileComponent(
 
   fun copyUser(user: User): User {
     return user.copy(
-        user.public.copy(username = username),
-        user.details?.copy(firstName = firstName, lastName = lastName),
-        user.localSession?.copy(profilePictureUri = profilePictureUri)
-            ?: LocalSession(profilePictureUri = profilePictureUri))
+        public = user.public.copy(username = username),
+        details = user.details?.copy(firstName = firstName, lastName = lastName),
+        localSession =
+            user.localSession?.copy(profilePictureUri = profilePictureUri)
+                ?: LocalSession(profilePictureUri = profilePictureUri))
   }
 
   val imagePickerLauncher =

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/EditProfileComponent.kt
@@ -37,7 +37,8 @@ import com.github.se.cyrcle.ui.theme.atoms.Text
 fun EditProfileComponent(
     user: User?,
     saveButton: @Composable (User) -> Unit,
-    cancelButton: @Composable () -> Unit
+    cancelButton: @Composable () -> Unit,
+    verticalButtonDisplay: Boolean = false
 ) {
   if (user == null) {
     Text(stringResource(R.string.profile_is_null), Modifier.testTag("NullUserText"))
@@ -51,6 +52,14 @@ fun EditProfileComponent(
   val profilePictureUrl by remember { mutableStateOf(user.localSession?.profilePictureUrl) }
   // To display the local profile picture when the user changes it, and hasn't uploaded (saved) it
   var hasTemporarilyChangedProfilePicture by remember { mutableStateOf(false) }
+
+  fun copyUser(user: User): User {
+    return user.copy(
+        user.public.copy(username = username),
+        user.details?.copy(firstName = firstName, lastName = lastName),
+        user.localSession?.copy(profilePictureUri = profilePictureUri)
+            ?: LocalSession(profilePictureUri = profilePictureUri))
+  }
 
   val imagePickerLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
@@ -99,16 +108,14 @@ fun EditProfileComponent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (verticalButtonDisplay) {
+          saveButton(copyUser(user))
           cancelButton()
-
-          saveButton(
-              // Use .copy to not lose the local session and avoid re-fetching the user from db.
-              user.copy(
-                  user.public.copy(username = username),
-                  user.details?.copy(firstName = firstName, lastName = lastName),
-                  user.localSession?.copy(profilePictureUri = profilePictureUri)
-                      ?: LocalSession(profilePictureUri = profilePictureUri)))
+        } else {
+          Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            cancelButton()
+            saveButton(copyUser(user))
+          }
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/InviteToAuthScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/InviteToAuthScreen.kt
@@ -35,17 +35,17 @@ fun InviteToAuthScreen(navigationActions: NavigationActions) {
           horizontalAlignment = Alignment.CenterHorizontally,
       ) {
         Text(
-            stringResource(R.string.profile_screen_invite_to_sign_in),
+            stringResource(R.string.invite_auth_screen_invite_to_sign_in),
             style = MaterialTheme.typography.titleLarge)
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Text(stringResource(R.string.profile_screen_give_reasons_to_sign_in))
+        Text(stringResource(R.string.invite_auth_screen_give_reasons_to_sign_in))
 
         Spacer(modifier = Modifier.height(8.dp))
 
         Button(
-            text = "Go back to sign in",
+            text = stringResource(R.string.invite_auth_screen_to_sign_in),
             onClick = {
               // navigate to the route to not clear backstack
               navigationActions.navigateTo(Route.AUTH)

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/InviteToAuthScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/InviteToAuthScreen.kt
@@ -1,0 +1,58 @@
+package com.github.se.cyrcle.ui.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Route
+import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
+
+@Composable
+fun InviteToAuthScreen(navigationActions: NavigationActions) {
+  Scaffold(
+      modifier = Modifier.fillMaxSize().testTag("CreateProfileScreen"),
+      bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.VIEW_PROFILE) },
+  ) { padding ->
+    Box(modifier = Modifier.padding(padding)) {
+      Column(
+          modifier = Modifier.fillMaxSize().padding(16.dp),
+          verticalArrangement = Arrangement.Center,
+          horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(
+            stringResource(R.string.profile_screen_invite_to_sign_in),
+            style = MaterialTheme.typography.titleLarge)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(stringResource(R.string.profile_screen_give_reasons_to_sign_in))
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            text = "Go back to sign in",
+            onClick = {
+              // navigate to the route to not clear backstack
+              navigationActions.navigateTo(Route.AUTH)
+            })
+
+        Spacer(modifier = Modifier.height(200.dp))
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ProfileScreen.kt
@@ -16,5 +16,5 @@ fun ProfileScreen(
   val isSignedIn by userViewModel.isSignedIn.collectAsState(false)
 
   if (isSignedIn) ViewProfileScreen(navigationActions, userViewModel, authenticator)
-  else CreateProfileScreen(navigationActions)
+  else InviteToAuthScreen(navigationActions)
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -78,7 +78,7 @@ fun ViewProfileScreen(
         BottomNavigationBar(
             navigationActions = navigationActions,
             tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = Route.PROFILE)
+            selectedItem = Route.VIEW_PROFILE)
       }) { innerPadding ->
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
           authenticator.SignOutButton(Modifier.padding(10.dp).align(Alignment.TopEnd)) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
@@ -109,7 +109,7 @@ fun ConditionCheckingInputText(
     val isError = value.length !in minCharacters..maxCharacters
     InputText(
         label = label,
-        modifier = modifier,
+        modifier = modifier.align(Alignment.CenterHorizontally),
         onValueChange = onValueChange,
         value = value,
         singleLine = false,
@@ -119,7 +119,7 @@ fun ConditionCheckingInputText(
     // Display error message below the text field if the input is not valid
     if (isError) {
       Row(
-          modifier = Modifier.padding(start = 16.dp, top = 4.dp).testTag("${testTag}ErrorRow"),
+          modifier = Modifier.padding(top = 4.dp).testTag("${testTag}ErrorRow"),
           verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.Filled.WarningAmber,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,10 +102,17 @@
     <string name="profile_is_null">User is not signed in, should not happen</string>
 
     <!-- Create Profile Screen -->
-    <string name="profile_screen_title">Create your profile</string>
-    <string name="profile_screen_finish_sign_in_indication">Finish by signing in with Google to link your e-mail</string>
-    <string name="profile_screen_invite_to_sign_in">You need to be signed-in to modify your profile</string>
-    <string name="profile_screen_give_reasons_to_sign_in">"Sign in now to add new spots, share reviews, and help fellow cyclists find the perfect parking space."</string>
+    <string name="create_profile_screen_title">Create your profile</string>
+    <string name="create_profile_validation_toast">Profile created successfully!</string>
+    <string name="create_profile_error_toast">Error during authentication…</string>
+    <string name="create_profile_sign_in_explanation">To complete account creation,\n please authenticate with Google to link your email.</string>
+
+    <!-- Invite to AuthScreen Screen -->
+    <string name="invite_auth_screen_to_sign_in">Go back to sign in</string>
+    <string name="invite_auth_screen_finish_sign_in_indication">Finish by signing in with Google to link your e-mail</string>
+    <string name="invite_auth_screen_invite_to_sign_in">You need to be signed-in to modify your profile</string>
+    <string name="invite_auth_screen_give_reasons_to_sign_in">"Sign in now to add new spots, share reviews, and help fellow cyclists find the perfect parking space."</string>
+
     <!-- View Profile Screen -->
     <string name="view_profile_screen_first_name_label">First Name</string>
     <string name="view_profile_screen_last_name_label">Last Name</string>


### PR DESCRIPTION
## What is this PR?
This PR introduces a new screen allowing users to create their account.

## How?
A new button was added to the `SignInScreen`, it brings users to a new screen that allows them to create their account.


### Pitfals:
Currently, no checks are made to check the presence of an already existing user. 
Also, the button for creating the account can be a bit confusing. There is no control over it's appearance since it is issued by the `Authenticator`. This will have to be change in a refactor for the `Authenticator` system.
Both of these points could be worked on as a part of a later sprint.

## Features:
<img width="305" alt="image" src="https://github.com/user-attachments/assets/9b743411-3985-44eb-8ca2-c6d716c177dc">
<img width="305" alt="image" src="https://github.com/user-attachments/assets/db6adc54-a4be-4949-9ed8-f338ba16c58d">


### Test coverage:
![image](https://github.com/user-attachments/assets/300ae95f-eded-41a3-9d3e-29f3f0d91e27)



CLoses #110 