### PR TITLE
BugFix : advanced Mode and camera state not persistent across Screen navigation

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -266,7 +266,12 @@ class MapViewModel : ViewModel() {
       plabelAnnotationManager: PointAnnotationManager?,
       parkingsList: List<Parking>
   ) {
+
+    // Create a list of annotations to draw
     val annotations: MutableList<PolygonAnnotationOptions> = mutableListOf()
+
+    // For each parking, add the polygon and the label to their respective Annotation Manager and
+    // draw them.
     parkingsList.map { parking ->
       val location = parking.location
       val topLeft = location.topLeft
@@ -292,9 +297,13 @@ class MapViewModel : ViewModel() {
                 .withTextColor("#FFFFFF")
                 .withTextHaloColor("#FFFFFF")
                 .withTextHaloWidth(0.2)
+
+        // draw the labels via the labelAnnotationManager
         plabelAnnotationManager?.create(labelAnnotationOption)
       }
     }
+
+    // draw the polygons via the polygonAnnotationManager
     polygonAnnotationManager?.create(annotations)
   }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/attributes/AttributesPicker.kt
@@ -61,7 +61,6 @@ import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.map.MapConfig
-import com.github.se.cyrcle.ui.map.drawRectangles
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
@@ -387,7 +386,7 @@ fun AttributePickerTopBar(mapViewModel: MapViewModel, title: MutableState<String
         // we need to wrap the location in a Parking object to pass it to the drawRectangles
         // function
         val placeholderParking = TestInstancesParking.parking1.copy(location = location)
-        drawRectangles(annotationManager, null, listOf(placeholderParking))
+        mapViewModel.drawRectangles(annotationManager, null, listOf(placeholderParking))
       }
 }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -48,7 +48,6 @@ import com.github.se.cyrcle.ui.theme.atoms.IconButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.disabledColor
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
-import com.github.se.cyrcle.ui.theme.molecules.DropDownableEnum
 import com.google.gson.Gson
 import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.maps.CameraBoundsOptions
@@ -56,7 +55,6 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.ViewAnnotationAnchor
 import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
-import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.AnnotationSourceOptions
 import com.mapbox.maps.plugin.annotation.ClusterOptions
@@ -64,9 +62,7 @@ import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPolygonAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
-import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
-import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
 import com.mapbox.maps.plugin.gestures.OnMoveListener
@@ -77,7 +73,6 @@ import com.mapbox.maps.viewannotation.annotatedLayerFeature
 import com.mapbox.maps.viewannotation.annotationAnchor
 import com.mapbox.maps.viewannotation.geometry
 import com.mapbox.maps.viewannotation.viewAnnotationOptions
-import com.mapbox.turf.TurfMeasurement
 
 const val defaultZoom = 16.0
 const val maxZoom = 18.0
@@ -87,19 +82,6 @@ const val LAYER_ID = "0128"
 const val LAYER_ID_RECT = "0129"
 const val ADVANCED_MODE_ZOOM_THRESHOLD = 15.5
 const val CLUSTER_COLORS = "#1A4988"
-
-/**
- * Enum class to represent the different modes of the map
- *
- * @param description the description of the mode
- * @param isAdvancedMode true if the mode is advanced, false otherwise The advanced mode is the mode
- *   where the rectangles are displayed The simple mode is the mode where the markers are displayed
- */
-enum class MapMode(override val description: String, val isAdvancedMode: Boolean) :
-    DropDownableEnum {
-  MARKERS("Simple", false),
-  RECTANGLES("Advanced", true)
-}
 
 @Composable
 fun MapScreen(
@@ -111,18 +93,39 @@ fun MapScreen(
     zoomState: MutableState<Double> = remember { mutableDoubleStateOf(defaultZoom) }
 ) {
 
+  // Collect the list of parkings from the ParkingViewModel as a state
   val listOfParkings by parkingViewModel.rectParkings.collectAsState()
+
+  // Collect the boolean to enable the parking addition from the UserViewModel as a state
   val enableParkingAddition by userViewModel.isSignedIn.collectAsState(false)
+
   // create a remember  state to store if the markers or the rectangles are displayed
-  val mapMode = remember { mutableStateOf(MapMode.MARKERS) }
-  // this is the state the user selected by the user, remembered even when zoomed out.
-  val userMapMode = remember { mutableStateOf(MapMode.MARKERS) }
+  val mapMode = mapViewModel.mapMode.collectAsState()
+
+  // this is the Map mode the user selected
+  val userMapMode = mapViewModel.userMapMode.collectAsState()
+
+  // Create the viewport state from the MapViewModel
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
+
+  // Mutable state to store the PointAnnotationManager for markers
   var markerAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
+
+  // Mutable state to store the PolygonAnnotationManager for rectangles
   var rectangleAnnotationManager by remember { mutableStateOf<PolygonAnnotationManager?>(null) }
+
+  // Mutable state to store the PointAnnotationManager for parking labels
   var pLabelAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
+
+  // Collect the selected parking from the ParkingViewModel as a state
   val selectedParking by parkingViewModel.selectedParking.collectAsState()
+
+  // Collect the location permission status as a state from the PermissionHandler
   val locationEnabled by permissionHandler.getLocalisationPerm().collectAsState()
+
+  // Prevent the camera from recentering when the user exit and come back to the map by disabling
+  // the related launchedEffect
+  val cameraRecentering = mapViewModel.cameraRecentering.collectAsState()
 
   // initialize the Gson object that will deserialize and serialize the parking to bind it to the
   // marker
@@ -142,362 +145,323 @@ fun MapScreen(
         markerAnnotationManager?.deleteAll()
         rectangleAnnotationManager?.deleteAll()
         if (mapMode.value.isAdvancedMode)
-            drawRectangles(rectangleAnnotationManager, pLabelAnnotationManager, listOfParkings)
-        else drawMarkers(markerAnnotationManager, listOfParkings, resizedBitmap)
+            mapViewModel.drawRectangles(
+                rectangleAnnotationManager, pLabelAnnotationManager, listOfParkings)
+        else mapViewModel.drawMarkers(markerAnnotationManager, listOfParkings, resizedBitmap)
       }
 
   // Center the camera on th puck and transition to the follow puck state. Update the user
   // position to the center of the camera
   LaunchedEffect(locationEnabled) {
-    mapViewportState.transitionToFollowPuckState(
-        FollowPuckViewportStateOptions.Builder()
-            .pitch(0.0)
-            .zoom(maxZoom)
-            .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
-            .build()) {
-          mapViewportState.cameraState?.let { mapViewModel.updateUserPosition(it.center) }
-        }
+    if (!cameraRecentering.value) {
+      mapViewportState.transitionToFollowPuckState(
+          FollowPuckViewportStateOptions.Builder()
+              .pitch(0.0)
+              .zoom(maxZoom)
+              .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
+              .build()) {
+            mapViewportState.cameraState?.let { mapViewModel.updateUserPosition(it.center) }
+            mapViewModel.updateMapRecentering(true)
+          }
+    }
   }
 
-  Scaffold(bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.MAP) }) {
-      padding ->
-    MapboxMap(
-        Modifier.fillMaxSize().padding(padding).testTag("MapScreen"),
-        mapViewportState = mapViewportState,
-        style = { MapConfig.DefaultStyle() }) {
-          DisposableMapEffect { mapView ->
-
-            // ======================= GLOBAL SETTINGS =======================
-            // Disable the rotation gesture
-            mapView.gestures.getGesturesManager().rotateGestureDetector.isEnabled = false
-            // Set camera bounds options
-            val cameraBoundsOptions =
-                CameraBoundsOptions.Builder().minZoom(minZoom).maxZoom(maxZoom).build()
-            mapView.mapboxMap.setBounds(cameraBoundsOptions)
-
-            // Get parkings in the current view
-            val (loadedBottomLeft, loadedTopRight) = mapViewModel.getScreenCorners(mapView)
-            parkingViewModel.getParkingsInRect(loadedBottomLeft, loadedTopRight)
-
-            // When map is loaded, check if the location permission is granted and initialize the
-            // location component
-            if (locationEnabled) mapViewModel.initLocationComponent(mapView)
-            // ======================= GLOBAL SETTINGS =======================
-
-            // ======================= ANNOTATIONS =======================
-            // Create annotation manager to draw markers
-            markerAnnotationManager =
-                mapView.annotations.createPointAnnotationManager(
-                    AnnotationConfig(
-                        annotationSourceOptions =
-                            AnnotationSourceOptions(
-                                clusterOptions =
-                                    ClusterOptions(
-                                        colorLevels =
-                                            listOf(
-                                                Pair(
-                                                    1,
-                                                    android.graphics.Color.parseColor(
-                                                        CLUSTER_COLORS))))),
-                        layerId = LAYER_ID))
-            // Create polygon annotation manager to draw rectangles
-            rectangleAnnotationManager =
-                mapView.annotations.createPolygonAnnotationManager(
-                    annotationConfig = AnnotationConfig().copy(layerId = LAYER_ID_RECT))
-            // Create point annotation manager to draw parking labels
-            pLabelAnnotationManager =
-                mapView.annotations.createPointAnnotationManager(AnnotationConfig())
-            // ======================= ANNOTATIONS =======================
-
-            val viewAnnotationManager = mapView.viewAnnotationManager
-            // upload the view annotation manager to the view model
-            mapViewModel.updateViewAnnotationManager(viewAnnotationManager)
-            // ======================= MOVE LISTENER =======================
-            // Add a move listener to the map to deactivate tracking mode when the user moves the
-            // map
-            val moveListener =
-                object : OnMoveListener {
-                  override fun onMoveBegin(detector: MoveGestureDetector) {
-                    // Remove any preview card displayed
-                    mapViewModel.removePreviewCard()
-                    if (mapViewModel.isTrackingModeEnable.value) {
-                      mapViewportState.transitionToOverviewState(
-                          OverviewViewportStateOptions.Builder()
-                              .geometry(mapViewportState.cameraState!!.center)
-                              .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
-                              .build())
-                      mapViewModel.updateTrackingMode(false)
-                    }
-                  }
-
-                  override fun onMove(detector: MoveGestureDetector): Boolean {
-                    return false
-                  }
-
-                  override fun onMoveEnd(detector: MoveGestureDetector) {}
-                }
-
-            mapView.gestures.addOnMoveListener(moveListener)
-            // ======================= MOVE LISTENER =======================
-
-            // ======================= MARKERS CLICK =======================
-            markerAnnotationManager?.addClickListener(
-                OnPointAnnotationClickListener { pointAnnotation ->
-                  mapViewModel.removePreviewCard()
-                  // get the data from the PointAnnotation and deserialize it
-                  val parkingData = pointAnnotation.getData()?.asJsonObject
-                  val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
-                  // move the camera to the selected parking
-                  mapViewportState.setCameraOptions { center(parkingDeserialized.location.center) }
-
-                  // Add the new view annotation
-                  val viewAnnotation =
-                      viewAnnotationManager.addViewAnnotation(
-                          resId = R.layout.item_callout_view,
-                          options =
-                              viewAnnotationOptions {
-                                annotatedLayerFeature(LAYER_ID) {
-                                  featureId(pointAnnotation.id)
-                                  geometry(pointAnnotation.geometry)
-                                  annotationAnchor {
-                                    anchor(ViewAnnotationAnchor.BOTTOM)
-                                    offsetY((pointAnnotation.iconImageBitmap?.height!!.toDouble()))
-                                  }
-                                }
-                              })
-
-                  // Set the text and the button of the view annotation
-                  ItemCalloutViewBinding.bind(viewAnnotation).apply {
-                    textNativeView.text =
-                        screenCapacityString.format(parkingDeserialized.capacity.description)
-                    selectButton.setOnClickListener {
-                      parkingViewModel.selectParking(parkingDeserialized)
-                      navigationActions.navigateTo(Screen.PARKING_DETAILS)
-                    }
-                  }
-                  true
-                })
-            // ======================= MARKERS CLICK =======================
-
-            // ======================= RECTANGLES CLICK =======================
-            rectangleAnnotationManager?.addClickListener(
-                OnPolygonAnnotationClickListener {
-                  // Remove any preview card displayed
-                  mapViewModel.removePreviewCard()
-                  // get the data from the PointAnnotation and deserialize it
-                  val parkingData = it.getData()?.asJsonObject
-                  val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
-                  // move the camera to the selected parking
-                  mapViewportState.setCameraOptions { center(parkingDeserialized.location.center) }
-
-                  // Add the new view annotation
-                  val viewAnnotation =
-                      viewAnnotationManager.addViewAnnotation(
-                          resId = R.layout.item_callout_view,
-                          options =
-                              viewAnnotationOptions {
-                                annotatedLayerFeature(LAYER_ID_RECT) {
-                                  featureId(it.id)
-                                  geometry(it.geometry)
-                                  annotationAnchor {
-                                    anchor(ViewAnnotationAnchor.BOTTOM)
-                                    offsetY(0.0)
-                                  }
-                                }
-                              })
-
-                  // Set the text and the button of the view annotation
-                  ItemCalloutViewBinding.bind(viewAnnotation).apply {
-                    textNativeView.text =
-                        screenCapacityString.format(parkingDeserialized.capacity.description)
-                    selectButton.setOnClickListener {
-                      parkingViewModel.selectParking(parkingDeserialized)
-                      navigationActions.navigateTo(Screen.PARKING_DETAILS)
-                    }
-                  }
-                  true
-                })
-            // ======================= RECTANGLES CLICK =======================
-
-            // =======================  CAMERA  LISTENER  =======================
-            mapView.mapboxMap.subscribeCameraChanged {
-
-              // Get the top right and bottom left coordinates of the current view only when
-              // what the user sees is outside the screen
-              val (currentBottomLeft, currentTopRight) = mapViewModel.getScreenCorners(mapView)
-
-              // Temporary fix to avoid loading too much parkings when zoomed out
-              if (mapView.mapboxMap.cameraState.zoom > thresholdDisplayZoom) {
-                parkingViewModel.getParkingsInRect(currentBottomLeft, currentTopRight)
-              }
-              // On zoom-out past the threshold, switch to the markers mode
-              if (mapView.mapboxMap.cameraState.zoom < ADVANCED_MODE_ZOOM_THRESHOLD &&
-                  zoomState.value >= ADVANCED_MODE_ZOOM_THRESHOLD) {
-                mapMode.value = MapMode.MARKERS
-              }
-              // On zoomin in past the threshold, switch to the user's selected mode
-              if (mapView.mapboxMap.cameraState.zoom >= ADVANCED_MODE_ZOOM_THRESHOLD &&
-                  zoomState.value < ADVANCED_MODE_ZOOM_THRESHOLD) {
-                mapMode.value = userMapMode.value
-              }
-
-              // store the zoom level
-              // This must stay at the end of the listener.
-              zoomState.value = mapView.mapboxMap.cameraState.zoom
-            }
-            // =======================  CAMERA  LISTENER  =======================
-
-            onDispose {
-              pLabelAnnotationManager?.deleteAll()
-              rectangleAnnotationManager?.deleteAll()
-              markerAnnotationManager?.deleteAll()
-              mapViewModel.removePreviewCard()
-              mapViewModel.updateViewAnnotationManager(null)
-            }
-          }
-        }
-
-    // ======================= OVERLAY =======================
-    Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-      // A switch to change the display mode
-      Row(
-          modifier =
-              Modifier.align(Alignment.TopStart).padding(start = 8.dp, top = 32.dp).alpha(alpha),
-          verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                stringResource(R.string.map_screen_mode_switch_label),
-                color = MaterialTheme.colorScheme.onBackground,
-                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
-            Switch(
-                modifier = Modifier.padding(start = 8.dp),
-                checked = mapMode.value.isAdvancedMode,
-                onCheckedChange = {
-                  userMapMode.value = if (it) MapMode.RECTANGLES else MapMode.MARKERS
-                  mapMode.value = userMapMode.value
-                },
-                colors =
-                    SwitchDefaults.colors()
-                        .copy(
-                            uncheckedTrackColor = disabledColor(),
-                        ))
-          }
-
-      ZoomControls(
-          modifier = Modifier.align(Alignment.TopEnd),
-          onZoomIn = {
-            mapViewModel.removePreviewCard()
-            mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom + 1.0) }
-          },
-          onZoomOut = {
-            mapViewModel.removePreviewCard()
-            mapViewportState.setCameraOptions { zoom(mapViewportState.cameraState!!.zoom - 1.0) }
-          })
-
-      if (locationEnabled) {
-        IconButton(
-            icon = Icons.Default.MyLocation,
-            contentDescription = "Recenter on Location",
-            modifier =
-                Modifier.align(Alignment.BottomEnd)
-                    .padding(bottom = 25.dp, end = 16.dp)
-                    .scale(1.2f)
-                    .testTag("recenterButton"),
-            onClick = {
-              mapViewModel.removePreviewCard()
-              mapViewModel.updateTrackingMode(true)
-              mapViewportState.transitionToFollowPuckState(
-                  FollowPuckViewportStateOptions.Builder()
-                      .pitch(0.0)
-                      .zoom(maxZoom)
-                      .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
-                      .build())
-            },
-            colorLevel =
-                if (mapViewModel.isTrackingModeEnable.collectAsState().value) ColorLevel.SECONDARY
-                else ColorLevel.PRIMARY)
-      }
-
-      if (enableParkingAddition) {
-        IconButton(
-            icon = Icons.Default.Add,
-            contentDescription = "Add parking spots",
-            modifier =
-                Modifier.align(Alignment.BottomStart)
-                    .scale(1.2f)
-                    .padding(bottom = 25.dp, start = 16.dp),
-            onClick = {
+  Scaffold(
+      bottomBar = {
+        BottomNavigationBar(
+            navigationActions,
+            selectedItem = Route.MAP,
+            onTabSelect = {
               mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
-              navigationActions.navigateTo(Route.ADD_SPOTS)
-            },
-            colorLevel = ColorLevel.PRIMARY,
-            testTag = "addButton")
+              navigationActions.navigateTo(it)
+            })
+      }) { padding ->
+        MapboxMap(
+            Modifier.fillMaxSize().padding(padding).testTag("MapScreen"),
+            mapViewportState = mapViewportState,
+            style = { MapConfig.DefaultStyle() }) {
+              DisposableMapEffect { mapView ->
+
+                // ======================= GLOBAL SETTINGS =======================
+                // Disable the rotation gesture
+                mapView.gestures.getGesturesManager().rotateGestureDetector.isEnabled = false
+                // Set camera bounds options
+                val cameraBoundsOptions =
+                    CameraBoundsOptions.Builder().minZoom(minZoom).maxZoom(maxZoom).build()
+                mapView.mapboxMap.setBounds(cameraBoundsOptions)
+
+                // Get parkings in the current view
+                val (loadedBottomLeft, loadedTopRight) = mapViewModel.getScreenCorners(mapView)
+                parkingViewModel.getParkingsInRect(loadedBottomLeft, loadedTopRight)
+
+                // When map is loaded, check if the location permission is granted and initialize
+                // the
+                // location component
+                if (locationEnabled) mapViewModel.initLocationComponent(mapView)
+                // ======================= GLOBAL SETTINGS =======================
+
+                // ======================= ANNOTATIONS =======================
+                // Create annotation manager to draw markers
+                markerAnnotationManager =
+                    mapView.annotations.createPointAnnotationManager(
+                        AnnotationConfig(
+                            annotationSourceOptions =
+                                AnnotationSourceOptions(
+                                    clusterOptions =
+                                        ClusterOptions(
+                                            colorLevels =
+                                                listOf(
+                                                    Pair(
+                                                        1,
+                                                        android.graphics.Color.parseColor(
+                                                            CLUSTER_COLORS))))),
+                            layerId = LAYER_ID))
+                // Create polygon annotation manager to draw rectangles
+                rectangleAnnotationManager =
+                    mapView.annotations.createPolygonAnnotationManager(
+                        annotationConfig = AnnotationConfig().copy(layerId = LAYER_ID_RECT))
+                // Create point annotation manager to draw parking labels
+                pLabelAnnotationManager =
+                    mapView.annotations.createPointAnnotationManager(AnnotationConfig())
+                // ======================= ANNOTATIONS =======================
+
+                val viewAnnotationManager = mapView.viewAnnotationManager
+                // upload the view annotation manager to the view model
+                mapViewModel.updateViewAnnotationManager(viewAnnotationManager)
+                // ======================= MOVE LISTENER =======================
+                // Add a move listener to the map to deactivate tracking mode when the user moves
+                // the
+                // map
+                val moveListener =
+                    object : OnMoveListener {
+                      override fun onMoveBegin(detector: MoveGestureDetector) {
+                        // Remove any preview card displayed
+                        mapViewModel.removePreviewCard()
+                        if (mapViewModel.isTrackingModeEnable.value) {
+                          mapViewportState.transitionToOverviewState(
+                              OverviewViewportStateOptions.Builder()
+                                  .geometry(mapViewportState.cameraState!!.center)
+                                  .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
+                                  .build())
+                          mapViewModel.updateTrackingMode(false)
+                        }
+                      }
+
+                      override fun onMove(detector: MoveGestureDetector): Boolean {
+                        return false
+                      }
+
+                      override fun onMoveEnd(detector: MoveGestureDetector) {}
+                    }
+
+                mapView.gestures.addOnMoveListener(moveListener)
+                // ======================= MOVE LISTENER =======================
+
+                // ======================= MARKERS CLICK =======================
+                markerAnnotationManager?.addClickListener(
+                    OnPointAnnotationClickListener { pointAnnotation ->
+                      mapViewModel.removePreviewCard()
+                      // get the data from the PointAnnotation and deserialize it
+                      val parkingData = pointAnnotation.getData()?.asJsonObject
+                      val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
+                      // move the camera to the selected parking
+                      mapViewportState.setCameraOptions {
+                        center(parkingDeserialized.location.center)
+                      }
+
+                      // Add the new view annotation
+                      val viewAnnotation =
+                          viewAnnotationManager.addViewAnnotation(
+                              resId = R.layout.item_callout_view,
+                              options =
+                                  viewAnnotationOptions {
+                                    annotatedLayerFeature(LAYER_ID) {
+                                      featureId(pointAnnotation.id)
+                                      geometry(pointAnnotation.geometry)
+                                      annotationAnchor {
+                                        anchor(ViewAnnotationAnchor.BOTTOM)
+                                        offsetY(
+                                            (pointAnnotation.iconImageBitmap?.height!!.toDouble()))
+                                      }
+                                    }
+                                  })
+
+                      // Set the text and the button of the view annotation
+                      ItemCalloutViewBinding.bind(viewAnnotation).apply {
+                        textNativeView.text =
+                            screenCapacityString.format(parkingDeserialized.capacity.description)
+                        selectButton.setOnClickListener {
+                          parkingViewModel.selectParking(parkingDeserialized)
+                          navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                        }
+                      }
+                      true
+                    })
+                // ======================= MARKERS CLICK =======================
+
+                // ======================= RECTANGLES CLICK =======================
+                rectangleAnnotationManager?.addClickListener(
+                    OnPolygonAnnotationClickListener {
+                      // Remove any preview card displayed
+                      mapViewModel.removePreviewCard()
+                      // get the data from the PointAnnotation and deserialize it
+                      val parkingData = it.getData()?.asJsonObject
+                      val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
+                      // move the camera to the selected parking
+                      mapViewportState.setCameraOptions {
+                        center(parkingDeserialized.location.center)
+                      }
+
+                      // Add the new view annotation
+                      val viewAnnotation =
+                          viewAnnotationManager.addViewAnnotation(
+                              resId = R.layout.item_callout_view,
+                              options =
+                                  viewAnnotationOptions {
+                                    annotatedLayerFeature(LAYER_ID_RECT) {
+                                      featureId(it.id)
+                                      geometry(it.geometry)
+                                      annotationAnchor {
+                                        anchor(ViewAnnotationAnchor.BOTTOM)
+                                        offsetY(0.0)
+                                      }
+                                    }
+                                  })
+
+                      // Set the text and the button of the view annotation
+                      ItemCalloutViewBinding.bind(viewAnnotation).apply {
+                        textNativeView.text =
+                            screenCapacityString.format(parkingDeserialized.capacity.description)
+                        selectButton.setOnClickListener {
+                          parkingViewModel.selectParking(parkingDeserialized)
+                          navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                        }
+                      }
+                      true
+                    })
+                // ======================= RECTANGLES CLICK =======================
+
+                // =======================  CAMERA  LISTENER  =======================
+                mapView.mapboxMap.subscribeCameraChanged {
+
+                  // Get the top right and bottom left coordinates of the current view only when
+                  // what the user sees is outside the screen
+                  val (currentBottomLeft, currentTopRight) = mapViewModel.getScreenCorners(mapView)
+
+                  // Temporary fix to avoid loading too much parkings when zoomed out
+                  if (mapView.mapboxMap.cameraState.zoom > thresholdDisplayZoom) {
+                    parkingViewModel.getParkingsInRect(currentBottomLeft, currentTopRight)
+                  }
+                  // On zoom-out past the threshold, switch to the markers mode
+                  if (mapView.mapboxMap.cameraState.zoom < ADVANCED_MODE_ZOOM_THRESHOLD &&
+                      zoomState.value >= ADVANCED_MODE_ZOOM_THRESHOLD) {
+                    mapViewModel.updateMapMode(MapViewModel.MapMode.MARKERS)
+                  }
+                  // On zoomin in past the threshold, switch to the user's selected mode
+                  if (mapView.mapboxMap.cameraState.zoom >= ADVANCED_MODE_ZOOM_THRESHOLD &&
+                      zoomState.value < ADVANCED_MODE_ZOOM_THRESHOLD) {
+                    mapViewModel.updateMapMode(userMapMode.value)
+                  }
+
+                  // store the zoom level
+                  // This must stay at the end of the listener.
+                  zoomState.value = mapView.mapboxMap.cameraState.zoom
+                }
+                // =======================  CAMERA  LISTENER  =======================
+
+                onDispose {
+                  pLabelAnnotationManager?.deleteAll()
+                  rectangleAnnotationManager?.deleteAll()
+                  markerAnnotationManager?.deleteAll()
+                  mapViewModel.removePreviewCard()
+                  mapViewModel.updateViewAnnotationManager(null)
+                }
+              }
+            }
+
+        // ======================= OVERLAY =======================
+        Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+          // A switch to change the display mode
+          Row(
+              modifier =
+                  Modifier.align(Alignment.TopStart)
+                      .padding(start = 8.dp, top = 32.dp)
+                      .alpha(alpha),
+              verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    stringResource(R.string.map_screen_mode_switch_label),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
+                Switch(
+                    modifier = Modifier.padding(start = 8.dp),
+                    checked = mapMode.value.isAdvancedMode,
+                    onCheckedChange = {
+                      mapViewModel.updateUserMapMode(
+                          if (it) MapViewModel.MapMode.RECTANGLES else MapViewModel.MapMode.MARKERS)
+                      mapViewModel.updateMapMode(userMapMode.value)
+                    },
+                    colors =
+                        SwitchDefaults.colors()
+                            .copy(
+                                uncheckedTrackColor = disabledColor(),
+                            ))
+              }
+
+          ZoomControls(
+              modifier = Modifier.align(Alignment.TopEnd),
+              onZoomIn = {
+                mapViewModel.removePreviewCard()
+                mapViewportState.setCameraOptions {
+                  zoom(mapViewportState.cameraState!!.zoom + 1.0)
+                }
+              },
+              onZoomOut = {
+                mapViewModel.removePreviewCard()
+                mapViewportState.setCameraOptions {
+                  zoom(mapViewportState.cameraState!!.zoom - 1.0)
+                }
+              })
+
+          if (locationEnabled) {
+            IconButton(
+                icon = Icons.Default.MyLocation,
+                contentDescription = "Recenter on Location",
+                modifier =
+                    Modifier.align(Alignment.BottomEnd)
+                        .padding(bottom = 25.dp, end = 16.dp)
+                        .scale(1.2f)
+                        .testTag("recenterButton"),
+                onClick = {
+                  mapViewModel.removePreviewCard()
+                  mapViewModel.updateTrackingMode(true)
+                  mapViewportState.transitionToFollowPuckState(
+                      FollowPuckViewportStateOptions.Builder()
+                          .pitch(0.0)
+                          .zoom(maxZoom)
+                          .padding(EdgeInsets(100.0, 100.0, 100.0, 100.0))
+                          .build())
+                },
+                colorLevel =
+                    if (mapViewModel.isTrackingModeEnable.collectAsState().value)
+                        ColorLevel.SECONDARY
+                    else ColorLevel.PRIMARY)
+          }
+
+          if (enableParkingAddition) {
+            IconButton(
+                icon = Icons.Default.Add,
+                contentDescription = "Add parking spots",
+                modifier =
+                    Modifier.align(Alignment.BottomStart)
+                        .scale(1.2f)
+                        .padding(bottom = 25.dp, start = 16.dp),
+                onClick = {
+                  mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
+                  navigationActions.navigateTo(Route.ADD_SPOTS)
+                },
+                colorLevel = ColorLevel.PRIMARY,
+                testTag = "addButton")
+          }
+        }
       }
-    }
-  }
-}
-
-/**
- * Draw the rectangles on the map
- *
- * @param polygonAnnotationManager the polygon annotation manager
- * @param parkingsList the list of locations to draw
- */
-fun drawRectangles(
-    polygonAnnotationManager: PolygonAnnotationManager?,
-    plabelAnnotationManager: PointAnnotationManager?,
-    parkingsList: List<Parking>
-) {
-  val annotations: MutableList<PolygonAnnotationOptions> = mutableListOf()
-  parkingsList.map { parking ->
-    val location = parking.location
-    val topLeft = location.topLeft
-    val topRight = location.topRight
-    val bottomLeft = location.bottomLeft
-    val bottomRight = location.bottomRight
-    if (topLeft != null && topRight != null && bottomLeft != null && bottomRight != null) {
-      val polygon = location.toPolygon()
-
-      val polygonAnnotationOptions =
-          PolygonAnnotationOptions()
-              .withGeometry(polygon)
-              .withFillColor("#1A4988")
-              .withFillOpacity(0.7)
-              .withData(Gson().toJsonTree(parking))
-      annotations.add(polygonAnnotationOptions)
-      val area = TurfMeasurement.area(polygon)
-      val labelAnnotationOption =
-          PointAnnotationOptions()
-              .withPoint(location.center)
-              .withTextField("P")
-              .withTextSize(if (area < 30) 5.0 else 10.0)
-              .withTextColor("#FFFFFF")
-              .withTextHaloColor("#FFFFFF")
-              .withTextHaloWidth(0.2)
-      plabelAnnotationManager?.create(labelAnnotationOption)
-    }
-  }
-  polygonAnnotationManager?.create(annotations)
-}
-
-/**
- * Draw markers on the map.
- *
- * @param pointAnnotationManager the PointAnnotationManager to draw the markers on
- * @param parkingList the list of parkings to draw
- * @param bitmap the bitmap to use for the markers
- */
-private fun drawMarkers(
-    pointAnnotationManager: PointAnnotationManager?,
-    parkingList: List<Parking>,
-    bitmap: Bitmap,
-) {
-  parkingList.forEach {
-    pointAnnotationManager?.create(
-        PointAnnotationOptions()
-            .withPoint(it.location.center)
-            .withIconImage(bitmap)
-            .withIconAnchor(IconAnchor.BOTTOM)
-            .withIconOffset(listOf(0.0, bitmap.height / 12.0))
-            .withData(Gson().toJsonTree(it)))
-  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
@@ -100,10 +101,10 @@ fun MapScreen(
   val enableParkingAddition by userViewModel.isSignedIn.collectAsState(false)
 
   // create a remember  state to store if the markers or the rectangles are displayed
-  val mapMode = mapViewModel.mapMode.collectAsState()
+  val mapMode: State<MapViewModel.MapMode> = mapViewModel.mapMode.collectAsState()
 
   // this is the Map mode the user selected
-  val userMapMode = mapViewModel.userMapMode.collectAsState()
+  val userMapMode: State<MapViewModel.MapMode> = mapViewModel.userMapMode.collectAsState()
 
   // Create the viewport state from the MapViewModel
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
@@ -396,9 +397,10 @@ fun MapScreen(
                     modifier = Modifier.padding(start = 8.dp),
                     checked = mapMode.value.isAdvancedMode,
                     onCheckedChange = {
-                      mapViewModel.updateUserMapMode(
-                          if (it) MapViewModel.MapMode.RECTANGLES else MapViewModel.MapMode.MARKERS)
-                      mapViewModel.updateMapMode(userMapMode.value)
+                      val futurMapMode =
+                          if (it) MapViewModel.MapMode.RECTANGLES else MapViewModel.MapMode.MARKERS
+                      mapViewModel.updateUserMapMode(futurMapMode)
+                      mapViewModel.updateMapMode(futurMapMode)
                     },
                     colors =
                         SwitchDefaults.colors()

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -49,6 +49,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: Use
                   user,
                   {
                     userViewModel.setCurrentUser(user)
+                    userViewModel.updateUser(user, context)
                     Toast.makeText(context, validationToastText, Toast.LENGTH_SHORT).show()
                     navigationActions.navigateTo(TopLevelDestinations.MAP)
                   },


### PR DESCRIPTION
Closes #296 #275 

## What is the Content of this PR ? 

This PR does the following : 

1. Addresses the bug that makes the camera State and the advanced mode not persistent during screen navigations
2. Add some Documentation 
3. Refactor `MapScreen` logic into `MapViewModel` to prevent persistency bugs. 

## How ? 

1. For the Advanced mode, simply refactoring the variable to the `MapViewModel` was enough to make it persistent during screen Navigation. For the Camera State , I updated the variable `cameraPosition` inside all the OnClick lambdas that are linked to a button leaving the screen. I also created the Boolean `cameraRecentering` in the  `MapViewModel` to enable the `LaunchedEffect` that recenters the camera on the puck only when the map is initialized the first time. Then it is disabled by the boolean. 
2. Added Documentation to the different variables initialized at the beginning of `MapScreen.kt` 
3. Alongside the variables that were refactored, i also refactored `DrawRectangles` and `DrawMarkers` and the enum `MapMode` that were inside `MapScreen` to `MapViewModel` 

## Code Coverage
![image](https://github.com/user-attachments/assets/bc1c5149-cc14-46cb-94a6-3fe268981ca6)

I modified:

- ui.map (coverage 74% impossible to fix due to the same problem as previous PR) 
- model.map (coverage 82%)

## Additional Infos 

This PR also implements the fix of issue #296 since it is a one-liner solution. 