### PR TITLE
Add Personal Notes Feature for Parking Details

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -1,7 +1,9 @@
 package com.github.se.cyrcle.ui.parkingDetails
 
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildAt
@@ -234,5 +236,69 @@ class ParkingDetailsScreenTest {
     composeTestRule.onNodeWithTag("SeeAllReviewsText").performClick()
 
     verify(navigationActions).navigateTo(Screen.ALL_REVIEWS)
+  }
+
+  @Test
+  fun notesWhenInitiallyEmptyTest() {
+    userViewModel.setCurrentUser(TestInstancesUser.user1)
+    parkingViewModel.selectParking(TestInstancesParking.parking1)
+    composeTestRule.setContent {
+      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("NoteText").assertIsDisplayed()
+    // User has no note for this parking. Should show "Add note" button
+    composeTestRule.onNodeWithTag("NoteInputText").assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag("AddNoteIcon")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    // After clicking, the note input and save button should be displayed
+    composeTestRule.onNodeWithTag("NoteInputText").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("SaveNoteIcon")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    // After saving, the note input and save button should be hidden
+    composeTestRule.onNodeWithTag("NoteInputText").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("SaveNoteIcon").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun notesWhenInitiallyNotEmptyTest() {
+    val userWithNote =
+        TestInstancesUser.user1.copy(
+            details =
+                TestInstancesUser.user1.details?.copy(
+                    personalNotes = mapOf(TestInstancesParking.parking1.uid to "This is a note")))
+    userViewModel.setCurrentUser(userWithNote)
+    parkingViewModel.selectParking(TestInstancesParking.parking1)
+    composeTestRule.setContent {
+      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+    }
+
+    composeTestRule
+        .onNodeWithTag("NoteText")
+        .assertIsDisplayed()
+        .assertTextContains("This is a note")
+    // User has a note for this parking. Should show "Edit note" button
+    composeTestRule.onNodeWithTag("NoteInputText").assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag("EditNoteIcon")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    // After clicking, the note input and save button should be displayed
+    composeTestRule.onNodeWithTag("NoteInputText").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("SaveNoteIcon")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    // After saving, the note input and save button should be hidden
+    composeTestRule.onNodeWithTag("NoteInputText").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("SaveNoteIcon").assertIsNotDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -87,7 +87,7 @@ class ParkingDetailsScreenTest {
       ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
     }
 
-    composeTestRule.onNodeWithTag("PinAndFavoriteIconContainer").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("TopInteractionRow").assertIsDisplayed()
     composeTestRule.onNodeWithTag("BlackOutlinedFavoriteIcon").assertIsDisplayed()
     composeTestRule.onNodeWithTag("BlackOutlinedFavoriteIcon").performClick()
     composeTestRule.onNodeWithTag("BlackOutlinedFavoriteIcon").assertIsDisplayed()

--- a/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
@@ -1,5 +1,7 @@
 package com.github.se.cyrcle.model.user
 
+const val MAX_NOTE_LENGTH = 48
+
 /**
  * Data class representing the public information of a user.
  *

--- a/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/User.kt
@@ -32,7 +32,8 @@ data class UserDetails(
     val email: String = "",
     val favoriteParkings: List<String> = emptyList(),
     // val lastLoginTime: Timestamp? = null,
-    val wallet: Wallet = Wallet.empty()
+    val wallet: Wallet = Wallet.empty(),
+    val personalNotes: Map<String, String> = emptyMap()
 )
 
 /**

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -122,10 +122,6 @@ class UserViewModel(
 
     Log.d("UserViewModel", "Updating user: $user")
     // First update the user object in the view model.
-    if (currentUser.value == user) {
-      Log.d("UserViewModel", "No difference between the current user and the user to update")
-      return
-    }
     setCurrentUser(user)
     // Then update the user object in the database
     if (user.localSession?.profilePictureUri.isNullOrBlank() || context == null) {

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -122,6 +122,10 @@ class UserViewModel(
 
     Log.d("UserViewModel", "Updating user: $user")
     // First update the user object in the view model.
+    if (currentUser.value == user) {
+      Log.d("UserViewModel", "No difference between the current user and the user to update")
+      return
+    }
     setCurrentUser(user)
     // Then update the user object in the database
     if (user.localSession?.profilePictureUri.isNullOrBlank() || context == null) {

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -287,6 +287,25 @@ class UserViewModel(
   }
 
   /**
+   * Edits the personal note of the current user for the given parking. If the new note is blank,
+   * the personal note is removed (if it exists). If it doesn't exist, the function does nothing. If
+   * the new note is not empty, the personal note is added or updated.
+   *
+   * @param parking the parking to edit the personal note for
+   * @param newNote the new personal note for the parking
+   */
+  fun editCurrentUserPersonalNoteForParking(parking: Parking, newNote: String) {
+    currentUser.value?.let { user ->
+      user.details?.let { details ->
+        val key = parking.uid
+        val updatedNotes = details.personalNotes.toMutableMap()
+        if (newNote.isBlank()) updatedNotes.remove(key) else updatedNotes[key] = newNote
+        updateUser(user.copy(details = details.copy(personalNotes = updatedNotes)))
+      }
+    }
+  }
+
+  /**
    * Upload the picture to the cloud storage update the user object in the database with the cloud
    * path created. update the user object in the viewmodel with the url of the image and the cloud
    * path

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -144,27 +144,35 @@ fun ParkingDetailsScreen(
                     val editingNote = remember { mutableStateOf(false) }
                     val editingNoteText = remember { mutableStateOf(parkingNote ?: "") }
 
-                    if (editingNote.value) {
-                      ConditionCheckingInputText(
-                          value = editingNoteText.value,
-                          onValueChange = { editingNoteText.value = it },
-                          label = stringResource(R.string.note),
-                          minCharacters = 0,
-                          maxCharacters = 32,
-                          testTag = "NoteInputText",
-                      )
-                    } else {
-                      Text(
-                          text = parkingNote ?: stringResource(R.string.no_note),
-                          style = MaterialTheme.typography.bodyLarge,
-                          textAlign = TextAlign.Left,
-                          modifier = Modifier.padding(end = 8.dp).testTag("NoteText"))
-                    }
+                    // Column to handle text wrapping
+                    Column(
+                        modifier =
+                            Modifier.weight(1f) // Allow this column to take available space
+                                .padding(end = 16.dp) // Space for icons
+                        ) {
+                          if (editingNote.value) {
+                            ConditionCheckingInputText(
+                                value = editingNoteText.value,
+                                onValueChange = { editingNoteText.value = it },
+                                label = stringResource(R.string.note),
+                                minCharacters = 0,
+                                maxCharacters = 32,
+                                testTag = "NoteInputText")
+                          } else {
+                            Text(
+                                text = parkingNote ?: stringResource(R.string.no_note),
+                                style = MaterialTheme.typography.bodyLarge,
+                                textAlign = TextAlign.Left,
+                                modifier = Modifier.testTag("NoteText"))
+                          }
+                        }
 
+                    // Icons Row
                     Row(
                         modifier = Modifier.testTag("IconsRow"),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                          // Save or Add/Edit Note Icon
                           if (editingNote.value) {
                             Icon(
                                 imageVector = Icons.Default.Check,
@@ -178,78 +186,72 @@ fun ParkingDetailsScreen(
                                         }
                                         .testTag("SaveNoteIcon"))
                           } else {
-                            if (parkingNote == null) {
-                              Icon(
-                                  imageVector = Icons.Default.Add,
-                                  contentDescription = "Add Note",
-                                  tint = Black,
-                                  modifier =
-                                      Modifier.clickable { editingNote.value = true }
-                                          .testTag("AddNoteIcon"))
-                            } else {
-                              Icon(
-                                  imageVector = Icons.Default.Edit,
-                                  contentDescription = "Edit Note",
-                                  tint = Black,
-                                  modifier =
-                                      Modifier.clickable { editingNote.value = true }
-                                          .testTag("EditNoteIcon"))
-                            }
-
-                            val isPinned =
-                                parkingViewModel.pinnedParkings
-                                    .collectAsState()
-                                    .value
-                                    .contains(selectedParking)
                             Icon(
                                 imageVector =
-                                    if (isPinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
-                                contentDescription = "Pin",
+                                    if (parkingNote == null) Icons.Default.Add
+                                    else Icons.Default.Edit,
+                                contentDescription =
+                                    if (parkingNote == null) "Add Note" else "Edit Note",
                                 tint = Black,
                                 modifier =
-                                    Modifier.testTag("PinIcon")
-                                        .clickable {
-                                          parkingViewModel.togglePinStatus(selectedParking)
-                                        }
-                                        .rotate(45f) // Rotate the push pin icon
-                                )
-
-                            val isFavorite =
-                                userSignedIn.value &&
-                                    userViewModel.favoriteParkings
-                                        .collectAsState()
-                                        .value
-                                        .contains(selectedParking)
-
-                            Icon(
-                                imageVector =
-                                    if (isFavorite) Icons.Default.Favorite
-                                    else Icons.Outlined.FavoriteBorder,
-                                contentDescription = "Favorite",
-                                tint = if (isFavorite) Red else Black,
-                                modifier =
-                                    Modifier.testTag(
-                                            if (isFavorite) "RedFilledFavoriteIcon"
-                                            else "BlackOutlinedFavoriteIcon")
-                                        .clickable {
-                                          if (userSignedIn.value) {
-                                            if (isFavorite) {
-                                              userViewModel.removeFavoriteParkingFromSelectedUser(
-                                                  selectedParking)
-                                            } else {
-                                              userViewModel.addFavoriteParkingToSelectedUser(
-                                                  selectedParking)
-                                            }
-                                          } else {
-                                            Toast.makeText(
-                                                    context, toastMessage, Toast.LENGTH_SHORT)
-                                                .show()
-                                          }
-                                        })
+                                    Modifier.clickable { editingNote.value = true }
+                                        .testTag(
+                                            if (parkingNote == null) "AddNoteIcon"
+                                            else "EditNoteIcon"))
                           }
+
+                          // Pin Icon
+                          val isPinned =
+                              parkingViewModel.pinnedParkings
+                                  .collectAsState()
+                                  .value
+                                  .contains(selectedParking)
+                          Icon(
+                              imageVector =
+                                  if (isPinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                              contentDescription = "Pin",
+                              tint = Black,
+                              modifier =
+                                  Modifier.clickable {
+                                        parkingViewModel.togglePinStatus(selectedParking)
+                                      }
+                                      .rotate(45f)
+                                      .testTag("PinIcon"))
+
+                          // Favorite Icon
+                          val isFavorite =
+                              userSignedIn.value &&
+                                  userViewModel.favoriteParkings
+                                      .collectAsState()
+                                      .value
+                                      .contains(selectedParking)
+
+                          Icon(
+                              imageVector =
+                                  if (isFavorite) Icons.Default.Favorite
+                                  else Icons.Outlined.FavoriteBorder,
+                              contentDescription = "Favorite",
+                              tint = if (isFavorite) Red else Black,
+                              modifier =
+                                  Modifier.clickable {
+                                        if (userSignedIn.value) {
+                                          if (isFavorite) {
+                                            userViewModel.removeFavoriteParkingFromSelectedUser(
+                                                selectedParking)
+                                          } else {
+                                            userViewModel.addFavoriteParkingToSelectedUser(
+                                                selectedParking)
+                                          }
+                                        } else {
+                                          Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT)
+                                              .show()
+                                        }
+                                      }
+                                      .testTag(
+                                          if (isFavorite) "RedFilledFavoriteIcon"
+                                          else "BlackOutlinedFavoriteIcon"))
                         }
                   }
-
               // Reviews
               Row(
                   modifier =

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -53,6 +53,7 @@ import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.parking.ParkingReport
 import com.github.se.cyrcle.model.parking.ParkingReportReason
 import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.user.MAX_NOTE_LENGTH
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
@@ -156,7 +157,7 @@ fun ParkingDetailsScreen(
                                 onValueChange = { editingNoteText.value = it },
                                 label = stringResource(R.string.note),
                                 minCharacters = 0,
-                                maxCharacters = 32,
+                                maxCharacters = MAX_NOTE_LENGTH,
                                 testTag = "NoteInputText")
                           } else {
                             Text(
@@ -180,9 +181,11 @@ fun ParkingDetailsScreen(
                                 tint = Black,
                                 modifier =
                                     Modifier.clickable {
-                                          userViewModel.editCurrentUserPersonalNoteForParking(
-                                              selectedParking, editingNoteText.value)
-                                          editingNote.value = false
+                                          if (editingNoteText.value.length <= MAX_NOTE_LENGTH) {
+                                            userViewModel.editCurrentUserPersonalNoteForParking(
+                                                selectedParking, editingNoteText.value)
+                                            editingNote.value = false
+                                          }
                                         }
                                         .testTag("SaveNoteIcon"))
                           } else {

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
@@ -102,6 +102,7 @@ fun ConditionCheckingInputText(
     value: String = "",
     minCharacters: Int = 0,
     maxCharacters: Int = Int.MAX_VALUE,
+    maxLines: Int = Int.MAX_VALUE,
     hasClearIcon: Boolean = true,
     testTag: String = "ConditionCheckingInputText"
 ) {
@@ -113,6 +114,7 @@ fun ConditionCheckingInputText(
         onValueChange = onValueChange,
         value = value,
         singleLine = false,
+        maxLines = maxLines,
         hasClearIcon = hasClearIcon,
         testTag = testTag,
         isError = isError)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,9 @@
     <string name="list_screen_rating">Rating: %.1f</string>
     <string name="list_screen_display_only_cctv">Only display parkings with CCTV camera</string>
     <string name="all_parkings_radius">All parkings in a radius of %1$d m</string>
-    <string name="note">Edit your note</string>
-    <string name="no_note">You can add a note by clicking on +</string>
+    <string name="list_screen_edit_note">Edit your note</string>
+    <string name="list_screen_no_note">Add a note by clicking on +</string>
+    <string name="sign_in_to_add_note">Please sign in to add notes</string>
 
     <!-- Zoom Controls -->
     <string name="zoom_in">Zoom In</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,8 @@
     <string name="list_screen_rating">Rating: %.1f</string>
     <string name="list_screen_display_only_cctv">Only display parkings with CCTV camera</string>
     <string name="all_parkings_radius">All parkings in a radius of %1$d m</string>
+    <string name="note">Edit your note</string>
+    <string name="no_note">You can add a note by clicking on +</string>
 
     <!-- Zoom Controls -->
     <string name="zoom_in">Zoom In</string>

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
@@ -275,8 +276,15 @@ class UserViewModelTest {
     userViewModel.setCurrentUser(TestInstancesUser.user1)
     userViewModel.updateUser(TestInstancesUser.user1)
 
-    // Check if the user was updated in the repository
-    verify(userRepository).updateUser(eq(TestInstancesUser.user1), any(), any())
+    // Check that the user was not updated in the repository as the user is the same
+    verify(userRepository, times(0)).updateUser(any(), any(), any())
+
+    val updatedUser =
+        TestInstancesUser.user1.copy(
+            details = TestInstancesUser.user1.details?.copy(firstName = "New name"))
+    userViewModel.updateUser(updatedUser)
+    // Check that the user was updated in the repository
+    verify(userRepository).updateUser(eq(updatedUser), any(), any())
   }
 
   @Test

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -384,4 +384,61 @@ class UserViewModelTest {
     // Check if the selected user is the updated user
     assert(userViewModel.currentUser.value == updatedUser)
   }
+
+  @Test
+  fun editCurrentUserPersonalNoteForParkingTest() {
+    val user = TestInstancesUser.user1
+    val parking = TestInstancesParking.parking1
+
+    // Case 1: New note is empty while there is an existing note
+    val actualUserCase1 =
+        user.copy(
+            details = user.details?.copy(personalNotes = mapOf("Test_spot_1" to "Test note 1")))
+
+    userViewModel.setCurrentUser(actualUserCase1)
+    userViewModel.editCurrentUserPersonalNoteForParking(parking, "")
+
+    val expectedUserCase1 = user.copy(details = user.details?.copy(personalNotes = emptyMap()))
+    assert(userViewModel.currentUser.value == expectedUserCase1)
+
+    // Case 2: New note is empty while there is no existing note
+    val actualUserCase2 = user
+    userViewModel.setCurrentUser(actualUserCase2)
+    userViewModel.editCurrentUserPersonalNoteForParking(parking, "")
+
+    val expectedUserCase2 = user // We expect no change
+    assert(userViewModel.currentUser.value == expectedUserCase2)
+
+    // Case 3: New note is not empty while there is an existing note
+    val actualUserCase3 =
+        user.copy(
+            details = user.details?.copy(personalNotes = mapOf("Test_spot_1" to "Test note 1")))
+
+    userViewModel.setCurrentUser(actualUserCase3)
+    userViewModel.editCurrentUserPersonalNoteForParking(parking, "New note")
+
+    val expectedUserCase3 =
+        user.copy(details = user.details?.copy(personalNotes = mapOf("Test_spot_1" to "New note")))
+    assert(userViewModel.currentUser.value == expectedUserCase3)
+
+    // Case 4: New note is not empty while there is no existing note
+    val actualUserCase4 = user
+    userViewModel.setCurrentUser(actualUserCase4)
+    userViewModel.editCurrentUserPersonalNoteForParking(parking, "New note")
+
+    val expectedUserCase4 =
+        user.copy(details = user.details?.copy(personalNotes = mapOf("Test_spot_1" to "New note")))
+    assert(userViewModel.currentUser.value == expectedUserCase4)
+
+    // Case 0: User is null
+    userViewModel.setCurrentUser(null)
+    userViewModel.editCurrentUserPersonalNoteForParking(parking, "New note")
+    assert(userViewModel.currentUser.value == null)
+
+    // Case 0 (continued): User is not null but details is null
+    val userCase0bis = User(TestInstancesUser.user1.public, null)
+    userViewModel.setCurrentUser(userCase0bis)
+    userViewModel.editCurrentUserPersonalNoteForParking(parking, "New note")
+    assert(userViewModel.currentUser.value == userCase0bis)
+  }
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/user/UserViewModelTest.kt
@@ -16,7 +16,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
@@ -276,15 +275,8 @@ class UserViewModelTest {
     userViewModel.setCurrentUser(TestInstancesUser.user1)
     userViewModel.updateUser(TestInstancesUser.user1)
 
-    // Check that the user was not updated in the repository as the user is the same
-    verify(userRepository, times(0)).updateUser(any(), any(), any())
-
-    val updatedUser =
-        TestInstancesUser.user1.copy(
-            details = TestInstancesUser.user1.details?.copy(firstName = "New name"))
-    userViewModel.updateUser(updatedUser)
-    // Check that the user was updated in the repository
-    verify(userRepository).updateUser(eq(updatedUser), any(), any())
+    // Check if the user was updated in the repository
+    verify(userRepository).updateUser(eq(TestInstancesUser.user1), any(), any())
   }
 
   @Test


### PR DESCRIPTION
This PR introduces a new feature that allows users to add, edit, and view personal notes for parking spots. The changes include backend support, UI implementation, and corresponding tests.

### Changes
#### Backend
- Added `personalNotes` field to the `UserDetails` data class
- Implemented `editCurrentUserPersonalNoteForParking` function in `UserViewModel`

#### UI
- Updated `ParkingDetailsScreen` to display and edit personal notes
- Implemented a new row in the parking details screen for note interaction
- Added icons for adding, editing, and saving notes
- Ensured proper alignment and spacing of UI elements

<img width="200" alt="image" src="https://github.com/user-attachments/assets/d7e56011-d827-4244-bff8-99c803232cef">
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ad65a66e-2224-4ac1-80d9-83247e7f3ef3">
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5d41bb25-5448-4fcd-adf0-fc585eff1ed3">

### Implementation details of editCurrentUserPersonalNoteForParking
Unified Functionality: The function handles all three operations (add, edit, remove) based on the content of newNote:
- If newNote is blank, it removes the existing note (if any).
- If newNote is not blank, it either adds a new note or updates an existing one.

### Testing
- Added new UI tests in **ParkingDetailsScreenTest** to cover note-related functionality
- Added tests for the UserViewModel's new editCurrentUserPersonalNoteForParking function
- Updated existing tests to accommodate new changes

### Coverage
![image](https://github.com/user-attachments/assets/3e5d2351-d7e2-404a-89b7-fba2e92de73d)

