### PR TITLE
bugfix : non persistent state in view model during Configuration changes

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -3,12 +3,15 @@ package com.github.se.cyrcle
 import CyrcleNavHost
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
+import com.github.se.cyrcle.model.CustomViewModelFactory
 import com.github.se.cyrcle.model.address.AddressRepository
 import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.image.ImageRepository
@@ -47,7 +50,7 @@ class MainActivity : ComponentActivity() {
     CustomViewModelFactory { ReviewViewModel(reviewRepository) }
   }
   private val userViewModel: UserViewModel by viewModels {
-    CustomViewModelFactory { UserViewModel(userRepository, parkingRepository) }
+    CustomViewModelFactory { UserViewModel(userRepository, parkingRepository,imageRepository) }
   }
   private val parkingViewModel: ParkingViewModel by viewModels {
     CustomViewModelFactory { ParkingViewModel(imageRepository, parkingRepository) }
@@ -62,12 +65,6 @@ class MainActivity : ComponentActivity() {
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
     permissionsHandler.initHandler(this@MainActivity)
-
-    val reviewViewModel = ReviewViewModel(reviewRepository)
-    val userViewModel = UserViewModel(userRepository, parkingRepository)
-    val parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
-    val mapViewModel = MapViewModel()
-    val addressViewModel = AddressViewModel(addressRepository)
 
     setContent {
       CyrcleTheme {

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -43,6 +43,20 @@ class MainActivity : ComponentActivity() {
 
   @Inject lateinit var authenticator: Authenticator
 
+  private val reviewViewModel: ReviewViewModel by viewModels {
+    CustomViewModelFactory { ReviewViewModel(reviewRepository) }
+  }
+  private val userViewModel: UserViewModel by viewModels {
+    CustomViewModelFactory { UserViewModel(userRepository, parkingRepository) }
+  }
+  private val parkingViewModel: ParkingViewModel by viewModels {
+    CustomViewModelFactory { ParkingViewModel(imageRepository, parkingRepository) }
+  }
+  private val mapViewModel: MapViewModel by viewModels { CustomViewModelFactory { MapViewModel() } }
+  private val addressViewModel: AddressViewModel by viewModels {
+    CustomViewModelFactory { AddressViewModel(addressRepository) }
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
@@ -50,7 +64,7 @@ class MainActivity : ComponentActivity() {
     permissionsHandler.initHandler(this@MainActivity)
 
     val reviewViewModel = ReviewViewModel(reviewRepository)
-    val userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
+    val userViewModel = UserViewModel(userRepository, parkingRepository)
     val parkingViewModel = ParkingViewModel(imageRepository, parkingRepository)
     val mapViewModel = MapViewModel()
     val addressViewModel = AddressViewModel(addressRepository)

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -3,7 +3,6 @@ package com.github.se.cyrcle
 import CyrcleNavHost
 import android.content.pm.ActivityInfo
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -50,7 +49,7 @@ class MainActivity : ComponentActivity() {
     CustomViewModelFactory { ReviewViewModel(reviewRepository) }
   }
   private val userViewModel: UserViewModel by viewModels {
-    CustomViewModelFactory { UserViewModel(userRepository, parkingRepository,imageRepository) }
+    CustomViewModelFactory { UserViewModel(userRepository, parkingRepository, imageRepository) }
   }
   private val parkingViewModel: ParkingViewModel by viewModels {
     CustomViewModelFactory { ParkingViewModel(imageRepository, parkingRepository) }

--- a/app/src/main/java/com/github/se/cyrcle/model/CustomViewModelFactory.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/CustomViewModelFactory.kt
@@ -6,7 +6,12 @@ import androidx.lifecycle.ViewModelProvider
 class CustomViewModelFactory<T : ViewModel>(private val creator: () -> T) :
     ViewModelProvider.Factory {
 
-  // Factory to unify the different factory of view Models
+  /**
+   * Factory to unify the different factory of ViewModels
+   *
+   * @param modelClass the class of the ViewModel to create
+   * @return the created ViewModel
+   */
   override fun <T : ViewModel> create(modelClass: Class<T>): T {
     @Suppress("UNCHECKED_CAST") return creator() as T
   }

--- a/app/src/main/java/com/github/se/cyrcle/model/CustomViewModelFactory.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/CustomViewModelFactory.kt
@@ -1,0 +1,11 @@
+package com.github.se.cyrcle.model
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class CustomViewModelFactory<T : ViewModel>(private val creator: () -> T) :
+    ViewModelProvider.Factory {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    @Suppress("UNCHECKED_CAST") return creator() as T
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/model/CustomViewModelFactory.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/CustomViewModelFactory.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModelProvider
 
 class CustomViewModelFactory<T : ViewModel>(private val creator: () -> T) :
     ViewModelProvider.Factory {
+
+  // Factory to unify the different factory of view Models
   override fun <T : ViewModel> create(modelClass: Class<T>): T {
     @Suppress("UNCHECKED_CAST") return creator() as T
   }


### PR DESCRIPTION
## PR content

This PR fixes the bug linked to the state and view models being destroyed when the configuration changes (e.g switch to dark theme)

## Fix

The fix was to refactor the view models outside the `OnCreate` of the MainActivity so that they are not recreated each time the activity is destroyed creating persistence. 

The new file `CustomViewModelFactory` is here to unify the different factories of the view models and to allow the refactoring in `MainActivity`


## Code Coverage
![image](https://github.com/user-attachments/assets/22691f36-e61b-473e-9a8a-6f80d0e809c4)

Closes #239 
