### PR TITLE
Check that users exist for sign in and account creation

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
@@ -27,6 +27,15 @@ class MockUserRepository @Inject constructor() : UserRepository {
     else onSuccess(_users.find { it.public.userId == userId }!!)
   }
 
+  override fun userExists(
+      user: User,
+      onSuccess: (Boolean) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (user.public.userId == "") onFailure(Exception("Error checking user"))
+    else onSuccess(users.any { it.public.userId == user.public.userId })
+  }
+
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     if (user.public.userId == "") onFailure(Exception("Error adding user"))
     else {

--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockUserRepository.kt
@@ -33,7 +33,11 @@ class MockUserRepository @Inject constructor() : UserRepository {
       onFailure: (Exception) -> Unit
   ) {
     if (user.public.userId == "") onFailure(Exception("Error checking user"))
-    else onSuccess(users.any { it.public.userId == user.public.userId })
+    else
+        onSuccess(
+            users.any {
+              it.public.userId == user.public.userId && it.public.username == user.public.username
+            })
   }
 
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
@@ -17,6 +17,7 @@ import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.first
@@ -50,17 +51,44 @@ class SignInTest {
 
     val mockAuthenticator = AuthenticatorMock()
 
+    userRepository.addUser(TestInstancesUser.user1, {}, {})
+    userViewModel.signIn(TestInstancesUser.user1)
+
+    mockAuthenticator.testUser = TestInstancesUser.user1
+
     composeTestRule.setContent { SignInScreen(mockAuthenticator, navigationActions, userViewModel) }
   }
 
   @Test
-  fun testComponentsAndFunctionality() = runTest {
+  fun testScreenDisplays() {
     composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("AppLogo").assertIsDisplayed()
 
     composeTestRule
         .onNodeWithTag("LoginTitle")
         .assertIsDisplayed()
         .assertTextEquals("Welcome to Cyrcle")
+
+    composeTestRule.onNodeWithTag("AuthenticateButton").assertIsDisplayed().assertHasClickAction()
+
+    composeTestRule.onNodeWithTag("CreateAccountButton").assertIsDisplayed().assertHasClickAction()
+
+    composeTestRule.onNodeWithTag("AnonymousLoginButton").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  fun testCreateProfileButtonGoesToCreateProfileScreen() {
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("CreateAccountButton").assertIsDisplayed().performClick()
+
+    verify(navigationActions).navigateTo(Screen.CREATE_PROFILE)
+  }
+
+  @Test
+  fun testComponentsAndFunctionality() = runTest {
+    composeTestRule.waitForIdle()
 
     composeTestRule
         .onNodeWithTag("AuthenticateButton")
@@ -72,7 +100,5 @@ class SignInTest {
     assertEquals(TestInstancesUser.user1, userViewModel.currentUser.first())
 
     verify(navigationActions).navigateTo(TopLevelDestinations.MAP)
-
-    composeTestRule.onNodeWithTag("AnonymousLoginButton").assertIsDisplayed().assertHasClickAction()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -72,7 +72,7 @@ class ListScreenTest {
     parkingViewModel =
         ParkingViewModel(mockImageRepository, mockParkingRepository, mockReportedObjectRepository)
     mapViewModel = MapViewModel()
-    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository, mockImageRepository)
 
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.LIST)
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -52,7 +52,7 @@ class MapScreenTest {
 
     parkingViewModel =
         ParkingViewModel(imageRepository, parkingRepository, mockReportedObjectRepository)
-    userViewModel = UserViewModel(userRepository, parkingRepository)
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
     mapViewModel = MapViewModel()
     permissionHandler = MockPermissionHandler()
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -66,7 +66,7 @@ class ParkingDetailsScreenTest {
 
     parkingViewModel =
         ParkingViewModel(imageRepository, parkingRepository, mockReportedObjectRepository)
-    userViewModel = UserViewModel(userRepository, parkingRepository)
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
     reviewViewModel = ReviewViewModel(reviewRepository, mockReportedObjectRepository)
 
     parkingViewModel.addParking(TestInstancesParking.parking2)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/CreateProfileScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.AuthenticatorMock
+import com.github.se.cyrcle.di.mocks.MockImageRepository
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.user.TestInstancesUser
@@ -32,6 +33,7 @@ class CreateProfileScreenTest {
 
   private lateinit var mockUserRepository: MockUserRepository
   private lateinit var mockParkingRepository: MockParkingRepository
+  private lateinit var mockImageRepository: MockImageRepository
 
   @Before
   fun setUp() {
@@ -40,7 +42,8 @@ class CreateProfileScreenTest {
 
     mockUserRepository = MockUserRepository()
     mockParkingRepository = MockParkingRepository()
-    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+    mockImageRepository = MockImageRepository()
+    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository, mockImageRepository)
 
     composeTestRule.setContent {
       CreateProfileScreen(mockNavigationActions, mockAuthenticator, userViewModel)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ProfileScreenTest.kt
@@ -45,7 +45,7 @@ class ProfileScreenTest {
     userRepository = MockUserRepository()
     parkingRepository = MockParkingRepository()
     reportedObjectRepository = MockReportedObjectRepository()
-    userViewModel = UserViewModel(userRepository, parkingRepository)
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
     parkingViewModel =
         ParkingViewModel(imageRepository, parkingRepository, reportedObjectRepository)
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -71,7 +71,7 @@ class ViewProfileScreenTest {
             UserPublic("1", "janesmith", "http://example.com/jane.jpg"),
             UserDetails("Jane", "Smith", "jane.smith@example.com"))
 
-    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository, mockImageRepository)
     parkingViewModel =
         ParkingViewModel(mockImageRepository, mockParkingRepository, mockReportedObjectRepository)
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
@@ -30,16 +30,32 @@ class AllReviewsScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private val navigationActions = mock(NavigationActions::class.java)
-  private val parkingViewModel =
-      ParkingViewModel(
-          MockImageRepository(), MockParkingRepository(), MockReportedObjectRepository())
-  private val reviewViewModel =
-      ReviewViewModel(MockReviewRepository(), MockReportedObjectRepository())
-  private val userViewModel = UserViewModel(MockUserRepository(), MockParkingRepository())
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var parkingRepository: MockParkingRepository
+  private lateinit var reviewRepository: MockReviewRepository
+  private lateinit var userRepository: MockUserRepository
+  private lateinit var imageRepository: MockImageRepository
+  private lateinit var reportedObjectRepository: MockReportedObjectRepository
+
+  private lateinit var parkingViewModel: ParkingViewModel
+  private lateinit var reviewViewModel: ReviewViewModel
+  private lateinit var userViewModel: UserViewModel
 
   @Before
   fun setUp() {
+
+    navigationActions = mock(NavigationActions::class.java)
+    parkingRepository = MockParkingRepository()
+    reviewRepository = MockReviewRepository()
+    userRepository = MockUserRepository()
+    imageRepository = MockImageRepository()
+    reportedObjectRepository = MockReportedObjectRepository()
+
+    parkingViewModel =
+        ParkingViewModel(imageRepository, parkingRepository, reportedObjectRepository)
+    reviewViewModel = ReviewViewModel(reviewRepository, reportedObjectRepository)
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
+
     reviewViewModel.addReview(TestInstancesReview.review4)
     reviewViewModel.addReview(TestInstancesReview.review3)
     reviewViewModel.addReview(TestInstancesReview.review2)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/ReviewScreenTest.kt
@@ -61,7 +61,7 @@ class ReviewScreenTest {
     mockReviewRepository = MockReviewRepository()
     mockReportedObjectRepository = MockReportedObjectRepository()
 
-    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository)
+    userViewModel = UserViewModel(mockUserRepository, mockParkingRepository, mockImageRepository)
     parkingViewModel =
         ParkingViewModel(mockImageRepository, mockParkingRepository, mockReportedObjectRepository)
     reviewViewModel = ReviewViewModel(mockReviewRepository, mockReportedObjectRepository)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -24,6 +24,7 @@ import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.TestInstancesParking
+import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.permission.PermissionHandler
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -65,6 +66,8 @@ class MainActivityTest {
 
   @Test
   fun testAddParking() {
+    composeTestRule.activity.userRepository.addUser(TestInstancesUser.user1, {}, {})
+
     authRobot.assertAuthScreen()
     authRobot.performSignIn()
 

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepository.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepository.kt
@@ -26,6 +26,15 @@ interface UserRepository {
   fun getUserById(userId: String, onSuccess: (User) -> Unit, onFailure: (Exception) -> Unit)
 
   /**
+   * Check if a user exists
+   *
+   * @param user the user to check
+   * @param onSuccess a callback that is called with a boolean indicating if the user exists
+   * @param onFailure a callback that is called when an error occurs
+   */
+  fun userExists(user: User, onSuccess: (Boolean) -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
    * Add a user
    *
    * @param user the user to add

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
@@ -68,6 +68,22 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
         .addOnFailureListener(onFailure)
   }
 
+  override fun userExists(
+      user: User,
+      onSuccess: (Boolean) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereEqualTo("userId", user.public.userId)
+        .whereEqualTo("username", user.public.username)
+        .get()
+        .addOnSuccessListener {
+          Log.d("UserRepositoryFirestore", "User exists: ${it.size()}")
+          onSuccess(!it.isEmpty)
+        }
+        .addOnFailureListener(onFailure)
+  }
+
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     if (user.details == null) {
       onFailure(Exception("User details are required"))

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserRepositoryFirestore.kt
@@ -75,13 +75,15 @@ constructor(private val db: FirebaseFirestore, private val auth: FirebaseAuth) :
   ) {
     db.collection(collectionPath)
         .whereEqualTo("userId", user.public.userId)
-        .whereEqualTo("username", user.public.username)
         .get()
         .addOnSuccessListener {
-          Log.d("UserRepositoryFirestore", "User exists: ${it.size()}")
+          Log.d("UserRepositoryFirestore", "User exists: ${!it.isEmpty}")
           onSuccess(!it.isEmpty)
         }
-        .addOnFailureListener(onFailure)
+        .addOnFailureListener {
+          Log.d("UserRepositoryFirestore", "Failed to check user's existence: ${it.message}")
+          onFailure(it)
+        }
   }
 
   override fun addUser(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -96,12 +96,7 @@ class UserViewModel(
    * @param onSuccess the callback to call with a boolean indicating if the user exists
    */
   fun doesUserExist(user: User, onSuccess: (Boolean) -> Unit) {
-    userRepository.userExists(
-        user,
-        onSuccess = onSuccess,
-        onFailure = {
-          Log.e("UserViewModel", "Failed to check if user exists: ${user.public.userId}", it)
-        })
+    userRepository.userExists(user, onSuccess = onSuccess, onFailure = {})
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.map
 class UserViewModel(
     private val userRepository: UserRepository,
     private val parkingRepository: ParkingRepository,
-    private val imageRepository: ImageRepository? = null
+    private val imageRepository: ImageRepository
 ) : ViewModel() {
 
   private val _currentUser = MutableStateFlow<User?>(null)
@@ -86,6 +86,21 @@ class UserViewModel(
               "com.github.se.cyrcle.model.user.UserViewModel",
               "Failed to fetch user by ID: $userId",
               exception)
+        })
+  }
+
+  /**
+   * Checks if a user exists in the database.
+   *
+   * @param user the user to check
+   * @param onSuccess the callback to call with a boolean indicating if the user exists
+   */
+  fun doesUserExist(user: User, onSuccess: (Boolean) -> Unit) {
+    userRepository.userExists(
+        user,
+        onSuccess = onSuccess,
+        onFailure = {
+          Log.e("UserViewModel", "Failed to check if user exists: ${user.public.userId}", it)
         })
   }
 
@@ -200,10 +215,6 @@ class UserViewModel(
    * @param context the context used to resolve the image uri
    */
   private fun uploadProfilePicture(context: Context) {
-    if (imageRepository == null) {
-      Log.e("UserViewModel", "ImageRepository is null, should not upload image")
-      return
-    }
     if (currentUser.value == null) {
       Log.e("UserViewModel", "Current user is null, should not upload image")
       return
@@ -252,10 +263,7 @@ class UserViewModel(
       onSuccess(user)
       return
     }
-    if (imageRepository == null) {
-      Log.e("UserViewModel", "ImageRepository is null")
-      return
-    }
+
     val cloudPath = user.public.profilePictureCloudPath
     if (cloudPath.isBlank()) {
       Log.d("UserViewModel", "No image to fetch for user")

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -92,7 +92,7 @@ fun SignInScreen(
           Image(
               painter = painterResource(id = R.drawable.app_logo_name),
               contentDescription = "App Logo",
-              modifier = Modifier.size(250.dp))
+              modifier = Modifier.size(250.dp).testTag("AppLogo"))
 
           // Authenticate With Google Button
           authenticator.AuthenticateButton(onAuthComplete, onAuthFailure)
@@ -105,7 +105,8 @@ fun SignInScreen(
                       .border(BorderStroke(1.dp, Color.LightGray), RoundedCornerShape(50))
                       .height(48.dp)
                       .width(250.dp),
-              onClick = { navigationActions.navigateTo(Screen.CREATE_PROFILE) })
+              onClick = { navigationActions.navigateTo(Screen.CREATE_PROFILE) },
+              testTag = "CreateAccountButton")
 
           // Anonymous Login Button
           authenticator.SignInAnonymouslyButton(

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -48,14 +48,18 @@ fun SignInScreen(
 
   val failSignInMsg = stringResource(R.string.sign_in_failed_toast)
   val successSignInMsg = stringResource(R.string.sign_in_successful_toast)
+  val accountNotFoundToast = stringResource(R.string.sign_in_account_not_found)
 
   val onAuthComplete = { user: User ->
-    Toast.makeText(context, successSignInMsg, Toast.LENGTH_LONG).show()
-
-    // TODO add checks if user is already exists
-
-    userViewModel.signIn(user)
-    navigationActions.navigateTo(TopLevelDestinations.MAP)
+    userViewModel.doesUserExist(user) {
+      if (it) {
+        Toast.makeText(context, successSignInMsg, Toast.LENGTH_LONG).show()
+        userViewModel.signIn(user)
+        navigationActions.navigateTo(TopLevelDestinations.MAP)
+      } else {
+        Toast.makeText(context, accountNotFoundToast, Toast.LENGTH_SHORT).show()
+      }
+    }
   }
   val onAuthFailure = { e: Exception ->
     when (e) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -33,16 +33,23 @@ fun CreateProfileScreen(
 
   val validationToastText = stringResource(R.string.create_profile_validation_toast)
   val errorToastText = stringResource(R.string.create_profile_error_toast)
+  val accountExistsToastText = stringResource(R.string.create_profile_account_already_exists)
 
   // Uses the Auth UID as userID for our new user
   val authCompleteCallback = { userAttempt: User, userAuthenticated: User ->
     val user =
         userAttempt.copy(public = userAttempt.public.copy(userId = userAuthenticated.public.userId))
 
-    userViewModel.signIn(user)
-
-    Toast.makeText(context, validationToastText, Toast.LENGTH_SHORT).show()
-    navigationActions.navigateTo(TopLevelDestinations.MAP)
+    userViewModel.doesUserExist(user) {
+      if (it) {
+        Toast.makeText(context, accountExistsToastText, Toast.LENGTH_SHORT).show()
+        navigationActions.goBack()
+      } else {
+        userViewModel.signIn(user)
+        Toast.makeText(context, validationToastText, Toast.LENGTH_SHORT).show()
+        navigationActions.navigateTo(TopLevelDestinations.MAP)
+      }
+    }
   }
 
   val authErrorCallback = { e: Exception ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="sign_in_successful_toast">Login successful!</string>
     <string name="sign_in_failed_toast">Login failed!</string>
     <string name="sign_in_guest_button">Continue as Guest</string>
+    <string name="sign_in_account_not_found">Your account was not found, please create one</string>
     <string name="sign_in_google_button">Sign in with Google</string>
 
     <!-- Card Screen -->
@@ -116,6 +117,7 @@
     <string name="create_profile_screen_title">Create your profile</string>
     <string name="create_profile_validation_toast">Profile created successfully!</string>
     <string name="create_profile_error_toast">Error during authentication…</string>
+    <string name="create_profile_account_already_exists">Your account already exists, please sign in</string>
     <string name="create_profile_sign_in_explanation">To complete account creation,\n please authenticate with Google to link your email.</string>
 
     <!-- Invite to AuthScreen Screen -->

--- a/app/src/test/java/com/github/se/cyrcle/model/user/CoinViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/CoinViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.user
 
+import com.github.se.cyrcle.model.image.ImageRepository
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import org.junit.Assert.*
 import org.junit.Before
@@ -9,15 +10,16 @@ import org.mockito.MockitoAnnotations
 
 class CoinViewModelTest {
 
-  @Mock private lateinit var userViewModel: UserViewModel
+  private lateinit var userViewModel: UserViewModel
   @Mock private lateinit var userRepository: UserRepository
   @Mock private lateinit var parkingRepository: ParkingRepository
+  @Mock private lateinit var imageRepository: ImageRepository
 
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
 
-    userViewModel = UserViewModel(userRepository, parkingRepository)
+    userViewModel = UserViewModel(userRepository, parkingRepository, imageRepository)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
@@ -27,6 +27,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -199,6 +200,54 @@ class UserRepositoryFirestoreTest {
 
     verify(mockDocumentReference, times(0)).get()
     assertTrue(onFailureCallbackCalled)
+  }
+
+  @Test
+  fun userExists_callsOnSuccess() {
+    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
+
+    `when`(mockCollectionReference.whereEqualTo(eq("userId"), eq(user.public.userId)))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereEqualTo(eq("username"), eq(user.public.username)))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
+
+    var onSuccessCalled = false
+    userRepositoryFirestore.userExists(
+        user = user,
+        onSuccess = { onSuccessCalled = true },
+        onFailure = { fail("Expected onSuccess to be called") })
+    // Complete the task to trigger the addOnCompleteListener with an exception
+    taskCompletionSource.setResult(mockUserQuerySnapshot)
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockCollectionReference, times(2)).whereEqualTo(any<String>(), any())
+    verify(mockCollectionReference, times(1)).get()
+    assertTrue(onSuccessCalled)
+  }
+
+  @Test
+  fun userExists_callsOnFailure() {
+    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
+
+    `when`(mockCollectionReference.whereEqualTo(eq("userId"), eq(user.public.userId)))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereEqualTo(eq("username"), eq(user.public.username)))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
+
+    var onFailureCalled = false
+    userRepositoryFirestore.userExists(
+        user = user,
+        onSuccess = { fail("Expected on failure to be called") },
+        onFailure = { onFailureCalled = true })
+    // Complete the task to trigger the addOnCompleteListener with an exception
+    taskCompletionSource.setException(Exception("Test exception"))
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockCollectionReference, times(2)).whereEqualTo(any<String>(), any())
+    verify(mockCollectionReference, times(1)).get()
+    assertTrue(onFailureCalled)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserRepositoryFirestoreTest.kt
@@ -208,8 +208,6 @@ class UserRepositoryFirestoreTest {
 
     `when`(mockCollectionReference.whereEqualTo(eq("userId"), eq(user.public.userId)))
         .thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.whereEqualTo(eq("username"), eq(user.public.username)))
-        .thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
 
     var onSuccessCalled = false
@@ -221,7 +219,7 @@ class UserRepositoryFirestoreTest {
     taskCompletionSource.setResult(mockUserQuerySnapshot)
     shadowOf(Looper.getMainLooper()).idle()
 
-    verify(mockCollectionReference, times(2)).whereEqualTo(any<String>(), any())
+    verify(mockCollectionReference, times(1)).whereEqualTo(any<String>(), any())
     verify(mockCollectionReference, times(1)).get()
     assertTrue(onSuccessCalled)
   }
@@ -231,8 +229,6 @@ class UserRepositoryFirestoreTest {
     val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
 
     `when`(mockCollectionReference.whereEqualTo(eq("userId"), eq(user.public.userId)))
-        .thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.whereEqualTo(eq("username"), eq(user.public.username)))
         .thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
 
@@ -245,7 +241,7 @@ class UserRepositoryFirestoreTest {
     taskCompletionSource.setException(Exception("Test exception"))
     shadowOf(Looper.getMainLooper()).idle()
 
-    verify(mockCollectionReference, times(2)).whereEqualTo(any<String>(), any())
+    verify(mockCollectionReference, times(1)).whereEqualTo(any<String>(), any())
     verify(mockCollectionReference, times(1)).get()
     assertTrue(onFailureCalled)
   }

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -54,6 +54,14 @@ class UserViewModelTest {
   }
 
   @Test
+  fun testUserExists() {
+    userViewModel.doesUserExist(TestInstancesUser.user1) {}
+
+    // Check if the repository was called
+    verify(userRepository).userExists(eq(TestInstancesUser.user1), any(), any())
+  }
+
+  @Test
   fun setCurrentUserByIdTest() {
     userViewModel.setCurrentUserById("user1")
 


### PR DESCRIPTION
## What is this PR? 
This PR implements checks for the user's existence in our database

This is reflected in the UI in the following way:
* If the user attempts to create an account:
    * If his account exists already, toast and redirect him to sign in
    * If it doesn't exist, create the account, log in and go to map
* If the user attempts to sign in:
    * If his account exists, log him in and go to map
    * If it doesn't exist, toast and stay in sign in screen

**Footnote:** It also removes the `null` default argument from the `UserViewModel`

## How?
A new function was added to the `UserRepository`, `userExists` that takes a callback `(Boolean) -> Unit` and a Failure callback.




### Code coverage:
- Overall coverage at 82%
- UserRepositoryFirestore at 93%
- UserViewModel at 80%
- SignInScreen at 93%

Closes #238 