### PR TITLE
Update Google SignIn API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,6 +166,11 @@ dependencies {
     implementation(libs.compose.preview)
     debugImplementation(libs.compose.tooling)
 
+    implementation(libs.credentials)
+    implementation(libs.credentials.play.services.auth)
+    implementation(libs.android.googleid)
+
+
 
     // ---------------------------------------------------
     // -------------------  PLUGINS  ---------------------
@@ -173,7 +178,6 @@ dependencies {
 
     // ---------------- Firebase  ------------------
     implementation(libs.google.services)
-    implementation(libs.play.services.auth)
 
     val firebaseBom = platform(libs.firebase.bom)
     implementation(firebaseBom)

--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/AuthenticatorMock.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/AuthenticatorMock.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.di.mocks
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.github.se.cyrcle.model.user.TestInstancesUser
@@ -12,6 +13,8 @@ class AuthenticatorMock @Inject constructor() : Authenticator {
   // This is a public attribute since it can be used as a parameter
   // in tests to make the authenticator fail
   var testUser: User? = TestInstancesUser.user1
+
+  override fun init(context: Context) {}
 
   @Composable
   override fun AuthenticateButton(

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImplTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImplTest.kt
@@ -5,12 +5,8 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.auth.FirebaseAuth
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,13 +21,7 @@ class AuthenticatorImplTest {
 
   @Before
   fun setUp() {
-    Intents.init()
     authenticator = AuthenticatorImpl(FirebaseAuth.getInstance())
-  }
-
-  @After
-  fun tearDown() {
-    Intents.release()
   }
 
   @Test
@@ -43,9 +33,6 @@ class AuthenticatorImplTest {
         .assertExists()
         .assertHasClickAction()
         .performClick()
-    composeTestRule.waitForIdle()
-    // assert that an Intent resolving to Google Mobile Services has been sent (for sign-in)
-    intended(toPackage("com.google.android.gms"))
   }
 
   @Test

--- a/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
+++ b/app/src/main/java/com/github/se/cyrcle/MainActivity.kt
@@ -67,6 +67,7 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
+    authenticator.init(this)
     permissionsHandler.initHandler(this@MainActivity)
 
     setContent {

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/Authenticator.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/Authenticator.kt
@@ -1,5 +1,6 @@
 package com.github.se.cyrcle.ui.authentication
 
+import android.content.Context
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
@@ -34,6 +35,13 @@ import com.github.se.cyrcle.ui.theme.googleSignInButtonStyle
  * complete This does not interface with the UserRepository or ViewModel
  */
 interface Authenticator {
+
+  /**
+   * Initialize the Authenticator
+   *
+   * @param context the context of the application
+   */
+  fun init(context: Context)
 
   /**
    * Composable button that authenticates the user

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImpl.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/AuthenticatorImpl.kt
@@ -1,25 +1,28 @@
 package com.github.se.cyrcle.ui.authentication
 
-import android.content.Intent
-import androidx.activity.compose.ManagedActivityResultLauncher
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserDetails
 import com.github.se.cyrcle.model.user.UserPublic
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.common.api.ApiException
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
+import java.security.MessageDigest
+import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
@@ -29,6 +32,17 @@ import kotlinx.coroutines.tasks.await
  * authenticate users
  */
 class AuthenticatorImpl @Inject constructor(private val auth: FirebaseAuth) : Authenticator {
+  private lateinit var credentialManager: CredentialManager
+
+  /**
+   * Initialize the Authenticator
+   *
+   * @param context the context of the application
+   */
+  override fun init(context: Context) {
+    // Initialize the credential manager
+    credentialManager = CredentialManager.create(context)
+  }
 
   /**
    * Composable button that authenticates the user
@@ -37,23 +51,14 @@ class AuthenticatorImpl @Inject constructor(private val auth: FirebaseAuth) : Au
    * @param onAuthError callback for when authentication fails
    */
   @Composable
+  @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
   override fun AuthenticateButton(
       onAuthComplete: (User) -> Unit,
       onAuthError: (Exception) -> Unit
   ) {
     val context = LocalContext.current
-    val token = stringResource(R.string.default_web_client_id)
-
-    val launcher = rememberFirebaseAuthLauncher(onAuthComplete, onAuthError)
-
     Authenticator.DefaultAuthenticateButton {
-      val gso =
-          GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-              .requestIdToken(token)
-              .requestEmail()
-              .build()
-      val googleSignInClient = GoogleSignIn.getClient(context, gso)
-      launcher.launch(googleSignInClient.signInIntent)
+      loginCallBack(context).invoke(onAuthComplete, onAuthError)
     }
   }
 
@@ -78,42 +83,65 @@ class AuthenticatorImpl @Inject constructor(private val auth: FirebaseAuth) : Au
   @Composable
   override fun SignOutButton(modifier: Modifier, onComplete: () -> Unit) {
     Authenticator.DefaultSignOutButton(modifier) {
-      auth.signOut()
-      onComplete()
+      CoroutineScope(Dispatchers.Unconfined).launch {
+        credentialManager.clearCredentialState(ClearCredentialStateRequest())
+        auth.signOut()
+        onComplete()
+      }
     }
   }
 
   /**
-   * Function to remember the Firebase Auth launcher
+   * Callback for when the user logs in
    *
-   * @param onAuthComplete callback for when authentication is successful
-   * @param onAuthError callback for when authentication fails
-   * @return the Firebase Auth launcher
+   * @param context the context of the application
+   * @return a callback that takes two functions, The first is a callback for when the user logs in
+   *   successfully The second is a callback for when the user fails to log in
    */
-  @Composable
-  private fun rememberFirebaseAuthLauncher(
-      onAuthComplete: (User) -> Unit,
-      onAuthError: (ApiException) -> Unit
-  ): ManagedActivityResultLauncher<Intent, ActivityResult> {
-    val scope = rememberCoroutineScope()
-    return rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        result ->
-      val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-      try {
-        val account = task.getResult(ApiException::class.java)!!
-        val credential = GoogleAuthProvider.getCredential(account.idToken!!, null)
-        scope.launch {
-          val authResult = auth.signInWithCredential(credential).await()
+  @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+  private fun loginCallBack(context: Context): ((User) -> Unit, (Exception) -> Unit) -> Unit {
+    return { onSuccess, onFailure ->
+      val webClientId = context.getString(R.string.default_web_client_id)
 
-          val user =
-              User(
-                  UserPublic(authResult.user!!.uid, authResult.user!!.displayName!!),
-                  UserDetails(email = authResult.user!!.email!!))
+      // Generate a nonce for security (a random number used once)
+      val ranNonce: String = UUID.randomUUID().toString()
+      val bytes: ByteArray = ranNonce.toByteArray()
+      val md: MessageDigest = MessageDigest.getInstance("SHA-256")
+      val digest: ByteArray = md.digest(bytes)
+      val hashedNonce: String = digest.fold("") { str, it -> str + "%02x".format(it) }
 
-          onAuthComplete(user)
+      // Setup the options for the credential request
+      val signInWithGoogleOption =
+          GetSignInWithGoogleOption.Builder(webClientId).setNonce(hashedNonce).build()
+
+      val request =
+          GetCredentialRequest.Builder().addCredentialOption(signInWithGoogleOption).build()
+
+      CoroutineScope(Dispatchers.Unconfined).launch {
+        try {
+          val credential = credentialManager.getCredential(context, request).credential
+
+          if (credential is CustomCredential &&
+              credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+
+            // Use googleIdTokenCredential and extract id to validate the user
+            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+            val authCredential =
+                GoogleAuthProvider.getCredential(googleIdTokenCredential.idToken, null)
+            val authResult = auth.signInWithCredential(authCredential).await()
+
+            val user =
+                User(
+                    UserPublic(authResult.user!!.uid, authResult.user!!.displayName!!),
+                    UserDetails(email = authResult.user!!.email!!))
+
+            onSuccess(user)
+          } else {
+            onFailure(Exception("Unexpected type of credential"))
+          }
+        } catch (e: Exception) {
+          onFailure(e)
         }
-      } catch (e: ApiException) {
-        onAuthError(e)
       }
     }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.se.cyrcle.MainActivity
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.user.User
 import com.github.se.cyrcle.model.user.UserViewModel
@@ -66,7 +67,11 @@ fun SignInScreen(
       is ApiException -> Log.e("Cyrcle", "Failed to sign in: ${e.statusCode}")
       else -> e.printStackTrace()
     }
-    Toast.makeText(context, failSignInMsg, Toast.LENGTH_LONG).show()
+
+    // Prevents a crash when toasting on Login fails
+    (context as MainActivity).runOnUiThread {
+      Toast.makeText(context, failSignInMsg, Toast.LENGTH_LONG).show()
+    }
   }
 
   // The main container for the screen

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,8 +25,9 @@ hilt = "2.52"
 
 # Firebase
 gms = "4.4.2"
+credentials = "1.3.0"
+googleid = "1.1.1"
 firebaseBom = "33.5.1"
-playServicesAuth = "21.2.0"
 
 # OkHTTP
 okhttp = "4.12.0"
@@ -86,7 +87,10 @@ androidx-material-compose = { group = "androidx.compose.material", name = "mater
 androidx-material-icons-extended = { group = "androidx.compose.material", name="material-icons-extended" }
 
 google-services = { module = "com.google.gms:google-services", version.ref = "gms" }
-play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
+credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
+android-googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
+
 
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom"}
 firebase-auth = { group = "com.google.firebase" , name = "firebase-auth" }


### PR DESCRIPTION
## What is this PR?

This PR aims to remove the deprecated version of the Google SignIn API that we used. It now uses the new API that does not launch any Intents.

## Future work (#274):
With this new API, the `Authenticator` system is not necesary since we don't need compose functions to authenticate.
My next PR will be aimmed at integrating authentication code within the `UserViewModel`.

### Test Coverage:
![image](https://github.com/user-attachments/assets/5e4c8940-08f0-4df7-be59-8cfb4d880b09)

Closes #277 
