### PR TITLE
Prevent users from adding thin and long parkings

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.model.parking
 
+import android.util.Log
 import com.github.se.cyrcle.ui.theme.molecules.DropDownableEnum
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.Polygon
@@ -98,6 +99,10 @@ data class Location(
    * @return The polygon representing the location.
    */
   fun toPolygon(): Polygon {
+    if (topLeft == null || topRight == null || bottomLeft == null || bottomRight == null) {
+      Log.e("Location", "Cannot convert location to polygon, some corners are null")
+      return Polygon.fromLngLats(listOf(listOf()))
+    }
     return Polygon.fromLngLats(listOf(listOf(topLeft, topRight, bottomRight, bottomLeft, topLeft)))
   }
 
@@ -109,6 +114,21 @@ data class Location(
    */
   fun computeArea(): Double {
     return TurfMeasurement.area(toPolygon())
+  }
+
+  /**
+   * Compute the height and width of the location in meters.
+   *
+   * @return A pair of the height and width of the location in meters.
+   */
+  fun computeHeightAndWidth(): Pair<Double, Double> {
+    if (topLeft == null || topRight == null || bottomLeft == null || bottomRight == null) {
+      Log.e("Location", "Cannot compute height and width of location, some corners are null")
+      return Pair(0.0, 0.0)
+    }
+    val height = TurfMeasurement.distance(topLeft, bottomLeft, "meters")
+    val width = TurfMeasurement.distance(topLeft, topRight, "meters")
+    return Pair(height, width)
   }
 
   constructor(

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -27,8 +27,10 @@ const val RADIUS_INCREMENT = 100.0
 const val MIN_NB_PARKINGS = 10
 const val NB_REPORTS_THRESH = 10
 const val NB_REPORTS_MAXSEVERITY_THRESH = 4
-const val PARKING_MAX_AREA = 1000.0
 const val MAX_SEVERITY = 3
+
+const val PARKING_MAX_AREA = 1000.0
+const val PARKING_MAX_SIDE_LENGTH = 50.0
 
 /**
  * ViewModel for the Parking feature.

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -66,6 +66,7 @@ import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.github.se.cyrcle.ui.theme.Typography
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
+import com.github.se.cyrcle.ui.theme.disabledColor
 import com.github.se.cyrcle.ui.theme.molecules.BooleanRadioButton
 import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
 import com.mapbox.geojson.Point
@@ -288,7 +289,8 @@ fun BottomBarAddAttr(
                   colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
                     Text(
                         text = stringResource(R.string.attributes_picker_bottom_bar_submit_button),
-                        color = if (validInputs) MaterialTheme.colorScheme.primary else Color.Gray,
+                        color =
+                            if (validInputs) MaterialTheme.colorScheme.primary else disabledColor(),
                         fontWeight = FontWeight.Bold,
                         style = Typography.headlineMedium,
                         textAlign = TextAlign.Center,

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.ui.addParking.location
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -32,6 +33,7 @@ import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.Typography
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.disabledColor
 import com.mapbox.maps.MapView
 
 @Composable
@@ -41,7 +43,7 @@ fun LocationPickerBottomBar(
     mapView: MutableState<MapView?>,
 ) {
   val locationPickerState by mapViewModel.locationPickerState.collectAsState()
-  val isAreaTooLarge by mapViewModel.isAreaTooLarge.collectAsState()
+  val isLocationValid by mapViewModel.isLocationValid.collectAsState(true)
   Box(Modifier.background(Color.White).height(100.dp).testTag("LocationPickerBottomBar")) {
     Row(
         Modifier.fillMaxWidth()
@@ -85,22 +87,25 @@ fun LocationPickerBottomBar(
           } else if (locationPickerState == LocationPickerState.TOP_LEFT_SET) {
             Button(
                 {
-                  if (isAreaTooLarge) {
+                  if (isLocationValid) {
+                    onBottomRightSelected(mapViewModel)
+                  } else {
                     Toast.makeText(
                             mapView.value?.context,
                             R.string.location_picker_invalid_area,
                             Toast.LENGTH_SHORT)
                         .show()
-                  } else {
-                    onBottomRightSelected(mapViewModel)
                   }
                 },
                 modifier = Modifier.testTag("nextButton"),
                 colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                  Log.d("LocationPickerBottomBar", "isLocationValid: $isLocationValid")
                   Text(
                       stringResource(R.string.location_picker_bottom_bar_next_button),
                       modifier = Modifier.width(100.dp),
-                      color = if (isAreaTooLarge) Color.Gray else MaterialTheme.colorScheme.primary,
+                      color =
+                          if (isLocationValid) MaterialTheme.colorScheme.primary
+                          else disabledColor(),
                       style = Typography.headlineMedium,
                       textAlign = TextAlign.Center)
                 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
@@ -41,7 +41,7 @@ fun RectangleSelection(
     mapView: MapView?
 ) {
   val locationPickerState by mapViewModel.locationPickerState.collectAsState()
-  val isAreaTooLarge by mapViewModel.isAreaTooLarge.collectAsState()
+  val isLocationValid by mapViewModel.isLocationValid.collectAsState(true)
   val center = Offset(0.5f, 0.5f)
   var touchPosition by remember { mutableStateOf(Offset.Unspecified) }
   val hasDragged = remember { mutableStateOf(false) }
@@ -76,22 +76,19 @@ fun RectangleSelection(
 
           val listScreenCoordinates = computeCornersScreenCoordinates(canvasCenter, width, height)
           val pointsList = mapView?.mapboxMap?.coordinatesForPixels(listScreenCoordinates)
-          mapViewModel.updateIsAreaTooLarge(pointsList?.let { Location(it).computeArea() } ?: 0.0)
+          if (pointsList != null) mapViewModel.updateLocation(Location(pointsList))
 
           if (hasDragged.value) {
             // Fill of the rectangle
             drawRect(
-                color = if (isAreaTooLarge) Red.copy(alpha = 0.5f) else Cerulean.copy(alpha = 0.7f),
+                color =
+                    if (isLocationValid) Cerulean.copy(alpha = 0.7f) else Red.copy(alpha = 0.5f),
                 topLeft = canvasCenter,
                 size = rectSize)
 
             // Outline of the rectangle
             drawRect(
-                color = if (isAreaTooLarge) Red.copy(alpha = 0.5f) else Cerulean.copy(alpha = 0.7f),
-                topLeft = canvasCenter,
-                size = rectSize)
-            drawRect(
-                color = if (isAreaTooLarge) Red else Cerulean,
+                color = if (isLocationValid) Cerulean else Red,
                 topLeft = canvasCenter,
                 size = rectSize,
                 style = Stroke(width = 2f))


### PR DESCRIPTION
This PR addresses issue #281 by implementing a limit on both the width and height of parkings, in addition to the existing area limit. This change prevents users from adding extremely long or thin parkings while maintaining the current area restrictions.

### Changes
- Added a new constant `PARKING_MAX_SIDE_LENGTH` in `ParkingViewModel.kt`.
- Modified `MapViewModel.kt` to include a new `isLocationValid` flow that checks both area and side length constraints
- Updated `Parking.kt` to include a new `computeHeightAndWidth()` function. Also added null checks to `toPolygon()` function.
- Updated UI components to use the new `isLocationValid` state instead of the previous isAreaTooLarge.

### Testing
Manually tested the new validation logic by attempting to create parkings with various dimensions

### Notes
- The maximum side length is set to 50 meters, but this value can be adjusted if needed.

### Coverage
![image](https://github.com/user-attachments/assets/fdbed420-0123-40a3-b722-efccb8511cf9)

-- -
Closes #281 