### PR TITLE
Add Report Screens

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockParkingRepository.kt
@@ -14,7 +14,7 @@ class MockParkingRepository @Inject constructor() : ParkingRepository {
   private val reports =
       mutableListOf(
           ParkingReport(
-              "1", ParkingReportReason.INEXISTANT, "1", TestInstancesParking.parking1.uid))
+              "1", ParkingReportReason.INEXISTANT, "1", TestInstancesParking.parking1.uid, ""))
 
   override fun getNewUid(): String {
     return (uid++).toString()

--- a/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockReviewRepository.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/di/mocks/MockReviewRepository.kt
@@ -12,7 +12,7 @@ class MockReviewRepository @Inject constructor() : ReviewRepository {
   private val reviews = mutableListOf<Review>()
   private val reports =
       mutableListOf(
-          ReviewReport("1", ReviewReportReason.HARMFUL, "1", TestInstancesReview.review1.uid))
+          ReviewReport("1", ReviewReportReason.HARMFUL, "1", TestInstancesReview.review1.uid, ""))
 
   override fun getNewUid(): String {
     return (uid++).toString()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ParkingReportScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ParkingReportScreenTest.kt
@@ -1,0 +1,134 @@
+package com.github.se.cyrcle.ui.report
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.di.mocks.*
+import com.github.se.cyrcle.model.parking.ParkingRepository
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.parking.TestInstancesParking
+import com.github.se.cyrcle.model.report.ReportedObjectRepository
+import com.github.se.cyrcle.model.review.ReviewRepository
+import com.github.se.cyrcle.model.review.ReviewViewModel
+import com.github.se.cyrcle.model.user.UserRepository
+import com.github.se.cyrcle.model.user.UserViewModel
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@RunWith(AndroidJUnit4::class)
+class ParkingReportScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var parkingRepository: ParkingRepository
+  private lateinit var userRepository: UserRepository
+  private lateinit var reviewRepository: ReviewRepository
+  private lateinit var reportedObjectRepository: ReportedObjectRepository
+
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var parkingViewModel: ParkingViewModel
+  private lateinit var reviewViewModel: ReviewViewModel
+
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
+    parkingRepository = MockParkingRepository()
+    userRepository = MockUserRepository()
+    reviewRepository = MockReviewRepository()
+    reportedObjectRepository = MockReportedObjectRepository()
+
+    parkingViewModel =
+        ParkingViewModel(MockImageRepository(), parkingRepository, reportedObjectRepository)
+    userViewModel =
+        UserViewModel(
+            userRepository,
+            parkingRepository,
+            MockImageRepository(),
+            MockAuthenticationRepository())
+    reviewViewModel = ReviewViewModel(reviewRepository, reportedObjectRepository)
+
+    parkingViewModel.addParking(TestInstancesParking.parking2)
+    parkingViewModel.addParking(TestInstancesParking.parking3)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.PARKING_DETAILS)
+  }
+
+  @Test
+  fun parkingReportScreen_displaysCorrectly() {
+    composeTestRule.setContent {
+      ParkingReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel)
+    }
+
+    // Assert that the report title is displayed
+    composeTestRule.onNodeWithTag("ReportTitleText").assertIsDisplayed()
+
+    // Assert that the bullet points section is displayed
+    composeTestRule.onNodeWithTag("ReportBulletPoints").assertExists()
+
+    // Assert that the dropdown for reason selection is displayed
+    composeTestRule.onNodeWithTag("ReasonDropDown").assertExists()
+
+    // Assert that the input field for additional details is displayed
+    composeTestRule.onNodeWithTag("ReportDetailsInput").assertExists()
+
+    // Assert that the submit button is displayed
+    composeTestRule.onNodeWithTag("SubmitButton").assertExists()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun submitButton_displaysDialog_whenClicked() {
+    composeTestRule.setContent {
+      ParkingReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel)
+    }
+
+    // Click on the submit button
+    composeTestRule.onNodeWithTag("SubmitButton").performClick()
+    // Assert that the dialog exists
+    composeTestRule.onNodeWithTag("ReportScreenAlertDialog").assertExists()
+  }
+
+  @Test
+  fun detailsInput_acceptsTextInput() {
+    composeTestRule.setContent {
+      ParkingReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel)
+    }
+
+    // Enter text in the details input field
+    val detailsText = "This parking has accessibility issues."
+    composeTestRule.onNodeWithTag("ReportDetailsInput").performTextInput(detailsText)
+
+    // Assert that the input field contains the entered text
+    composeTestRule.onNodeWithTag("ReportDetailsInput").assertTextContains(detailsText)
+  }
+
+  @Test
+  fun reasonDropDown_isClickable() {
+    composeTestRule.setContent {
+      ParkingReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("ReasonDropDown").performClick()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ParkingReportScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ParkingReportScreenTest.kt
@@ -10,6 +10,7 @@ import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.report.ReportedObjectRepository
 import com.github.se.cyrcle.model.review.ReviewRepository
 import com.github.se.cyrcle.model.review.ReviewViewModel
+import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -54,6 +55,7 @@ class ParkingReportScreenTest {
             parkingRepository,
             MockImageRepository(),
             MockAuthenticationRepository())
+    userViewModel.setCurrentUser(TestInstancesUser.user1)
     reviewViewModel = ReviewViewModel(reviewRepository, reportedObjectRepository)
 
     parkingViewModel.addParking(TestInstancesParking.parking2)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ParkingReportScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ParkingReportScreenTest.kt
@@ -63,7 +63,7 @@ class ParkingReportScreenTest {
   }
 
   @Test
-  fun parkingReportScreen_displaysCorrectly() {
+  fun parkingReportScreenDisplaysCorrectly() {
     composeTestRule.setContent {
       ParkingReportScreen(
           navigationActions = navigationActions,
@@ -89,7 +89,7 @@ class ParkingReportScreenTest {
 
   @OptIn(ExperimentalTestApi::class)
   @Test
-  fun submitButton_displaysDialog_whenClicked() {
+  fun submitButtonDisplaysDialogWhenClicked() {
     composeTestRule.setContent {
       ParkingReportScreen(
           navigationActions = navigationActions,
@@ -104,7 +104,7 @@ class ParkingReportScreenTest {
   }
 
   @Test
-  fun detailsInput_acceptsTextInput() {
+  fun detailsInputAcceptsTextInput() {
     composeTestRule.setContent {
       ParkingReportScreen(
           navigationActions = navigationActions,
@@ -121,7 +121,7 @@ class ParkingReportScreenTest {
   }
 
   @Test
-  fun reasonDropDown_isClickable() {
+  fun reasonDropDownIsClickable() {
     composeTestRule.setContent {
       ParkingReportScreen(
           navigationActions = navigationActions,

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialogTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialogTest.kt
@@ -1,0 +1,75 @@
+package com.github.se.cyrcle.ui.report
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReportScreenAlertDialogTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun dialogDisplaysCorrectContent() {
+    composeTestRule.setContent { ReportScreenAlertDialog(onDismiss = {}, onAccept = {}) }
+
+    // Check that the dialog is displayed
+    composeTestRule.onNodeWithTag("ReportScreenAlertDialog").assertIsDisplayed()
+
+    // Check the title
+    composeTestRule.onNodeWithTag("AlertDialogTitle").assertTextEquals("Are You Sure?")
+
+    // Check the content text
+    composeTestRule
+        .onNodeWithTag("AlertDialogContent")
+        .assertTextContains(
+            "We take reports very seriously. Please make sure that the information you have mentioned is accurate. If enough users also submit reports on this object, it will be flagged for administrator review. Do you still want to add this Report?")
+
+    // Check for "Yes" and "No" buttons
+    composeTestRule.onNodeWithTag("CancelButton").assertIsDisplayed().assertTextEquals("No")
+
+    composeTestRule.onNodeWithTag("AcceptButton").assertIsDisplayed().assertTextEquals("Yes")
+  }
+
+  @Test
+  fun dismissButtonWorksCorrectly() {
+    var isDismissed = false
+    composeTestRule.setContent {
+      ReportScreenAlertDialog(onDismiss = { isDismissed = true }, onAccept = {})
+    }
+
+    // Click on the "No" button
+    composeTestRule.onNodeWithTag("CancelButton").performClick()
+
+    // Verify the dismissal action
+    assert(isDismissed)
+  }
+
+  @Test
+  fun acceptButtonWorksCorrectly() {
+    var isAccepted = false
+    composeTestRule.setContent {
+      ReportScreenAlertDialog(onDismiss = {}, onAccept = { isAccepted = true })
+    }
+
+    // Click on the "Yes" button
+    composeTestRule.onNodeWithTag("AcceptButton").performClick()
+
+    // Verify the acceptance action
+    assert(isAccepted)
+  }
+
+  @Test
+  fun buttonsHaveCorrectArrangement() {
+    composeTestRule.setContent { ReportScreenAlertDialog(onDismiss = {}, onAccept = {}) }
+
+    // Check that buttons are horizontally aligned
+    composeTestRule
+        .onNodeWithTag("AlertDialogButtons")
+        .assert(hasAnyChild(hasTestTag("CancelButton")))
+        .assert(hasAnyChild(hasTestTag("AcceptButton")))
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReviewReportScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReviewReportScreenTest.kt
@@ -68,7 +68,7 @@ class ReviewReportScreenTest {
   }
 
   @Test
-  fun reviewReportScreen_displaysCorrectly() {
+  fun reviewReportScreenDisplaysCorrectly() {
     composeTestRule.setContent {
       ReviewReportScreen(
           navigationActions = navigationActions,
@@ -94,7 +94,7 @@ class ReviewReportScreenTest {
 
   @OptIn(ExperimentalTestApi::class)
   @Test
-  fun submitButton_displaysDialog_whenClicked() {
+  fun submitButtonDisplaysDialogWhenClicked() {
     composeTestRule.setContent {
       ReviewReportScreen(
           navigationActions = navigationActions,
@@ -114,7 +114,7 @@ class ReviewReportScreenTest {
   }
 
   @Test
-  fun detailsInput_acceptsTextInput() {
+  fun detailsInputAcceptsTextInput() {
     composeTestRule.setContent {
       ReviewReportScreen(
           navigationActions = navigationActions,
@@ -129,7 +129,7 @@ class ReviewReportScreenTest {
   }
 
   @Test
-  fun reasonDropDown_isClickable() {
+  fun reasonDropDownIsClickable() {
     composeTestRule.setContent {
       ParkingReportScreen(
           navigationActions = navigationActions,

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReviewReportScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReviewReportScreenTest.kt
@@ -15,6 +15,7 @@ import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.report.ReportedObjectRepository
 import com.github.se.cyrcle.model.review.ReviewRepository
 import com.github.se.cyrcle.model.review.ReviewViewModel
+import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -63,6 +64,8 @@ class ReviewReportScreenTest {
 
     parkingViewModel.addParking(TestInstancesParking.parking2)
     parkingViewModel.addParking(TestInstancesParking.parking3)
+
+    userViewModel.setCurrentUser(TestInstancesUser.user1)
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PARKING_DETAILS)
   }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReviewReportScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/report/ReviewReportScreenTest.kt
@@ -1,0 +1,142 @@
+package com.github.se.cyrcle.ui.report
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.di.mocks.MockAuthenticationRepository
+import com.github.se.cyrcle.di.mocks.MockImageRepository
+import com.github.se.cyrcle.di.mocks.MockParkingRepository
+import com.github.se.cyrcle.di.mocks.MockReportedObjectRepository
+import com.github.se.cyrcle.di.mocks.MockReviewRepository
+import com.github.se.cyrcle.di.mocks.MockUserRepository
+import com.github.se.cyrcle.model.parking.ParkingRepository
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.parking.TestInstancesParking
+import com.github.se.cyrcle.model.report.ReportedObjectRepository
+import com.github.se.cyrcle.model.review.ReviewRepository
+import com.github.se.cyrcle.model.review.ReviewViewModel
+import com.github.se.cyrcle.model.user.UserRepository
+import com.github.se.cyrcle.model.user.UserViewModel
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@RunWith(AndroidJUnit4::class)
+class ReviewReportScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var parkingRepository: ParkingRepository
+  private lateinit var userRepository: UserRepository
+  private lateinit var reviewRepository: ReviewRepository
+  private lateinit var reportedObjectRepository: ReportedObjectRepository
+
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var parkingViewModel: ParkingViewModel
+  private lateinit var reviewViewModel: ReviewViewModel
+
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
+    parkingRepository = MockParkingRepository()
+    userRepository = MockUserRepository()
+    reviewRepository = MockReviewRepository()
+    reportedObjectRepository = MockReportedObjectRepository()
+
+    parkingViewModel =
+        ParkingViewModel(MockImageRepository(), parkingRepository, reportedObjectRepository)
+    userViewModel =
+        UserViewModel(
+            userRepository,
+            parkingRepository,
+            MockImageRepository(),
+            MockAuthenticationRepository())
+    reviewViewModel = ReviewViewModel(reviewRepository, reportedObjectRepository)
+
+    parkingViewModel.addParking(TestInstancesParking.parking2)
+    parkingViewModel.addParking(TestInstancesParking.parking3)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.PARKING_DETAILS)
+  }
+
+  @Test
+  fun reviewReportScreen_displaysCorrectly() {
+    composeTestRule.setContent {
+      ReviewReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          reviewViewModel = reviewViewModel)
+    }
+
+    // Assert that the title is displayed
+    composeTestRule.onNodeWithTag("ReportTitle").assertIsDisplayed()
+
+    // Assert that bullet points are displayed
+    composeTestRule.onNodeWithTag("ReportBulletPoints").assertExists()
+
+    // Assert that the reason dropdown is displayed
+    composeTestRule.onNodeWithTag("ReasonDropdown").assertExists()
+
+    // Assert that the details input field is displayed
+    composeTestRule.onNodeWithTag("DetailsInput").assertExists()
+
+    // Assert that the submit button is displayed
+    composeTestRule.onNodeWithTag("SubmitButton").assertExists()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun submitButton_displaysDialog_whenClicked() {
+    composeTestRule.setContent {
+      ReviewReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          reviewViewModel = reviewViewModel)
+    }
+
+    // Click on the submit button
+    composeTestRule.onNodeWithTag("SubmitButton").performClick()
+
+    // Wait for the dialog
+    composeTestRule.waitUntilAtLeastOneExists(
+        hasTestTag("ReportScreenAlertDialog"), timeoutMillis = 5000)
+
+    // Assert that the dialog exists
+    composeTestRule.onNodeWithTag("ReportScreenAlertDialog").assertExists()
+  }
+
+  @Test
+  fun detailsInput_acceptsTextInput() {
+    composeTestRule.setContent {
+      ReviewReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          reviewViewModel = reviewViewModel)
+    }
+
+    val testInput = "This review is misleading."
+
+    composeTestRule.onNodeWithTag("DetailsInput").performTextInput(testInput)
+    composeTestRule.onNodeWithTag("DetailsInput").assertTextContains(testInput)
+  }
+
+  @Test
+  fun reasonDropDown_isClickable() {
+    composeTestRule.setContent {
+      ParkingReportScreen(
+          navigationActions = navigationActions,
+          userViewModel = userViewModel,
+          parkingViewModel = parkingViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("ReasonDropDown").performClick()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/review/AllReviewsScreenTest.kt
@@ -67,14 +67,13 @@ class AllReviewsScreenTest {
   }
 
   @Test
-  fun allReviewsScreen_displaysTopBarAndList() {
+  fun allReviewsScreen_displaysList() {
 
     composeTestRule.setContent {
       AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
       userViewModel.setCurrentUser(TestInstancesUser.user1)
     }
 
-    composeTestRule.onNodeWithTag("AllReviewsScreenBox").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ReviewCard0").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ReviewCard1").assertIsDisplayed()
   }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -23,6 +23,8 @@ import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.parkingDetails.ParkingDetailsScreen
 import com.github.se.cyrcle.ui.profile.CreateProfileScreen
 import com.github.se.cyrcle.ui.profile.ProfileScreen
+import com.github.se.cyrcle.ui.report.ParkingReportScreen
+import com.github.se.cyrcle.ui.report.ReviewReportScreen
 import com.github.se.cyrcle.ui.review.AllReviewsScreen
 import com.github.se.cyrcle.ui.review.ReviewScreen
 
@@ -37,63 +39,69 @@ fun CyrcleNavHost(
     addressViewModel: AddressViewModel,
     permissionHandler: PermissionHandler
 ) {
-  NavHost(navController = navController, startDestination = Route.AUTH) {
-    navigation(
-        startDestination = Screen.AUTH,
-        route = Route.AUTH,
-    ) {
-      composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
-      composable(Screen.CREATE_PROFILE) { CreateProfileScreen(navigationActions, userViewModel) }
-    }
+    NavHost(navController = navController, startDestination = Route.AUTH) {
+        navigation(
+            startDestination = Screen.AUTH,
+            route = Route.AUTH,
+        ) {
+            composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
+            composable(Screen.CREATE_PROFILE) { CreateProfileScreen(navigationActions, userViewModel) }
+        }
 
-    navigation(
-        startDestination = Screen.LIST,
-        route = Route.LIST,
-    ) {
-      composable(Screen.LIST) {
-        SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
-      }
-      composable(Screen.PARKING_DETAILS) {
-        ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
-      }
-    }
-    navigation(
-        startDestination = Screen.ALL_REVIEWS,
-        route = Route.REVIEW,
-    ) {
-      composable(Screen.ADD_REVIEW) {
-        ReviewScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
-      }
-      composable(Screen.ALL_REVIEWS) {
-        AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
-      }
-    }
+        navigation(
+            startDestination = Screen.LIST,
+            route = Route.LIST,
+        ) {
+            composable(Screen.LIST) {
+                SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
+            }
+            composable(Screen.PARKING_DETAILS) {
+                ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+            }
+        }
+        navigation(
+            startDestination = Screen.ALL_REVIEWS,
+            route = Route.REVIEW,
+        ) {
+            composable(Screen.ADD_REVIEW) {
+                ReviewScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+            }
+            composable(Screen.ALL_REVIEWS) {
+                AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+            }
+            composable(Screen.PARKING_REPORT) {
+                ParkingReportScreen(navigationActions,userViewModel,parkingViewModel)
+            }
+            composable(Screen.REVIEW_REPORT) {
+                ReviewReportScreen(navigationActions,userViewModel,reviewViewModel)
+            }
+        }
 
-    navigation(
-        startDestination = Screen.MAP,
-        route = Route.MAP,
-    ) {
-      composable(Screen.MAP) {
-        MapScreen(
-            navigationActions, parkingViewModel, userViewModel, mapViewModel, permissionHandler)
-      }
-    }
+        navigation(
+            startDestination = Screen.MAP,
+            route = Route.MAP,
+        ) {
+            composable(Screen.MAP) {
+                MapScreen(
+                    navigationActions, parkingViewModel, userViewModel, mapViewModel, permissionHandler)
+            }
+        }
 
-    navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
-      composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, mapViewModel) }
-      composable(Screen.ATTRIBUTES_PICKER) {
-        AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
-      }
-      composable(Screen.RACK_INFO) { RackTypeHelpScreen(navigationActions) }
-    }
+        navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
+            composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, mapViewModel) }
+            composable(Screen.ATTRIBUTES_PICKER) {
+                AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
+            }
+            composable(Screen.RACK_INFO) { RackTypeHelpScreen(navigationActions) }
+        }
 
-    navigation(
-        startDestination = Screen.VIEW_PROFILE,
-        route = Route.VIEW_PROFILE,
-    ) {
-      composable(Screen.VIEW_PROFILE) {
-        ProfileScreen(navigationActions, userViewModel, parkingViewModel)
-      }
+        navigation(
+            startDestination = Screen.VIEW_PROFILE,
+            route = Route.VIEW_PROFILE,
+        ) {
+            composable(Screen.VIEW_PROFILE) {
+                ProfileScreen(navigationActions, userViewModel, parkingViewModel)
+            }
+        }
     }
-  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -58,6 +58,9 @@ fun CyrcleNavHost(
       composable(Screen.PARKING_DETAILS) {
         ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
       }
+      composable(Screen.PARKING_REPORT) {
+        ParkingReportScreen(navigationActions, userViewModel, parkingViewModel)
+      }
     }
     navigation(
         startDestination = Screen.ALL_REVIEWS,
@@ -68,9 +71,6 @@ fun CyrcleNavHost(
       }
       composable(Screen.ALL_REVIEWS) {
         AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
-      }
-      composable(Screen.PARKING_REPORT) {
-        ParkingReportScreen(navigationActions, userViewModel, parkingViewModel)
       }
       composable(Screen.REVIEW_REPORT) {
         ReviewReportScreen(navigationActions, userViewModel, reviewViewModel)

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -39,69 +39,69 @@ fun CyrcleNavHost(
     addressViewModel: AddressViewModel,
     permissionHandler: PermissionHandler
 ) {
-    NavHost(navController = navController, startDestination = Route.AUTH) {
-        navigation(
-            startDestination = Screen.AUTH,
-            route = Route.AUTH,
-        ) {
-            composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
-            composable(Screen.CREATE_PROFILE) { CreateProfileScreen(navigationActions, userViewModel) }
-        }
-
-        navigation(
-            startDestination = Screen.LIST,
-            route = Route.LIST,
-        ) {
-            composable(Screen.LIST) {
-                SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
-            }
-            composable(Screen.PARKING_DETAILS) {
-                ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
-            }
-        }
-        navigation(
-            startDestination = Screen.ALL_REVIEWS,
-            route = Route.REVIEW,
-        ) {
-            composable(Screen.ADD_REVIEW) {
-                ReviewScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
-            }
-            composable(Screen.ALL_REVIEWS) {
-                AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
-            }
-            composable(Screen.PARKING_REPORT) {
-                ParkingReportScreen(navigationActions,userViewModel,parkingViewModel)
-            }
-            composable(Screen.REVIEW_REPORT) {
-                ReviewReportScreen(navigationActions,userViewModel,reviewViewModel)
-            }
-        }
-
-        navigation(
-            startDestination = Screen.MAP,
-            route = Route.MAP,
-        ) {
-            composable(Screen.MAP) {
-                MapScreen(
-                    navigationActions, parkingViewModel, userViewModel, mapViewModel, permissionHandler)
-            }
-        }
-
-        navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
-            composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, mapViewModel) }
-            composable(Screen.ATTRIBUTES_PICKER) {
-                AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
-            }
-            composable(Screen.RACK_INFO) { RackTypeHelpScreen(navigationActions) }
-        }
-
-        navigation(
-            startDestination = Screen.VIEW_PROFILE,
-            route = Route.VIEW_PROFILE,
-        ) {
-            composable(Screen.VIEW_PROFILE) {
-                ProfileScreen(navigationActions, userViewModel, parkingViewModel)
-            }
-        }
+  NavHost(navController = navController, startDestination = Route.AUTH) {
+    navigation(
+        startDestination = Screen.AUTH,
+        route = Route.AUTH,
+    ) {
+      composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
+      composable(Screen.CREATE_PROFILE) { CreateProfileScreen(navigationActions, userViewModel) }
     }
+
+    navigation(
+        startDestination = Screen.LIST,
+        route = Route.LIST,
+    ) {
+      composable(Screen.LIST) {
+        SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
+      }
+      composable(Screen.PARKING_DETAILS) {
+        ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      }
+    }
+    navigation(
+        startDestination = Screen.ALL_REVIEWS,
+        route = Route.REVIEW,
+    ) {
+      composable(Screen.ADD_REVIEW) {
+        ReviewScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+      }
+      composable(Screen.ALL_REVIEWS) {
+        AllReviewsScreen(navigationActions, parkingViewModel, reviewViewModel, userViewModel)
+      }
+      composable(Screen.PARKING_REPORT) {
+        ParkingReportScreen(navigationActions, userViewModel, parkingViewModel)
+      }
+      composable(Screen.REVIEW_REPORT) {
+        ReviewReportScreen(navigationActions, userViewModel, reviewViewModel)
+      }
+    }
+
+    navigation(
+        startDestination = Screen.MAP,
+        route = Route.MAP,
+    ) {
+      composable(Screen.MAP) {
+        MapScreen(
+            navigationActions, parkingViewModel, userViewModel, mapViewModel, permissionHandler)
+      }
+    }
+
+    navigation(startDestination = Screen.LOCATION_PICKER, route = Route.ADD_SPOTS) {
+      composable(Screen.LOCATION_PICKER) { LocationPicker(navigationActions, mapViewModel) }
+      composable(Screen.ATTRIBUTES_PICKER) {
+        AttributesPicker(navigationActions, parkingViewModel, mapViewModel, addressViewModel)
+      }
+      composable(Screen.RACK_INFO) { RackTypeHelpScreen(navigationActions) }
+    }
+
+    navigation(
+        startDestination = Screen.VIEW_PROFILE,
+        route = Route.VIEW_PROFILE,
+    ) {
+      composable(Screen.VIEW_PROFILE) {
+        ProfileScreen(navigationActions, userViewModel, parkingViewModel)
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/Parking.kt
@@ -43,7 +43,8 @@ data class ParkingReport(
     val uid: String,
     val reason: ParkingReportReason,
     val userId: String,
-    val parking: String
+    val parking: String,
+    val description: String
 )
 
 interface ParkingAttribute : DropDownableEnum

--- a/app/src/main/java/com/github/se/cyrcle/model/review/Review.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/Review.kt
@@ -27,5 +27,6 @@ data class ReviewReport(
     val uid: String,
     val reason: ReviewReportReason,
     val userId: String,
-    val review: String
+    val review: String,
+    val description: String
 )

--- a/app/src/main/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/ReviewRepositoryFirestore.kt
@@ -151,7 +151,8 @@ class ReviewRepositoryFirestore @Inject constructor(private val db: FirebaseFire
             "id" to report.uid,
             "reason" to report.reason,
             "user" to report.userId,
-            "review" to report.review)
+            "review" to report.review,
+            "description" to report.description)
     db.collection(collectionPath)
         .document(report.review)
         .collection("reports")

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -50,19 +50,19 @@ data class TopLevelDestination(val route: String, val icon: ImageVector, val tex
 /** Object containing the top level destinations in the app. */
 object TopLevelDestinations {
   val AUTH =
-    TopLevelDestination(route = Route.AUTH, icon = Icons.Outlined.Menu, textId = Route.AUTH)
+      TopLevelDestination(route = Route.AUTH, icon = Icons.Outlined.Menu, textId = Route.AUTH)
   val LIST =
-    TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
+      TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
   val MAP =
-    TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.LocationOn, textId = Route.MAP)
+      TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.LocationOn, textId = Route.MAP)
   val PROFILE =
-    TopLevelDestination(
-      route = Route.VIEW_PROFILE, icon = Icons.Outlined.Person, textId = Route.VIEW_PROFILE)
+      TopLevelDestination(
+          route = Route.VIEW_PROFILE, icon = Icons.Outlined.Person, textId = Route.VIEW_PROFILE)
 }
 
 /** List of top level destinations in the app. */
 val LIST_TOP_LEVEL_DESTINATION =
-  listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
+    listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
 
 /** Adapter class for navigating between screens in the app. */
 open class NavigationActions(private val navController: NavHostController) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -14,6 +14,8 @@ object Route {
   const val ADD_SPOTS = "Add Spots"
   const val VIEW_PROFILE = "Profile"
   const val REVIEW = "Review"
+  const val PARKING_REPORT = "Report"
+  const val REVIEW_REPORT = "Report"
 }
 
 object Screen {
@@ -32,6 +34,8 @@ object Screen {
   const val AUTH = "Auth Screen"
   const val VIEW_PROFILE = "Profile Screen"
   const val CREATE_PROFILE = "Create Profile"
+  const val PARKING_REPORT = "Parking Report Screen"
+  const val REVIEW_REPORT = "Review Report Screen"
 }
 
 /**
@@ -46,19 +50,19 @@ data class TopLevelDestination(val route: String, val icon: ImageVector, val tex
 /** Object containing the top level destinations in the app. */
 object TopLevelDestinations {
   val AUTH =
-      TopLevelDestination(route = Route.AUTH, icon = Icons.Outlined.Menu, textId = Route.AUTH)
+    TopLevelDestination(route = Route.AUTH, icon = Icons.Outlined.Menu, textId = Route.AUTH)
   val LIST =
-      TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
+    TopLevelDestination(route = Route.LIST, icon = Icons.Outlined.Menu, textId = Route.LIST)
   val MAP =
-      TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.LocationOn, textId = Route.MAP)
+    TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.LocationOn, textId = Route.MAP)
   val PROFILE =
-      TopLevelDestination(
-          route = Route.VIEW_PROFILE, icon = Icons.Outlined.Person, textId = Route.VIEW_PROFILE)
+    TopLevelDestination(
+      route = Route.VIEW_PROFILE, icon = Icons.Outlined.Person, textId = Route.VIEW_PROFILE)
 }
 
 /** List of top level destinations in the app. */
 val LIST_TOP_LEVEL_DESTINATION =
-    listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
+  listOf(TopLevelDestinations.MAP, TopLevelDestinations.LIST, TopLevelDestinations.PROFILE)
 
 /** Adapter class for navigating between screens in the app. */
 open class NavigationActions(private val navController: NavHostController) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -445,14 +445,7 @@ fun ParkingDetailsScreen(
                       Button(
                           text = stringResource(R.string.card_screen_report),
                           onClick = {
-                            parkingViewModel.addReport(
-                                ParkingReport(
-                                    "TEST1",
-                                    ParkingReportReason.INEXISTANT,
-                                    userViewModel.currentUser.value?.public?.userId ?: "TESTUSER",
-                                    selectedParking.uid),
-                                userViewModel.currentUser.value!!)
-                            Toast.makeText(context, "Report added!", Toast.LENGTH_LONG).show()
+                              navigationActions.navigateTo(Screen.PARKING_REPORT)
                           },
                           modifier = Modifier.fillMaxWidth(),
                           colorLevel = ColorLevel.ERROR,

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -51,8 +51,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.cyrcle.R
-import com.github.se.cyrcle.model.parking.ParkingReport
-import com.github.se.cyrcle.model.parking.ParkingReportReason
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.user.MAX_NOTE_LENGTH
 import com.github.se.cyrcle.model.user.UserViewModel
@@ -444,9 +442,7 @@ fun ParkingDetailsScreen(
                     if (userViewModel.currentUser.value != null) {
                       Button(
                           text = stringResource(R.string.card_screen_report),
-                          onClick = {
-                              navigationActions.navigateTo(Screen.PARKING_REPORT)
-                          },
+                          onClick = { navigationActions.navigateTo(Screen.PARKING_REPORT) },
                           modifier = Modifier.fillMaxWidth(),
                           colorLevel = ColorLevel.ERROR,
                           testTag = "ReportButton")

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
@@ -1,0 +1,183 @@
+package com.github.se.cyrcle.ui.report
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.*
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.parking.ParkingReport
+import com.github.se.cyrcle.model.parking.ParkingReportReason
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.review.ReviewViewModel
+import com.github.se.cyrcle.model.user.UserViewModel
+import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MAX_LENGTH
+import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MIN_LENGTH
+import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import com.github.se.cyrcle.ui.theme.Typography
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
+import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.disabledColor
+import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+fun ParkingReportScreen(
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+    parkingViewModel: ParkingViewModel,
+) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val screenHeight = configuration.screenHeightDp.dp
+    var showDialog = remember { mutableStateOf(false) }
+
+    // Define padding as a percentage of screen dimensions
+    val horizontalPaddingScaleFactor = screenWidth * 0.03f
+    val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
+    val verticalPaddingScaleFactor = screenHeight * 0.02f
+
+    // State for report inputs
+    val selectedReason = rememberSaveable { mutableStateOf<ParkingReportReason>(ParkingReportReason.INEXISTANT) }
+    val parkingId = parkingViewModel.selectedParking.value?.uid
+    val reportDescription = rememberSaveable { mutableStateOf<String>("") }
+    val userId = userViewModel.currentUser.value?.public?.userId
+
+    fun onSubmit() {
+        if (selectedReason.value != null) {
+            val report = ParkingReport(
+                uid = parkingViewModel.getNewUid(),
+                reason = selectedReason.value!!,
+                userId = if (userId != null) userId else "",
+                parking = parkingId!!,
+                description = reportDescription.value
+            )
+            parkingViewModel.addReport(report, userViewModel.currentUser.value!!)
+            navigationActions.goBack()
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag("ParkingReportScreen"),
+        topBar = {
+            TopAppBar(
+                navigationActions,
+                title = "Report Parking: ${parkingViewModel.selectedParking.value?.optName ?: parkingId}"
+            )
+        },
+    ) { padding ->
+        val scaledPaddingValues = PaddingValues(
+            horizontal = horizontalPaddingScaleFactor,
+            vertical = verticalPaddingScaleFactor
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaledPaddingValues)
+                .verticalScroll(rememberScrollState())
+                .testTag("ParkingReportColumn"),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(topBoxHeight)
+                    .background(MaterialTheme.colorScheme.background)
+            )
+
+            // Text Block Section
+            Text(
+                text = "The following will be submitted in your report:",
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Start
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, bottom = 16.dp), // Indent bullet points
+                verticalArrangement = Arrangement.spacedBy(8.dp) // Add space between points
+            ) {
+                BulletPoint("Your User Information")
+                BulletPoint("This Parking's information")
+                BulletPoint( "Reason + Description below")
+            }
+
+            // Select Reason
+            EnumDropDown(
+                options = ParkingReportReason.entries,
+                selectedValue = selectedReason,
+                label = "Reason for Reporting"
+            )
+
+            // Additional Details Input
+            ConditionCheckingInputText(
+                value = reportDescription.value,
+                onValueChange = { reportDescription.value = it },
+                label = "Additional Details (Optional)",
+                minCharacters = 0,
+                maxCharacters = 256,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPaddingScaleFactor)
+            )
+
+            val validInputs = areInputsValid(reportDescription.value)
+
+            if (showDialog.value) {
+                ReportScreenAlertDialog(onDismiss = {
+                    showDialog.value = false
+                }, onAccept = {
+                    showDialog.value = false
+                    if (validInputs) onSubmit()
+                    navigationActions.goBack()
+                })
+            }
+
+            Button(
+                onClick = { showDialog.value = true },
+                modifier = Modifier
+                    .testTag("submitButton")
+                    .padding(top = 16.dp).align(alignment = Alignment.CenterHorizontally),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)
+            ) {
+                Text(
+                    text = stringResource(R.string.attributes_picker_bottom_bar_submit_button),
+                    color = if (validInputs) MaterialTheme.colorScheme.primary else disabledColor(),
+                    fontWeight = FontWeight.Bold,
+                    style = Typography.headlineMedium,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+private fun areInputsValid(description: String): Boolean {
+    return description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
@@ -5,10 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.*
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -17,27 +14,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.parking.ParkingReport
 import com.github.se.cyrcle.model.parking.ParkingReportReason
 import com.github.se.cyrcle.model.parking.ParkingViewModel
-import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MAX_LENGTH
 import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MIN_LENGTH
-import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.Typography
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.disabledColor
 import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
+import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
@@ -46,138 +39,150 @@ fun ParkingReportScreen(
     userViewModel: UserViewModel,
     parkingViewModel: ParkingViewModel,
 ) {
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp.dp
-    val screenHeight = configuration.screenHeightDp.dp
-    var showDialog = remember { mutableStateOf(false) }
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp.dp
+  val screenHeight = configuration.screenHeightDp.dp
+  var showDialog by remember { mutableStateOf(false) }
 
-    // Define padding as a percentage of screen dimensions
-    val horizontalPaddingScaleFactor = screenWidth * 0.03f
-    val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
-    val verticalPaddingScaleFactor = screenHeight * 0.02f
+  // Define padding as a percentage of screen dimensions
+  val horizontalPaddingScaleFactor = screenWidth * 0.03f
+  val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
+  val verticalPaddingScaleFactor = screenHeight * 0.02f
 
-    // State for report inputs
-    val selectedReason = rememberSaveable { mutableStateOf<ParkingReportReason>(ParkingReportReason.INEXISTANT) }
-    val parkingId = parkingViewModel.selectedParking.value?.uid
-    val reportDescription = rememberSaveable { mutableStateOf<String>("") }
-    val userId = userViewModel.currentUser.value?.public?.userId
+  // State for report inputs
+  val selectedReason = rememberSaveable {
+    mutableStateOf<ParkingReportReason>(ParkingReportReason.INEXISTANT)
+  }
+  val parkingId = parkingViewModel.selectedParking.value?.uid
+  val reportDescription = rememberSaveable { mutableStateOf("") }
+  val userId = userViewModel.currentUser.value?.public?.userId
 
-    fun onSubmit() {
-        if (selectedReason.value != null) {
-            val report = ParkingReport(
-                uid = parkingViewModel.getNewUid(),
-                reason = selectedReason.value!!,
-                userId = if (userId != null) userId else "",
-                parking = parkingId!!,
-                description = reportDescription.value
-            )
-            parkingViewModel.addReport(report, userViewModel.currentUser.value!!)
-            navigationActions.goBack()
-        }
+  fun onSubmit() {
+    if (selectedReason.value != null) {
+      val report =
+          ParkingReport(
+              uid = parkingViewModel.getNewUid(),
+              reason = selectedReason.value,
+              userId = userId ?: "",
+              parking = parkingId!!,
+              description = reportDescription.value)
+      parkingViewModel.addReport(report, userViewModel.currentUser.value!!)
+      navigationActions.goBack()
     }
+  }
 
-    Scaffold(
-        modifier = Modifier.testTag("ParkingReportScreen"),
-        topBar = {
-            TopAppBar(
-                navigationActions,
-                title = "Report Parking: ${parkingViewModel.selectedParking.value?.optName ?: parkingId}"
-            )
-        },
-    ) { padding ->
-        val scaledPaddingValues = PaddingValues(
-            horizontal = horizontalPaddingScaleFactor,
-            vertical = verticalPaddingScaleFactor
-        )
+  Scaffold(
+      modifier = Modifier.testTag("ParkingReportScreen"),
+      topBar = {
+        TopAppBar(
+            navigationActions,
+            title =
+                stringResource(R.string.report_parking)
+                    .format(parkingViewModel.selectedParking.value?.optName ?: parkingId))
+      },
+  ) { padding ->
+    val scaledPaddingValues =
+        PaddingValues(
+            horizontal = horizontalPaddingScaleFactor, vertical = verticalPaddingScaleFactor)
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
                 .padding(scaledPaddingValues)
                 .verticalScroll(rememberScrollState())
                 .testTag("ParkingReportColumn"),
-            horizontalAlignment = Alignment.Start
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(topBoxHeight)
-                    .background(MaterialTheme.colorScheme.background)
-            )
+        horizontalAlignment = Alignment.Start) {
+          Box(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .height(topBoxHeight)
+                      .background(MaterialTheme.colorScheme.background)
+                      .testTag("TopBoxPadding"))
 
-            // Text Block Section
-            Text(
-                text = "The following will be submitted in your report:",
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Start
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-            )
+          // Text Block Section
+          Text(
+              text = stringResource(R.string.report_title),
+              style =
+                  MaterialTheme.typography.titleMedium.copy(
+                      fontWeight = FontWeight.Bold, textAlign = TextAlign.Start),
+              modifier =
+                  Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("ReportTitleText"))
 
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, bottom = 16.dp), // Indent bullet points
-                verticalArrangement = Arrangement.spacedBy(8.dp) // Add space between points
-            ) {
-                BulletPoint("Your User Information")
-                BulletPoint("This Parking's information")
-                BulletPoint( "Reason + Description below")
-            }
+          Column(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(start = 16.dp, bottom = 16.dp)
+                      .testTag("ReportBulletPoints"),
+              verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                BulletPoint(
+                    stringResource(R.string.report_bullet_point_1), testTag = "BulletPoint1")
+                BulletPoint(
+                    stringResource(R.string.report_bullet_point_2_parking),
+                    testTag = "BulletPoint2")
+                BulletPoint(
+                    stringResource(R.string.report_bullet_point_3), testTag = "BulletPoint3")
+              }
 
-            // Select Reason
-            EnumDropDown(
-                options = ParkingReportReason.entries,
-                selectedValue = selectedReason,
-                label = "Reason for Reporting"
-            )
+          // Select Reason
+          EnumDropDown(
+              options = ParkingReportReason.entries,
+              selectedValue = selectedReason,
+              label = stringResource(R.string.report_reason),
+              modifier = Modifier.testTag("ReasonDropDown"))
 
-            // Additional Details Input
-            ConditionCheckingInputText(
-                value = reportDescription.value,
-                onValueChange = { reportDescription.value = it },
-                label = "Additional Details (Optional)",
-                minCharacters = 0,
-                maxCharacters = 256,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = horizontalPaddingScaleFactor)
-            )
+          // Additional Details Input
+          ConditionCheckingInputText(
+              value = reportDescription.value,
+              onValueChange = { reportDescription.value = it },
+              label = stringResource(R.string.report_details),
+              minCharacters = 0,
+              maxCharacters = 256,
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(horizontal = horizontalPaddingScaleFactor)
+                      .testTag("ReportDetailsInput"))
 
-            val validInputs = areInputsValid(reportDescription.value)
+          val validInputs = areInputsValid(reportDescription.value)
 
-            if (showDialog.value) {
-                ReportScreenAlertDialog(onDismiss = {
-                    showDialog.value = false
-                }, onAccept = {
-                    showDialog.value = false
-                    if (validInputs) onSubmit()
-                    navigationActions.goBack()
+          if (showDialog) {
+            ReportScreenAlertDialog(
+                onDismiss = { showDialog = false },
+                onAccept = {
+                  showDialog = false
+                  if (validInputs) onSubmit()
+                  navigationActions.goBack()
                 })
-            }
+          }
 
-            Button(
-                onClick = { showDialog.value = true },
-                modifier = Modifier
-                    .testTag("submitButton")
-                    .padding(top = 16.dp).align(alignment = Alignment.CenterHorizontally),
-                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)
-            ) {
+          Button(
+              onClick = { showDialog = true },
+              modifier =
+                  Modifier.testTag("SubmitButton")
+                      .padding(top = 16.dp)
+                      .align(alignment = Alignment.CenterHorizontally),
+              colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
                 Text(
                     text = stringResource(R.string.attributes_picker_bottom_bar_submit_button),
                     color = if (validInputs) MaterialTheme.colorScheme.primary else disabledColor(),
                     fontWeight = FontWeight.Bold,
                     style = Typography.headlineMedium,
-                    textAlign = TextAlign.Center
-                )
-            }
+                    textAlign = TextAlign.Center)
+              }
         }
-    }
+  }
 }
 
-private fun areInputsValid(description: String): Boolean {
-    return description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
+@Composable
+fun BulletPoint(text: String, testTag: String) {
+  Row(modifier = Modifier.fillMaxWidth().testTag(testTag), verticalAlignment = Alignment.Top) {
+    Text(
+        text = "\u2022",
+        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+        modifier = Modifier.padding(end = 8.dp))
+    Text(text = text, style = MaterialTheme.typography.bodyLarge)
+  }
+}
+
+fun areInputsValid(description: String): Boolean {
+  return description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.cyrcle.ui.report
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -12,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -43,6 +45,7 @@ fun ParkingReportScreen(
   val screenWidth = configuration.screenWidthDp.dp
   val screenHeight = configuration.screenHeightDp.dp
   var showDialog by remember { mutableStateOf(false) }
+  val context = LocalContext.current
 
   // Define padding as a percentage of screen dimensions
   val horizontalPaddingScaleFactor = screenWidth * 0.03f
@@ -50,25 +53,22 @@ fun ParkingReportScreen(
   val verticalPaddingScaleFactor = screenHeight * 0.02f
 
   // State for report inputs
-  val selectedReason = rememberSaveable {
-    mutableStateOf<ParkingReportReason>(ParkingReportReason.INEXISTANT)
-  }
+  val selectedReason = rememberSaveable { mutableStateOf(ParkingReportReason.INEXISTANT) }
   val parkingId = parkingViewModel.selectedParking.value?.uid
   val reportDescription = rememberSaveable { mutableStateOf("") }
   val userId = userViewModel.currentUser.value?.public?.userId
 
   fun onSubmit() {
-    if (selectedReason.value != null) {
-      val report =
-          ParkingReport(
-              uid = parkingViewModel.getNewUid(),
-              reason = selectedReason.value,
-              userId = userId ?: "",
-              parking = parkingId!!,
-              description = reportDescription.value)
-      parkingViewModel.addReport(report, userViewModel.currentUser.value!!)
-      navigationActions.goBack()
-    }
+    val report =
+        ParkingReport(
+            uid = parkingViewModel.getNewUid(),
+            reason = selectedReason.value,
+            userId = userId ?: "",
+            parking = parkingId!!,
+            description = reportDescription.value)
+    parkingViewModel.addReport(report, userViewModel.currentUser.value!!)
+    Toast.makeText(context, "Report added", Toast.LENGTH_SHORT).show()
+    navigationActions.goBack()
   }
 
   Scaffold(

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
@@ -28,11 +28,15 @@ import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MAX_LENGTH
 import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MIN_LENGTH
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.Typography
+import com.github.se.cyrcle.ui.theme.atoms.BulletPoint
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.disabledColor
 import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+
+const val MAX_CHARACTERS = 256
+const val MAX_LINES = 6
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
@@ -136,7 +140,8 @@ fun ParkingReportScreen(
               onValueChange = { reportDescription.value = it },
               label = stringResource(R.string.report_details),
               minCharacters = 0,
-              maxCharacters = 256,
+              maxCharacters = MAX_CHARACTERS,
+              maxLines = MAX_LINES,
               modifier =
                   Modifier.fillMaxWidth()
                       .padding(horizontal = horizontalPaddingScaleFactor)
@@ -169,17 +174,6 @@ fun ParkingReportScreen(
                     textAlign = TextAlign.Center)
               }
         }
-  }
-}
-
-@Composable
-fun BulletPoint(text: String, testTag: String) {
-  Row(modifier = Modifier.fillMaxWidth().testTag(testTag), verticalAlignment = Alignment.Top) {
-    Text(
-        text = "\u2022",
-        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
-        modifier = Modifier.padding(end = 8.dp))
-    Text(text = text, style = MaterialTheme.typography.bodyLarge)
   }
 }
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ParkingReportScreen.kt
@@ -51,6 +51,8 @@ fun ParkingReportScreen(
   var showDialog by remember { mutableStateOf(false) }
   val context = LocalContext.current
 
+  val strRes = stringResource(R.string.report_added)
+
   // Define padding as a percentage of screen dimensions
   val horizontalPaddingScaleFactor = screenWidth * 0.03f
   val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
@@ -60,18 +62,18 @@ fun ParkingReportScreen(
   val selectedReason = rememberSaveable { mutableStateOf(ParkingReportReason.INEXISTANT) }
   val parkingId = parkingViewModel.selectedParking.value?.uid
   val reportDescription = rememberSaveable { mutableStateOf("") }
-  val userId = userViewModel.currentUser.value?.public?.userId
+  val userId = userViewModel.currentUser.value?.public?.userId!!
 
   fun onSubmit() {
     val report =
         ParkingReport(
             uid = parkingViewModel.getNewUid(),
             reason = selectedReason.value,
-            userId = userId ?: "",
+            userId = userId,
             parking = parkingId!!,
             description = reportDescription.value)
     parkingViewModel.addReport(report, userViewModel.currentUser.value!!)
-    Toast.makeText(context, "Report added", Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, strRes, Toast.LENGTH_SHORT).show()
     navigationActions.goBack()
   }
 
@@ -176,7 +178,12 @@ fun ParkingReportScreen(
         }
   }
 }
-
+/**
+ * Checks if the description
+ *
+ * @param description element to check the size of
+ * @return true if it respects size requirements
+ */
 fun areInputsValid(description: String): Boolean {
   return description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialog.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialog.kt
@@ -1,0 +1,72 @@
+package com.github.se.cyrcle.ui.report
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.ui.theme.atoms.Text
+
+@Composable
+fun ReportScreenAlertDialog(
+    onDismiss: () -> Unit,
+    onAccept: () -> Unit
+) {
+    AlertDialog(
+        modifier = Modifier.testTag("parkingDetailsAlertDialog"),
+        onDismissRequest = { onDismiss() },
+        title = { Text("Are You Sure?") },
+        containerColor = MaterialTheme.colorScheme.surfaceBright,
+        text = {
+            Text(
+                text = "We take reports very seriously. Please make sure that the information you have mentioned is accurate. If enough users also submit reports on this object, it will be flagged for administrator review. Do you still want to add this Report?",
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 16.sp),
+                textAlign = TextAlign.Justify // Ensures justified alignment
+            )
+        },
+        confirmButton = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                // Cancel button (No)
+                TextButton(
+                    onClick = { onDismiss() },
+                    modifier = Modifier
+                        .padding(start = 8.dp, end = 8.dp)
+                        .testTag("cancelButton")
+                ) {
+                    Text(
+                        text = stringResource(R.string.no),
+                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp)
+                    )
+                }
+                // Confirmation button (Yes)
+                TextButton(
+                    onClick = { onAccept() },
+                    modifier = Modifier
+                        .padding(start = 8.dp, end = 8.dp)
+                        .testTag("acceptButton")
+                ) {
+                    Text(
+                        text = stringResource(R.string.yes),
+                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp)
+                    )
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialog.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialog.kt
@@ -1,72 +1,54 @@
 package com.github.se.cyrcle.ui.report
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.rememberAsyncImagePainter
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.ui.theme.atoms.Text
 
 @Composable
-fun ReportScreenAlertDialog(
-    onDismiss: () -> Unit,
-    onAccept: () -> Unit
-) {
-    AlertDialog(
-        modifier = Modifier.testTag("parkingDetailsAlertDialog"),
-        onDismissRequest = { onDismiss() },
-        title = { Text("Are You Sure?") },
-        containerColor = MaterialTheme.colorScheme.surfaceBright,
-        text = {
-            Text(
-                text = "We take reports very seriously. Please make sure that the information you have mentioned is accurate. If enough users also submit reports on this object, it will be flagged for administrator review. Do you still want to add this Report?",
-                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 16.sp),
-                textAlign = TextAlign.Justify // Ensures justified alignment
-            )
-        },
-        confirmButton = {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                // Cancel button (No)
-                TextButton(
-                    onClick = { onDismiss() },
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp)
-                        .testTag("cancelButton")
-                ) {
-                    Text(
-                        text = stringResource(R.string.no),
-                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp)
-                    )
-                }
-                // Confirmation button (Yes)
-                TextButton(
-                    onClick = { onAccept() },
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp)
-                        .testTag("acceptButton")
-                ) {
-                    Text(
-                        text = stringResource(R.string.yes),
-                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp)
-                    )
-                }
+fun ReportScreenAlertDialog(onDismiss: () -> Unit, onAccept: () -> Unit) {
+  AlertDialog(
+      modifier = Modifier.testTag("ReportScreenAlertDialog"),
+      onDismissRequest = { onDismiss() },
+      title = {
+        Text(
+            text = stringResource(R.string.alert_title),
+            modifier = Modifier.testTag("AlertDialogTitle"))
+      },
+      containerColor = MaterialTheme.colorScheme.surfaceBright,
+      text = {
+        Text(
+            text = stringResource(R.string.alert_content),
+            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 16.sp),
+            textAlign = TextAlign.Justify,
+            modifier = Modifier.testTag("AlertDialogContent"))
+      },
+      confirmButton = {
+        Row(
+            modifier = Modifier.fillMaxWidth().testTag("AlertDialogButtons"),
+            horizontalArrangement = Arrangement.SpaceEvenly) {
+              // Cancel button (No)
+              TextButton(onClick = { onDismiss() }, modifier = Modifier.testTag("CancelButton")) {
+                Text(
+                    text = stringResource(R.string.no),
+                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp))
+              }
+              // Confirmation button (Yes)
+              TextButton(onClick = { onAccept() }, modifier = Modifier.testTag("AcceptButton")) {
+                Text(
+                    text = stringResource(R.string.yes),
+                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp))
+              }
             }
-        }
-    )
+      })
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialog.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReportScreenAlertDialog.kt
@@ -43,7 +43,7 @@ fun ReportScreenAlertDialog(onDismiss: () -> Unit, onAccept: () -> Unit) {
                     text = stringResource(R.string.no),
                     style = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp))
               }
-              // Confirmation button (Yes)
+
               TextButton(onClick = { onAccept() }, modifier = Modifier.testTag("AcceptButton")) {
                 Text(
                     text = stringResource(R.string.yes),

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
@@ -66,7 +66,7 @@ fun ReviewReportScreen(
   val selectedReason = rememberSaveable { mutableStateOf(ReviewReportReason.IRRELEVANT) }
   val reviewId = reviewViewModel.selectedReview.value?.uid
   val reportDescription = rememberSaveable { mutableStateOf("") }
-  val userId = userViewModel.currentUser.value?.public?.userId
+  val userId = userViewModel.currentUser.value?.public?.userId!!
   val context = LocalContext.current
 
   fun onSubmit() {

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,8 +14,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -30,20 +27,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.cyrcle.R
-import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.review.ReviewReport
 import com.github.se.cyrcle.model.review.ReviewReportReason
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
-import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MAX_LENGTH
-import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MIN_LENGTH
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.disabledColor
@@ -57,162 +49,133 @@ fun ReviewReportScreen(
     userViewModel: UserViewModel,
     reviewViewModel: ReviewViewModel,
 ) {
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp.dp
-    val screenHeight = configuration.screenHeightDp.dp
-    var showDialog = remember { mutableStateOf(false) }
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp.dp
+  val screenHeight = configuration.screenHeightDp.dp
+  var showDialog = remember { mutableStateOf(false) }
 
-    // Define padding as a percentage of screen dimensions
-    val horizontalPaddingScaleFactor = screenWidth * 0.03f
-    val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
-    val verticalPaddingScaleFactor = screenHeight * 0.02f
+  // Define padding as a percentage of screen dimensions
+  val horizontalPaddingScaleFactor = screenWidth * 0.03f
+  val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
+  val verticalPaddingScaleFactor = screenHeight * 0.02f
 
-    // State for report inputs
-    val selectedReason = rememberSaveable { mutableStateOf<ReviewReportReason>(ReviewReportReason.IRRELEVANT) }
-    val reviewId = reviewViewModel.selectedReview.value?.uid
-    val reportDescription = rememberSaveable { mutableStateOf("") }
-    val userId = userViewModel.currentUser.value?.public?.userId
+  // State for report inputs
+  val selectedReason = rememberSaveable {
+    mutableStateOf<ReviewReportReason>(ReviewReportReason.IRRELEVANT)
+  }
+  val reviewId = reviewViewModel.selectedReview.value?.uid
+  val reportDescription = rememberSaveable { mutableStateOf("") }
+  val userId = userViewModel.currentUser.value?.public?.userId
 
-    fun onSubmit() {
-        if (selectedReason.value != null && reviewId != null) {
-            val report = ReviewReport(
-                uid = reviewViewModel.getNewUid(),
-                reason = selectedReason.value!!,
-                userId = userId ?: "",
-                review = reviewId,
-                description = reportDescription.value
-            )
-            reviewViewModel.addReport(report, userViewModel.currentUser.value!!)
-            navigationActions.goBack()
-        }
+  fun onSubmit() {
+    if (selectedReason.value != null && reviewId != null) {
+      val report =
+          ReviewReport(
+              uid = reviewViewModel.getNewUid(),
+              reason = selectedReason.value!!,
+              userId = userId ?: "",
+              review = reviewId,
+              description = reportDescription.value)
+      reviewViewModel.addReport(report, userViewModel.currentUser.value!!)
+      navigationActions.goBack()
     }
+  }
 
-    Scaffold(
-        modifier = Modifier.testTag("ReviewReportScreen"),
-        topBar = {
-            TopAppBar(
-                navigationActions,
-                title = "Report Review: ${reviewViewModel.selectedReview.value?.text?.take(30) ?: reviewId}"
-            )
-        },
-    ) { padding ->
-        val scaledPaddingValues = PaddingValues(
-            horizontal = horizontalPaddingScaleFactor,
-            vertical = verticalPaddingScaleFactor
-        )
+  Scaffold(
+      modifier = Modifier.testTag("ReviewReportScreen"),
+      topBar = {
+        TopAppBar(
+            navigationActions,
+            title =
+                stringResource(R.string.report_a_review)
+                    .format(reviewViewModel.selectedReview.value?.text?.take(30) ?: reviewId))
+      },
+  ) { padding ->
+    val scaledPaddingValues =
+        PaddingValues(
+            horizontal = horizontalPaddingScaleFactor, vertical = verticalPaddingScaleFactor)
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
                 .padding(scaledPaddingValues)
                 .verticalScroll(rememberScrollState())
                 .testTag("ReviewReportColumn"),
-            horizontalAlignment = Alignment.Start
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(topBoxHeight)
-                    .background(MaterialTheme.colorScheme.background)
-            )
+        horizontalAlignment = Alignment.Start) {
+          Box(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .height(topBoxHeight)
+                      .background(MaterialTheme.colorScheme.background))
 
-            // Text Block Section
-            Text(
-                text = "The following will be submitted in your report:",
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Start
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-            )
+          // Text Block Section
+          Text(
+              text = stringResource(R.string.report_title),
+              style =
+                  MaterialTheme.typography.titleMedium.copy(
+                      fontWeight = FontWeight.Bold, textAlign = TextAlign.Start),
+              modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("ReportTitle"))
 
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, bottom = 16.dp), // Indent bullet points
-                verticalArrangement = Arrangement.spacedBy(8.dp) // Add space between points
-            ) {
-                BulletPoint("Your User Information")
-                BulletPoint("This Review's information")
-                BulletPoint("Reason + Description below")
-            }
+          Column(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(start = 16.dp, bottom = 16.dp) // Indent bullet points
+                      .testTag("ReportBulletPoints"),
+              verticalArrangement = Arrangement.spacedBy(8.dp) // Add space between points
+              ) {
+                BulletPoint(
+                    stringResource(R.string.report_bullet_point_1), testTag = "BulletPoint1")
+                BulletPoint(
+                    stringResource(R.string.report_bullet_point_2_review), testTag = "BulletPoint2")
+                BulletPoint(
+                    stringResource(R.string.report_bullet_point_3), testTag = "BulletPoint3")
+              }
 
-            // Select Reason
-            EnumDropDown(
-                options = ReviewReportReason.entries,
-                selectedValue = selectedReason,
-                label = "Reason for Reporting"
-            )
+          // Select Reason
+          EnumDropDown(
+              options = ReviewReportReason.entries,
+              selectedValue = selectedReason,
+              label = stringResource(R.string.report_reason),
+              modifier = Modifier.testTag("ReasonDropdown"))
 
-            // Additional Details Input
-            ConditionCheckingInputText(
-                value = reportDescription.value,
-                onValueChange = { reportDescription.value = it },
-                label = "Additional Details (Optional)",
-                minCharacters = 0,
-                maxCharacters = 256,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = horizontalPaddingScaleFactor)
-            )
+          // Additional Details Input
+          ConditionCheckingInputText(
+              value = reportDescription.value,
+              onValueChange = { reportDescription.value = it },
+              label = stringResource(R.string.report_details),
+              minCharacters = 0,
+              maxCharacters = 256,
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(horizontal = horizontalPaddingScaleFactor)
+                      .testTag("DetailsInput"))
 
-            val validInputs = areInputsValid(reportDescription.value)
+          val validInputs = areInputsValid(reportDescription.value)
 
-            if (showDialog.value) {
-                ReportScreenAlertDialog(onDismiss = {
-                    showDialog.value = false
-                }, onAccept = {
-                    showDialog.value = false
-                    if (validInputs) onSubmit()
-                    navigationActions.goBack()
+          if (showDialog.value) {
+            ReportScreenAlertDialog(
+                onDismiss = { showDialog.value = false },
+                onAccept = {
+                  showDialog.value = false
+                  if (validInputs) onSubmit()
+                  navigationActions.goBack()
                 })
-            }
+          }
 
-            Button(
-                onClick = { showDialog.value = true },
-                modifier = Modifier
-                    .testTag("submitButton")
-                    .padding(top = 16.dp)
-                    .align(alignment = Alignment.CenterHorizontally),
-                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)
-            ) {
+          Button(
+              onClick = { showDialog.value = true },
+              modifier =
+                  Modifier.testTag("SubmitButton")
+                      .padding(top = 16.dp)
+                      .align(alignment = Alignment.CenterHorizontally),
+              colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)) {
                 Text(
                     text = stringResource(R.string.attributes_picker_bottom_bar_submit_button),
                     color = if (validInputs) MaterialTheme.colorScheme.primary else disabledColor(),
                     fontWeight = FontWeight.Bold,
                     fontSize = 20.sp,
-                    textAlign = TextAlign.Center
-                )
-            }
+                    textAlign = TextAlign.Center)
+              }
         }
-    }
-}
-
-@Composable
-fun BulletPoint(text: String) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth(0.85f), // Centers the content and adjusts the width
-        verticalAlignment = Alignment.Top
-    ) {
-        Text(
-            text = "\u2022",
-            style = MaterialTheme.typography.bodyLarge.copy(
-                fontSize = 18.sp,
-                color = MaterialTheme.colorScheme.primary
-            ),
-            modifier = Modifier.padding(end = 8.dp)
-        )
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 16.sp),
-            modifier = Modifier.weight(1f) // Ensures wrapping if the text is too long
-        )
-    }
-}
-
-private fun areInputsValid(description: String): Boolean {
-    return description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
@@ -39,6 +39,7 @@ import com.github.se.cyrcle.model.review.ReviewReportReason
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.theme.atoms.BulletPoint
 import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.disabledColor
 import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
@@ -1,0 +1,218 @@
+package com.github.se.cyrcle.ui.report
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.review.ReviewReport
+import com.github.se.cyrcle.model.review.ReviewReportReason
+import com.github.se.cyrcle.model.review.ReviewViewModel
+import com.github.se.cyrcle.model.user.UserViewModel
+import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MAX_LENGTH
+import com.github.se.cyrcle.ui.addParking.attributes.DESCRIPTION_MIN_LENGTH
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
+import com.github.se.cyrcle.ui.theme.disabledColor
+import com.github.se.cyrcle.ui.theme.molecules.EnumDropDown
+import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+fun ReviewReportScreen(
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+    reviewViewModel: ReviewViewModel,
+) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val screenHeight = configuration.screenHeightDp.dp
+    var showDialog = remember { mutableStateOf(false) }
+
+    // Define padding as a percentage of screen dimensions
+    val horizontalPaddingScaleFactor = screenWidth * 0.03f
+    val topBoxHeight = screenHeight * 0.10f // 10% of screen height for top box
+    val verticalPaddingScaleFactor = screenHeight * 0.02f
+
+    // State for report inputs
+    val selectedReason = rememberSaveable { mutableStateOf<ReviewReportReason>(ReviewReportReason.IRRELEVANT) }
+    val reviewId = reviewViewModel.selectedReview.value?.uid
+    val reportDescription = rememberSaveable { mutableStateOf("") }
+    val userId = userViewModel.currentUser.value?.public?.userId
+
+    fun onSubmit() {
+        if (selectedReason.value != null && reviewId != null) {
+            val report = ReviewReport(
+                uid = reviewViewModel.getNewUid(),
+                reason = selectedReason.value!!,
+                userId = userId ?: "",
+                review = reviewId,
+                description = reportDescription.value
+            )
+            reviewViewModel.addReport(report, userViewModel.currentUser.value!!)
+            navigationActions.goBack()
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag("ReviewReportScreen"),
+        topBar = {
+            TopAppBar(
+                navigationActions,
+                title = "Report Review: ${reviewViewModel.selectedReview.value?.text?.take(30) ?: reviewId}"
+            )
+        },
+    ) { padding ->
+        val scaledPaddingValues = PaddingValues(
+            horizontal = horizontalPaddingScaleFactor,
+            vertical = verticalPaddingScaleFactor
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaledPaddingValues)
+                .verticalScroll(rememberScrollState())
+                .testTag("ReviewReportColumn"),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(topBoxHeight)
+                    .background(MaterialTheme.colorScheme.background)
+            )
+
+            // Text Block Section
+            Text(
+                text = "The following will be submitted in your report:",
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Start
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, bottom = 16.dp), // Indent bullet points
+                verticalArrangement = Arrangement.spacedBy(8.dp) // Add space between points
+            ) {
+                BulletPoint("Your User Information")
+                BulletPoint("This Review's information")
+                BulletPoint("Reason + Description below")
+            }
+
+            // Select Reason
+            EnumDropDown(
+                options = ReviewReportReason.entries,
+                selectedValue = selectedReason,
+                label = "Reason for Reporting"
+            )
+
+            // Additional Details Input
+            ConditionCheckingInputText(
+                value = reportDescription.value,
+                onValueChange = { reportDescription.value = it },
+                label = "Additional Details (Optional)",
+                minCharacters = 0,
+                maxCharacters = 256,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPaddingScaleFactor)
+            )
+
+            val validInputs = areInputsValid(reportDescription.value)
+
+            if (showDialog.value) {
+                ReportScreenAlertDialog(onDismiss = {
+                    showDialog.value = false
+                }, onAccept = {
+                    showDialog.value = false
+                    if (validInputs) onSubmit()
+                    navigationActions.goBack()
+                })
+            }
+
+            Button(
+                onClick = { showDialog.value = true },
+                modifier = Modifier
+                    .testTag("submitButton")
+                    .padding(top = 16.dp)
+                    .align(alignment = Alignment.CenterHorizontally),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)
+            ) {
+                Text(
+                    text = stringResource(R.string.attributes_picker_bottom_bar_submit_button),
+                    color = if (validInputs) MaterialTheme.colorScheme.primary else disabledColor(),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun BulletPoint(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(0.85f), // Centers the content and adjusts the width
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = "\u2022",
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontSize = 18.sp,
+                color = MaterialTheme.colorScheme.primary
+            ),
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 16.sp),
+            modifier = Modifier.weight(1f) // Ensures wrapping if the text is too long
+        )
+    }
+}
+
+private fun areInputsValid(description: String): Boolean {
+    return description.length in DESCRIPTION_MIN_LENGTH..DESCRIPTION_MAX_LENGTH
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/report/ReviewReportScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.cyrcle.ui.report
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -52,7 +54,7 @@ fun ReviewReportScreen(
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp.dp
   val screenHeight = configuration.screenHeightDp.dp
-  var showDialog = remember { mutableStateOf(false) }
+  val showDialog = remember { mutableStateOf(false) }
 
   // Define padding as a percentage of screen dimensions
   val horizontalPaddingScaleFactor = screenWidth * 0.03f
@@ -60,23 +62,23 @@ fun ReviewReportScreen(
   val verticalPaddingScaleFactor = screenHeight * 0.02f
 
   // State for report inputs
-  val selectedReason = rememberSaveable {
-    mutableStateOf<ReviewReportReason>(ReviewReportReason.IRRELEVANT)
-  }
+  val selectedReason = rememberSaveable { mutableStateOf(ReviewReportReason.IRRELEVANT) }
   val reviewId = reviewViewModel.selectedReview.value?.uid
   val reportDescription = rememberSaveable { mutableStateOf("") }
   val userId = userViewModel.currentUser.value?.public?.userId
+  val context = LocalContext.current
 
   fun onSubmit() {
-    if (selectedReason.value != null && reviewId != null) {
+    if (reviewId != null) {
       val report =
           ReviewReport(
               uid = reviewViewModel.getNewUid(),
-              reason = selectedReason.value!!,
+              reason = selectedReason.value,
               userId = userId ?: "",
               review = reviewId,
               description = reportDescription.value)
       reviewViewModel.addReport(report, userViewModel.currentUser.value!!)
+      Toast.makeText(context, "Report added", Toast.LENGTH_SHORT).show()
       navigationActions.goBack()
     }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -307,7 +307,7 @@ fun AllReviewsScreen(
                                             Alignment
                                                 .BottomEnd) // Align the button to the bottom-right
                                         // corner
-                                        .padding(8.dp)
+                                        .padding(16.dp)
                                         .testTag("ReportReviewButton$index"),
                                 shape = MaterialTheme.shapes.medium) {
                                   Text(

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -304,17 +304,7 @@ fun AllReviewsScreen(
                                       FloatingActionButton(
                                           onClick = {
                                             reviewViewModel.selectReview(curReview)
-                                            reviewViewModel.addReport(
-                                                ReviewReport(
-                                                    "TEST0",
-                                                    ReviewReportReason.HARMFUL,
-                                                    userViewModel.currentUser.value?.public?.userId
-                                                        ?: "TESTUSER",
-                                                    curReview.uid),
-                                                userViewModel.currentUser.value!!)
-                                            Toast.makeText(
-                                                    context, "Review reported!", Toast.LENGTH_SHORT)
-                                                .show()
+                                            navigationActions.navigateTo(Screen.REVIEW_REPORT)
                                           },
                                           containerColor = MaterialTheme.colorScheme.error,
                                           modifier =

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -41,8 +42,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.parking.ParkingViewModel
-import com.github.se.cyrcle.model.review.ReviewReport
-import com.github.se.cyrcle.model.review.ReviewReportReason
 import com.github.se.cyrcle.model.review.ReviewViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -200,7 +199,7 @@ fun AllReviewsScreen(
 
   LaunchedEffect(Unit) {
     reviewViewModel.clearReviews()
-    reviewViewModel.getReviewsByParking(selectedParking!!.uid)
+    selectedParking?.let { reviewViewModel.getReviewsByParking(it.uid) }
   }
 
   LaunchedEffect(reviewsList) {
@@ -225,159 +224,150 @@ fun AllReviewsScreen(
                 .format(selectedParking?.optName ?: stringResource(R.string.default_parking_name)))
       },
       modifier = Modifier.testTag("AllReviewsScreen")) { innerPadding ->
-        Box(
-            modifier =
-                Modifier.fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
-                    .testTag("AllReviewsScreenBox")
-                    .padding(innerPadding)) {
-              Column {
-                // Add the FilterHeader here
-                FilterHeader(
-                    selectedSortingOption = selectedSortingOption,
-                    onSortingOptionSelected = { selectedOption ->
-                      selectedSortingOption = selectedOption
-                    })
+        Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+          // Header Section
+          FilterHeader(
+              selectedSortingOption = selectedSortingOption,
+              onSortingOptionSelected = { selectedOption ->
+                selectedSortingOption = selectedOption
+              })
 
-                LazyColumn(
-                    modifier =
-                        Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("ReviewList")) {
-                      items(items = sortedReviews) { curReview ->
-                        val index = sortedReviews.indexOf(curReview)
-                        val isExpanded = selectedCardIndex == index
-                        val cardHeight by
-                            animateDpAsState(
-                                if (isExpanded) 250.dp
-                                else 150.dp) // Adjust card height to account for ReviewSize +
-                        // Report button
-                        val cardColor = MaterialTheme.colorScheme.surfaceContainer
-                        Card(
-                            modifier =
-                                Modifier.fillMaxWidth()
-                                    .padding(8.dp)
-                                    .height(cardHeight)
-                                    .clickable { selectedCardIndex = if (isExpanded) -1 else index }
-                                    .testTag("ReviewCard$index"),
-                            colors = CardDefaults.cardColors(containerColor = cardColor),
-                            shape = MaterialTheme.shapes.medium,
-                            elevation = CardDefaults.cardElevation(8.dp)) {
-                              Column(
-                                  modifier =
-                                      Modifier.fillMaxWidth()
-                                          .padding(16.dp)
-                                          .testTag("ReviewCardContent$index")) {
-                                    val defaultUsername =
-                                        stringResource(R.string.undefined_username)
-                                    val uidOfOwner = remember { mutableStateOf(defaultUsername) }
-                                    userViewModel.getUserById(
-                                        curReview.owner, { uidOfOwner.value = it.public.username })
+          // Scrollable Review Cards
+          LazyColumn(
+              modifier = Modifier.weight(1f).padding(horizontal = 16.dp).testTag("ReviewList"),
+              contentPadding = PaddingValues(bottom = 16.dp)) {
+                items(items = sortedReviews) { curReview ->
+                  val index = sortedReviews.indexOf(curReview)
+                  val isExpanded = selectedCardIndex == index
+                  val cardHeight by
+                      animateDpAsState(
+                          if (isExpanded) 350.dp
+                          else 150.dp) // Adjust card height based on selection
+                  val cardColor = MaterialTheme.colorScheme.surfaceContainer
 
-                                    // Review details
-                                    Text(
-                                        text =
-                                            stringResource(R.string.by_text)
-                                                .format(uidOfOwner.value),
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        modifier = Modifier.testTag("ReviewOwner$index"))
-                                    Text(
-                                        text =
-                                            stringResource(R.string.on_text)
-                                                .format(curReview.time.toFormattedDate()),
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        modifier = Modifier.testTag("ReviewDate$index"))
-                                    Spacer(modifier = Modifier.height(4.dp))
-                                    ScoreStars(
-                                        curReview.rating,
-                                        scale = 0.9f,
-                                        starColor = MaterialTheme.colorScheme.onPrimaryContainer)
-                                    Spacer(modifier = Modifier.height(4.dp))
-                                    Text(
-                                        text = curReview.text,
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        modifier = Modifier.testTag("ReviewText$index"))
-                                    Spacer(modifier = Modifier.height(16.dp))
+                  Card(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .padding(8.dp)
+                              .height(cardHeight)
+                              .clickable { selectedCardIndex = if (isExpanded) -1 else index }
+                              .testTag("ReviewCard$index"),
+                      colors = CardDefaults.cardColors(containerColor = cardColor),
+                      shape = MaterialTheme.shapes.medium,
+                      elevation = CardDefaults.cardElevation(8.dp)) {
+                        Box(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                          Column(
+                              modifier =
+                                  Modifier.fillMaxWidth()
+                                      .align(Alignment.TopStart)
+                                      .testTag("ReviewCardContent$index")) {
+                                val defaultUsername = stringResource(R.string.undefined_username)
+                                val uidOfOwner = remember { mutableStateOf(defaultUsername) }
+                                userViewModel.getUserById(
+                                    curReview.owner, { uidOfOwner.value = it.public.username })
 
-                                    if (userViewModel.currentUser.value != null) {
-                                      FloatingActionButton(
-                                          onClick = {
-                                            reviewViewModel.selectReview(curReview)
-                                            navigationActions.navigateTo(Screen.REVIEW_REPORT)
-                                          },
-                                          containerColor = MaterialTheme.colorScheme.error,
-                                          modifier =
-                                              Modifier.align(Alignment.CenterHorizontally)
-                                                  .height(36.dp)
-                                                  .testTag("ReportReviewButton$index")) {
-                                            Text(
-                                                text = stringResource(R.string.review_reported),
-                                                color = MaterialTheme.colorScheme.onError,
-                                                style = MaterialTheme.typography.bodySmall)
-                                          }
-                                    }
-                                  }
-                            }
-                      }
-                    }
-              }
+                                // Review details
+                                Text(
+                                    text =
+                                        stringResource(R.string.by_text).format(uidOfOwner.value),
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    modifier = Modifier.testTag("ReviewOwner$index"))
+                                Text(
+                                    text =
+                                        stringResource(R.string.on_text)
+                                            .format(curReview.time.toFormattedDate()),
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    modifier = Modifier.testTag("ReviewDate$index"))
+                                Spacer(modifier = Modifier.height(4.dp))
+                                ScoreStars(
+                                    curReview.rating,
+                                    scale = 0.9f,
+                                    starColor = MaterialTheme.colorScheme.onPrimaryContainer)
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = curReview.text,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    modifier = Modifier.testTag("ReviewText$index"))
+                              }
 
-              if (userViewModel.currentUser.value?.public?.userId != null) {
-                val userReview =
-                    reviewsList.find { it.owner == userViewModel.currentUser.value?.public?.userId }
-                Box(
-                    modifier = Modifier.fillMaxSize().padding(16.dp),
-                    contentAlignment = Alignment.BottomEnd) {
-                      Row(
-                          modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
-                          horizontalArrangement = Arrangement.SpaceBetween) {
+                          // Conditionally show the Report Review button only when the card is
+                          // expanded
+                          if (isExpanded) {
                             FloatingActionButton(
                                 onClick = {
-                                  if (userReview != null) {
-                                    reviewViewModel.deleteReviewById(userReview)
-                                    parkingViewModel.handleReviewDeletion(
-                                        oldScore = userReview.rating)
-                                    Toast.makeText(context, "Review Deleted!", Toast.LENGTH_SHORT)
-                                        .show()
-                                    navigationActions.goBack()
-                                  } else {
-                                    Toast.makeText(
-                                            context, "Add A Review First!", Toast.LENGTH_SHORT)
-                                        .show()
-                                  }
+                                  reviewViewModel.selectReview(curReview)
+                                  navigationActions.navigateTo(Screen.REVIEW_REPORT)
                                 },
-                                containerColor = MaterialTheme.colorScheme.primary,
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
                                 modifier =
-                                    Modifier.weight(1f)
-                                        .padding(end = 8.dp)
-                                        .height(56.dp)
-                                        .testTag("DeleteReviewButton")) {
+                                    Modifier.align(
+                                            Alignment
+                                                .BottomEnd) // Align the button to the bottom-right
+                                        // corner
+                                        .padding(8.dp)
+                                        .testTag("ReportReviewButton$index"),
+                                shape = MaterialTheme.shapes.medium) {
                                   Text(
-                                      text = stringResource(R.string.delete_review),
-                                      color = MaterialTheme.colorScheme.onPrimary,
-                                      style = MaterialTheme.typography.bodyMedium)
-                                }
-
-                            FloatingActionButton(
-                                onClick = { navigationActions.navigateTo(Screen.ADD_REVIEW) },
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                modifier =
-                                    Modifier.weight(1f)
-                                        .padding(start = 8.dp)
-                                        .height(56.dp)
-                                        .testTag("AddOrEditReviewButton")) {
-                                  Text(
-                                      text =
-                                          if (ownerHasReviewed.value)
-                                              stringResource(R.string.edit_review)
-                                          else stringResource(R.string.add_review),
-                                      color = MaterialTheme.colorScheme.onPrimary,
+                                      text = stringResource(R.string.report_review),
+                                      color = MaterialTheme.colorScheme.onErrorContainer,
                                       style = MaterialTheme.typography.bodyMedium)
                                 }
                           }
-                    }
+                        }
+                      }
+                }
               }
-            }
+
+          // Fixed Bottom Buttons
+          if (userViewModel.currentUser.value?.public?.userId != null) {
+            val userReview =
+                reviewsList.find { it.owner == userViewModel.currentUser.value?.public?.userId }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween) {
+                  FloatingActionButton(
+                      onClick = {
+                        if (userReview != null) {
+                          reviewViewModel.deleteReviewById(userReview)
+                          parkingViewModel.handleReviewDeletion(oldScore = userReview.rating)
+                          Toast.makeText(context, "Review Deleted!", Toast.LENGTH_SHORT).show()
+                          navigationActions.goBack()
+                        } else {
+                          Toast.makeText(context, "Add A Review First!", Toast.LENGTH_SHORT).show()
+                        }
+                      },
+                      containerColor = MaterialTheme.colorScheme.primary,
+                      modifier =
+                          Modifier.weight(1f)
+                              .padding(end = 8.dp)
+                              .height(56.dp)
+                              .testTag("DeleteReviewButton")) {
+                        Text(
+                            text = stringResource(R.string.delete_review),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            style = MaterialTheme.typography.bodyMedium)
+                      }
+
+                  FloatingActionButton(
+                      onClick = { navigationActions.navigateTo(Screen.ADD_REVIEW) },
+                      containerColor = MaterialTheme.colorScheme.primary,
+                      modifier =
+                          Modifier.weight(1f)
+                              .padding(start = 8.dp)
+                              .height(56.dp)
+                              .testTag("AddOrEditReviewButton")) {
+                        Text(
+                            text =
+                                if (ownerHasReviewed.value) stringResource(R.string.edit_review)
+                                else stringResource(R.string.add_review),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            style = MaterialTheme.typography.bodyMedium)
+                      }
+                }
+          }
+        }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/ReviewScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
@@ -87,7 +89,11 @@ fun ReviewScreen(
                 else stringResource(R.string.review_screen_title_new_review))
       }) { paddingValues ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp),
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState()), // Make the entire content scrollable
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
               ScoreStars(sliderValue.toDouble(), scale = scaleFactor) // Use dynamic scale factor

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Text.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Text.kt
@@ -1,13 +1,19 @@
 package com.github.se.cyrcle.ui.theme.atoms
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.ui.theme.defaultOnColor
 
 /**
@@ -35,4 +41,26 @@ fun Text(
       style = style,
       textAlign = textAlign,
       color = color)
+}
+
+/**
+ * A composable function that displays a text with a bullet point symbol in a horizontal row.
+ *
+ * This function is useful for creating lists where each item is preceded by a bullet point,
+ * ensuring a consistent and visually appealing layout.
+ *
+ * @param text The text content to be displayed next to the bullet point.
+ * @param testTag A tag used for testing purposes, allowing this composable to be identified in UI
+ *   tests.
+ */
+@Composable
+fun BulletPoint(text: String, testTag: String) {
+  Row(modifier = Modifier.fillMaxWidth().testTag(testTag), verticalAlignment = Alignment.Top) {
+    com.github.se.cyrcle.ui.theme.atoms.Text(
+        text = "\u2022",
+        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+        modifier = Modifier.padding(end = 8.dp))
+    com.github.se.cyrcle.ui.theme.atoms.Text(
+        text = text, style = MaterialTheme.typography.bodyLarge)
+  }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,7 @@
     <string name="add_review">Add Review</string>
     <string name="edit_review">Edit Review</string>
     <string name="review_deleted">Review Deleted!</string>
+    <string name="report_review">Report Review</string>
     <string name="review_reported">Review Reported!</string>
 
     <!-- Review Screen -->
@@ -197,4 +198,19 @@
     <string name="rarity_common">Common</string>
     <string name="rarity_rare">Rare</string>
     <string name="rarity_epic">Epic</string>
+
+    <!-- Report Screens -->
+    <string name="report_title">The following will be submitted in your report:</string>
+    <string name="report_parking">Report Parking: %s</string>
+    <string name="report_a_review">Report Parking: %s</string>
+    <string name="report_bullet_point_1">Your User Information</string>
+    <string name="report_bullet_point_2_parking">This Parking\'s information</string>
+    <string name="report_bullet_point_2_review">This Review\'s information</string>
+    <string name="report_bullet_point_3">Reason + Description below</string>
+    <string name="report_reason">Reason for Reporting</string>
+    <string name="report_details">Additional Details (Optional)</string>
+    <string name="alert_content">We take reports very seriously. Please make sure that the information you have mentioned is accurate. If enough users also submit reports on this object, it will be flagged for administrator review. Do you still want to add this Report?</string>
+    <string name="alert_title">Are You Sure?</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,6 +211,7 @@
     <string name="report_details">Additional Details (Optional)</string>
     <string name="alert_content">We take reports very seriously. Please make sure that the information you have mentioned is accurate. If enough users also submit reports on this object, it will be flagged for administrator review. Do you still want to add this Report?</string>
     <string name="alert_title">Are You Sure?</string>
+    <string name="report_added">Report added</string>
 
 
 </resources>

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -118,7 +118,8 @@ class ParkingViewModelTest {
             uid = "report1",
             reason = ParkingReportReason.SAFETY_CONCERN,
             userId = user.public.userId,
-            parking = parking.uid)
+            parking = parking.uid,
+            "")
 
     // Mock repository behavior for report addition
     `when`(parkingRepository.addReport(eq(report), any(), any())).then {

--- a/app/src/test/java/com/github/se/cyrcle/model/report/ReportedObjectRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/report/ReportedObjectRepositoryFirestoreTest.kt
@@ -2,13 +2,13 @@ package com.github.se.cyrcle.model.report
 
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
+import com.github.se.cyrcle.model.review.ReviewReportReason
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.*
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
@@ -16,11 +16,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.times
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 
@@ -33,8 +31,8 @@ class ReportedObjectRepositoryFirestoreTest {
   @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
 
   private lateinit var reportedObjectRepositoryFirestore: ReportedObjectRepositoryFirestore
+  private val gson = Gson()
   private val reportedObject = TestInstancesReportedObject.reportedObject1
-  private lateinit var mockReportedObjectData: Map<String, Any>
 
   @Before
   fun setUp() {
@@ -44,9 +42,8 @@ class ReportedObjectRepositoryFirestoreTest {
     if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
       FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
     }
+
     reportedObjectRepositoryFirestore = ReportedObjectRepositoryFirestore(mockFirestore)
-    mockReportedObjectData =
-        reportedObjectRepositoryFirestore.serializeReportedObject(reportedObject)
 
     `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
@@ -54,15 +51,15 @@ class ReportedObjectRepositoryFirestoreTest {
   }
 
   @Test
-  fun getNewUid() {
-    `when`(mockDocumentReference.id).thenReturn("1")
+  fun getNewUidGeneratesUniqueID() {
+    `when`(mockDocumentReference.id).thenReturn("unique-id")
     val uid = reportedObjectRepositoryFirestore.getNewUid()
-    verify(mockDocumentReference).id
-    assertEquals("1", uid)
+    verify(mockCollectionReference).document()
+    assertEquals("unique-id", uid)
   }
 
   @Test
-  fun addReportedObject_callsOnSuccess() {
+  fun addReportedObjectCallsOnSuccessCallback() {
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 
     var onSuccessCallbackCalled = false
@@ -77,7 +74,7 @@ class ReportedObjectRepositoryFirestoreTest {
   }
 
   @Test
-  fun addReportedObject_callsOnFailure() {
+  fun addReportedObjectCallsOnFailureCallback() {
     val taskCompletionSource = TaskCompletionSource<Void>()
     `when`(mockDocumentReference.set(any())).thenReturn(taskCompletionSource.task)
 
@@ -89,12 +86,12 @@ class ReportedObjectRepositoryFirestoreTest {
     taskCompletionSource.setException(Exception("Test exception"))
     shadowOf(Looper.getMainLooper()).idle()
 
-    verify(mockDocumentReference, times(1)).set(any())
+    verify(mockDocumentReference).set(any())
     assertTrue(onFailureCallbackCalled)
   }
 
   @Test
-  fun getReportedObjectsByType_callsOnSuccess() {
+  fun getReportedObjectsByTypeRetrievesObjectsSuccessfully() {
     `when`(mockCollectionReference.whereEqualTo(any<String>(), any()))
         .thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
@@ -104,7 +101,7 @@ class ReportedObjectRepositoryFirestoreTest {
     reportedObjectRepositoryFirestore.getReportedObjectsByType(
         ReportedObjectType.REVIEW,
         onSuccess = { reportedObjects ->
-          assert(reportedObjects.isEmpty())
+          assertTrue(reportedObjects.isEmpty())
           onSuccessCallbackCalled = true
         },
         onFailure = { fail("Expected success but got failure") })
@@ -115,7 +112,7 @@ class ReportedObjectRepositoryFirestoreTest {
   }
 
   @Test
-  fun getReportedObjectsByType_callsOnFailure() {
+  fun getReportedObjectsByTypeCallsOnFailureCallback() {
     val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
     `when`(mockCollectionReference.whereEqualTo(any<String>(), any()))
         .thenReturn(mockCollectionReference)
@@ -134,34 +131,119 @@ class ReportedObjectRepositoryFirestoreTest {
   }
 
   @Test
-  fun deleteReportedObject_callsOnSuccess() {
-    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+  fun getReportedObjectsByUserRetrievesObjectsSuccessfully() {
+    `when`(mockCollectionReference.whereEqualTo(any<String>(), any()))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf())
 
     var onSuccessCallbackCalled = false
-    reportedObjectRepositoryFirestore.deleteReportedObject(
-        reportedObject.reportUID,
-        onSuccess = { onSuccessCallbackCalled = true },
+    reportedObjectRepositoryFirestore.getReportedObjectsByUser(
+        userUID = "user-id",
+        onSuccess = { reportedObjects ->
+          assertTrue(reportedObjects.isEmpty())
+          onSuccessCallbackCalled = true
+        },
         onFailure = { fail("Expected success but got failure") })
     shadowOf(Looper.getMainLooper()).idle()
 
-    verify(mockDocumentReference).delete()
+    verify(mockCollectionReference).whereEqualTo("userUID", "user-id")
     assertTrue(onSuccessCallbackCalled)
   }
 
   @Test
-  fun deleteReportedObject_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    `when`(mockDocumentReference.delete()).thenReturn(taskCompletionSource.task)
+  fun getReportedObjectsByUserCallsOnFailureCallback() {
+    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
+    `when`(mockCollectionReference.whereEqualTo(any<String>(), any()))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
 
     var onFailureCallbackCalled = false
-    reportedObjectRepositoryFirestore.deleteReportedObject(
-        reportedObject.reportUID,
+    reportedObjectRepositoryFirestore.getReportedObjectsByUser(
+        userUID = "user-id",
         onSuccess = { fail("Expected failure but got success") },
         onFailure = { onFailureCallbackCalled = true })
     taskCompletionSource.setException(Exception("Test exception"))
     shadowOf(Looper.getMainLooper()).idle()
 
-    verify(mockDocumentReference).delete()
+    verify(mockCollectionReference).whereEqualTo("userUID", "user-id")
     assertTrue(onFailureCallbackCalled)
+  }
+
+  @Test
+  fun serializeAndDeserializeReportedObjectWithAbstractFields() {
+    val reportReason = ReportReason.Review(ReviewReportReason.HARMFUL)
+    val reportedObjectWithReason = reportedObject.copy(reason = reportReason)
+
+    // Serialize the object
+    val serialized =
+        reportedObjectRepositoryFirestore.serializeReportedObject(reportedObjectWithReason)
+
+    // Deserialize the object
+    val deserializedMap: Map<String, Any> =
+        gson.fromJson(serialized, object : TypeToken<Map<String, Any>>() {}.type)
+    val deserialized = reportedObjectRepositoryFirestore.deserializeReportedObject(deserializedMap)
+
+    // Assert that the deserialized reason is of the expected type
+    assertTrue(deserialized.reason is ReportReason.Review)
+
+    // Check the specific properties of the reason to ensure correctness
+    val deserializedReason = deserialized.reason as ReportReason.Review
+    assertEquals(ReviewReportReason.HARMFUL, deserializedReason.reason)
+  }
+
+  @Test
+  fun getReportedObjectsByObjectUIDReturnsEmptyListIfNoMatches() {
+    `when`(mockCollectionReference.whereEqualTo(any<String>(), any()))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockQuerySnapshot.documents).thenReturn(emptyList())
+
+    var onSuccessCalled = false
+    reportedObjectRepositoryFirestore.getReportedObjectsByObjectUID(
+        objectUID = "non-existent-id",
+        onSuccess = { reportedObjects ->
+          assertTrue(reportedObjects.isEmpty())
+          onSuccessCalled = true
+        },
+        onFailure = { fail("Expected success but got failure") })
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockCollectionReference).whereEqualTo("objectUID", "non-existent-id")
+    assertTrue(onSuccessCalled)
+  }
+
+  @Test
+  fun getReportedObjectsByObjectUIDHandlesFailure() {
+    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
+    `when`(mockCollectionReference.whereEqualTo(any<String>(), any()))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.get()).thenReturn(taskCompletionSource.task)
+
+    var onFailureCalled = false
+    reportedObjectRepositoryFirestore.getReportedObjectsByObjectUID(
+        objectUID = "test-id",
+        onSuccess = { fail("Expected failure but got success") },
+        onFailure = { onFailureCalled = true })
+    taskCompletionSource.setException(Exception("Test exception"))
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockCollectionReference).whereEqualTo("objectUID", "test-id")
+    assertTrue(onFailureCalled)
+  }
+
+  @Test
+  fun deleteReportedObjectHandlesNonExistentReportUID() {
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+
+    var onSuccessCalled = false
+    reportedObjectRepositoryFirestore.deleteReportedObject(
+        reportUID = "non-existent-id",
+        onSuccess = { onSuccessCalled = true },
+        onFailure = { fail("Expected success but got failure") })
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockDocumentReference).delete()
+    assertTrue(onSuccessCalled)
   }
 }

--- a/app/src/test/java/com/github/se/cyrcle/model/review/ReviewViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/review/ReviewViewModelTest.kt
@@ -37,7 +37,8 @@ class ReviewViewModelTest {
             uid = "report1",
             reason = ReviewReportReason.HARMFUL,
             userId = user.public.userId,
-            review = review.uid)
+            review = review.uid,
+            "")
 
     // Mock repository behavior for report addition
     `when`(reviewRepository.addReport(eq(report), any(), any())).then {


### PR DESCRIPTION
### What is this PR? 

This PR implements screens for users to leave reports on Parkings and Reviews, using the logic implemented in #237.

### Why?

Users can now leave Reports with a user-friendly interface, which is useful to control what reviews are injected into the app

### How?

Two screens were added: one to report reviews and one parkings (I would have preferred to do only one, but that would violate the MVVM architecture since ParkingReports and ReviewReports are two separate subcollections of two separate viewModels so they need 2 separate screens). Each lets the user give the reason as well as an optional description for their report. An AlertDialog will then appear letting them confirm their choice before reporting.
<img width="549" alt="Screenshot 2024-11-26 at 12 00 02" src="https://github.com/user-attachments/assets/f8eb31b2-3fee-4e9d-99f6-363e4b520ab9">
<img width="555" alt="Screenshot 2024-11-26 at 12 00 35" src="https://github.com/user-attachments/assets/8ebcc657-dc56-4867-ac0a-df9deead2894">

### Code Coverage

<img width="1241" alt="Screenshot 2024-11-26 at 11 45 33" src="https://github.com/user-attachments/assets/28765d3e-bf16-42b5-8867-bed396df1d1c">
