### PR TITLE
fix: transformPathToUrl crashes the app with old user

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/addParking/AddScreensNavigationTest.kt
@@ -115,6 +115,7 @@ class AddScreensNavigationTest {
       val mapViewModel = list[4] as MapViewModel
       LocationPicker(navigationActions, mapViewModel)
     }
+    composeTestRule.waitForIdle()
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("nextButton"))
     // Perform click on the add button
     composeTestRule.onNodeWithTag("nextButton").performClick()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
@@ -55,6 +55,8 @@ class SignInTest {
 
   @Test
   fun testComponentsAndFunctionality() = runTest {
+    composeTestRule.waitForIdle()
+
     composeTestRule
         .onNodeWithTag("LoginTitle")
         .assertIsDisplayed()

--- a/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
@@ -11,7 +11,7 @@ package com.github.se.cyrcle.model.user
 data class UserPublic(
     val userId: String,
     val username: String,
-    val profilePictureCloudPath: String = "",
+    val profilePictureCloudPath: String? = "",
     // val accountCreationDate: Timestamp? = null,
     // val numberOfContributedSpots: Int = 0,
     // val userReputationScore: Int = 0

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -245,6 +245,13 @@ class UserViewModel(
    * @param onFailure the callback to call if the image fetching fails
    */
   private fun transformPathToUrl(user: User, onSuccess: (User) -> Unit, onFailure: () -> Unit) {
+    // For user with the old version of the app (i.e the M2)
+    // the new attribute profilePictureCloudPath is set to null by the deserializer.
+    // We skip the fetching of the image for those users.
+    if (user.public.profilePictureCloudPath == null) {
+      onSuccess(user)
+      return
+    }
     if (imageRepository == null) {
       Log.e("UserViewModel", "ImageRepository is null")
       return


### PR DESCRIPTION
### What

This PR fixes the following fatal bug :
`TransformPathToUrl` was called with a null `Path` for user that set up their account with the old M2 versions of the app. 

The function wasn't handling that case and it just made the app crash, now the function will just skip and return instantly if called for an old deprecate user