### PR TITLE
Interactions with rectangles

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -197,7 +197,7 @@ class MapViewModel : ViewModel() {
    *
    * @param viewAnnotationManager the ViewAnnotationManager to update
    */
-  fun updateViewAnnotationManager(viewAnnotationManager: ViewAnnotationManager) {
+  fun updateViewAnnotationManager(viewAnnotationManager: ViewAnnotationManager?) {
     _viewAnnotationManager.value = viewAnnotationManager
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -16,6 +16,7 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.plugin.locationcomponent.createDefault2DPuck
 import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.maps.viewannotation.ViewAnnotationManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -185,6 +186,26 @@ class MapViewModel : ViewModel() {
       }
     }
   }
+
+  // ================== ViewAnnotationManager ==================
+  // State to manage the preview cards on the map screen
+
+  private val _viewAnnotationManager = MutableStateFlow<ViewAnnotationManager?>(null)
+  val viewAnnotationManager: StateFlow<ViewAnnotationManager?> = _viewAnnotationManager
+  /**
+   * To call once on the creation on the map screen to initialize the ViewAnnotationManager
+   *
+   * @param viewAnnotationManager the ViewAnnotationManager to update
+   */
+  fun updateViewAnnotationManager(viewAnnotationManager: ViewAnnotationManager) {
+    _viewAnnotationManager.value = viewAnnotationManager
+  }
+
+  /** Remove the preview card from the map screen */
+  fun removePreviewCard() {
+    _viewAnnotationManager.value?.removeAllViewAnnotations()
+  }
+  // ===============  End Of  ViewAnnotationManager ==================
 
   /**
    * Enum class to represent the state of the location picker, This state is used to determine which

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -59,6 +59,7 @@ import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.map.drawRectangles
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -382,7 +383,11 @@ fun AttributePickerTopBar(mapViewModel: MapViewModel, title: MutableState<String
               fontWeight = FontWeight.Bold,
               maxLines = 1)
         }
-        drawRectangles(annotationManager, null, listOf(location))
+        // To draw a rectangles to preview the location of the future parking spot,
+        // we need to wrap the location in a Parking object to pass it to the drawRectangles
+        // function
+        val placeholderParking = TestInstancesParking.parking1.copy(location = location)
+        drawRectangles(annotationManager, null, listOf(placeholderParking))
       }
 }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -383,9 +383,11 @@ fun MapScreen(
       ZoomControls(
           modifier = Modifier.align(Alignment.TopEnd),
           onZoomIn = {
+            mapViewModel.removePreviewCard()
             mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom + 1.0) }
           },
           onZoomOut = {
+            mapViewModel.removePreviewCard()
             mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom - 1.0) }
           })
 
@@ -399,6 +401,7 @@ fun MapScreen(
                     .scale(1.2f)
                     .testTag("recenterButton"),
             onClick = {
+              mapViewModel.removePreviewCard()
               mapViewModel.updateTrackingMode(true)
               mapViewportState.transitionToFollowPuckState(
                   FollowPuckViewportStateOptions.Builder()

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -351,6 +351,8 @@ fun MapScreen(
               pLabelAnnotationManager?.deleteAll()
               rectangleAnnotationManager?.deleteAll()
               markerAnnotationManager?.deleteAll()
+              mapViewModel.removePreviewCard()
+              mapViewModel.updateViewAnnotationManager(null)
             }
           }
         }


### PR DESCRIPTION
- closes  #251 
## What
#### Making the rectangles clickable so that they have the same behaviour as the markers.

## How

### Simplifying the map screen.

This PR removes the three states used to manage the life cycle of a preview cards.
The listener on `MapIdleCallback` has been removed, removing the need to manage it, making `cancelables` and `removeViewAnnotation` useless.

The Preview card lifecycle is now easier to manage. 

```patch
-  var removeViewAnnotation = remember { true }
-  var cancelables = remember { Cancelable {} }
-  var listener: MapIdleCallback?
```



Before : On click, the boolean state is set to true, then a mapIdleCallback is created, and when it triggers, it recreate a card, then when the user move, the listener has to be canceled and the boolean set back to false.
Instead :  A Preview Card is drawn on Click and removed when a movement is detected. 
_(In depth: This simplification was made possible by moving the .`removeAllViewAnnotation` from a listener on the camera state to a listener on movement.)_ 

### Modifying the signature of DrawRectangles
Instead of taking a list of location it now takes a list of Parking, because for the preview Card we need all the Parking data.

```patch
  * Draw the rectangles on the map
  *
  * @param polygonAnnotationManager the polygon annotation manager
- * @param locationList the list of locations to draw
+ * @param parkingsList the list of locations to draw
  */
 fun drawRectangles(
     polygonAnnotationManager: PolygonAnnotationManager?,
     plabelAnnotationManager: PointAnnotationManager?,
-    locationList: List<Location>
+    parkingsList: List<Parking>
 ) {..}
```
### Copying the  marker click listener for polygon click listener
Once these changed have been made, it was just a copy/paste of the listener on click markers.

### Moving the annotationManager into the viewmodel

Finally the annotationManager has been moved in the viewmodel so that if a composable need later to launch an action on the preview Card, it can. 
This change was made to enable the My location button to remove the preview Card

## Why
#### Making the rectangles clickable match the expected behaviour, if the markers are clickable there are no reasons why rectangles should not be.


-- -
## Code coverage

<img src="https://github.com/user-attachments/assets/1c1e544d-ffd1-4f18-a4ab-a85bce5e1497" width=200>

- **MapViewModel**: 84%
- **MapScreen** : 77% (Listener on rectangles not tested, like the one on marker click :/ ) 
