### PR TITLE
Preliminary setup for Zone Management. 

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -196,6 +196,8 @@ class MapScreenTest {
 
     composeTestRule.onNodeWithTag("SettingsMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("advancedModeSwitch").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("SettingsToZoneRow").assertIsDisplayed().performClick()
+    verify(mockNavigation).navigateTo(Route.ZONE)
   }
 
   /** Test that verify that the Search Bar works */

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
@@ -1,0 +1,36 @@
+package com.github.se.cyrcle.ui.zone
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+
+class ZoneManagerScreenTest {
+  @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun checkAllUIElementsAreDisplayed() {
+    composeTestRule.setContent { ZoneManagerScreen(navigationActions) }
+
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("TopAppBar"))
+    composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("AddButton").assertIsDisplayed().performClick()
+    verify(navigationActions).navigateTo(Screen.ZONE_SELECTION)
+  }
+}

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreenTest.kt
@@ -1,0 +1,31 @@
+package com.github.se.cyrcle.ui.zone
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class ZoneSelectionScreenTest {
+  @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun checkAllUIElementsAreDisplayed() {
+    composeTestRule.setContent { ZoneSelectionScreen(navigationActions) }
+
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("TopAppBar"))
+    composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -133,12 +133,8 @@ fun CyrcleNavHost(
         startDestination = Screen.ZONE_MANAGER,
         route = Route.ZONE,
     ) {
-      composable(Screen.ZONE_MANAGER) {
-          ZoneManagerScreen(navigationActions)
-      }
-        composable(Screen.ZONE_SELECTION) {
-        ZoneSelectionScreen(navigationActions)
-      }
+      composable(Screen.ZONE_MANAGER) { ZoneManagerScreen(navigationActions) }
+      composable(Screen.ZONE_SELECTION) { ZoneSelectionScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -31,6 +31,8 @@ import com.github.se.cyrcle.ui.report.ReviewReportScreen
 import com.github.se.cyrcle.ui.report.ViewReportsScreen
 import com.github.se.cyrcle.ui.review.AllReviewsScreen
 import com.github.se.cyrcle.ui.review.ReviewScreen
+import com.github.se.cyrcle.ui.zone.ZoneManagerScreen
+import com.github.se.cyrcle.ui.zone.ZoneSelectionScreen
 
 @Composable
 fun CyrcleNavHost(
@@ -126,6 +128,15 @@ fun CyrcleNavHost(
         route = Route.GAMBLING,
     ) {
       composable(Screen.GAMBLING) { GamblingScreen(navigationActions, userViewModel) }
+    }
+    navigation(
+        startDestination = Screen.ZONE_MANAGER,
+        route = Route.ZONE,
+    ) {
+      composable(Screen.ZONE_MANAGER) {
+        ZoneManagerScreen(navigationActions)
+        ZoneSelectionScreen(navigationActions)
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -134,7 +134,9 @@ fun CyrcleNavHost(
         route = Route.ZONE,
     ) {
       composable(Screen.ZONE_MANAGER) {
-        ZoneManagerScreen(navigationActions)
+          ZoneManagerScreen(navigationActions)
+      }
+        composable(Screen.ZONE_SELECTION) {
         ZoneSelectionScreen(navigationActions)
       }
     }

--- a/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
@@ -1,0 +1,29 @@
+package com.github.se.cyrcle.model.zone
+
+import com.mapbox.geojson.BoundingBox
+import java.time.LocalTime
+import java.util.UUID
+
+data class Zone(
+    val boundingBox: BoundingBox,
+    val name: String,
+    val lastRefreshed: LocalTime,
+    val uid: String
+) {
+  /**
+   * Zone constructor that set the time of the last refresh to the current time, and generates a new
+   * UID.
+   *
+   * @param boundingBox The bounding box of the zone.
+   * @name The name of the zone chosen by the user.
+   */
+  constructor(
+      boundingBox: BoundingBox,
+      name: String
+  ) : this(boundingBox, name, LocalTime.now(), generateZoneUid())
+}
+
+/** Generates a new UID for a zone. */
+private fun generateZoneUid(): String {
+  return UUID.randomUUID().toString()
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -644,11 +643,12 @@ fun SettingsMenu(
               modifier = Modifier.padding(16.dp),
               horizontalAlignment = Alignment.CenterHorizontally,
           ) {
-            Text(text = stringResource(R.string.settings), style = MaterialTheme.typography.headlineMedium)
+            Text(
+                text = stringResource(R.string.settings),
+                style = MaterialTheme.typography.headlineMedium)
             Spacer(modifier = Modifier.height(16.dp))
             // Advanced Mode
             Row(verticalAlignment = Alignment.CenterVertically) {
-
               Switch(
                   modifier = Modifier.padding(start = 8.dp).testTag("advancedModeSwitch"),
                   checked = mapMode.value.isAdvancedMode,
@@ -663,27 +663,30 @@ fun SettingsMenu(
                           .copy(
                               uncheckedTrackColor = disabledColor(),
                           ))
-                Spacer(modifier = Modifier.weight(1f))
-                Text(text = stringResource(R.string.map_screen_mode_switch_label))
-
+              Spacer(modifier = Modifier.weight(1f))
+              Text(text = stringResource(R.string.map_screen_mode_switch_label))
             }
-              HorizontalDivider(thickness = 1.dp, modifier = Modifier.fillMaxWidth(0.9f).padding(16.dp), color= MaterialTheme.colorScheme.onBackground)
+            HorizontalDivider(
+                thickness = 1.dp,
+                modifier = Modifier.fillMaxWidth(0.9f).padding(16.dp),
+                color = MaterialTheme.colorScheme.onBackground)
             // Offline Map Management
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.clickable {
-                 navigationActions.navigateTo(Route.ZONE)
-                })
-             {
-                // Icon with offline world
-                Icon(
-                    imageVector = Icons.Filled.CloudDownload,
-                    contentDescription = "Search",
-                    tint = defaultOnColor(),
-                    modifier = Modifier.padding(start = 8.dp).size(40.dp))
-                Spacer(Modifier.weight(1f))
-              Text(text = stringResource(R.string.map_screen_settings_to_zone))
-            }
+                modifier =
+                    Modifier.testTag("SettingsToZoneRow").clickable {
+                      navigationActions.navigateTo(Route.ZONE)
+                    }) {
+                  // Icon with offline world
+                  Icon(
+                      imageVector = Icons.Filled.CloudDownload,
+                      contentDescription = "Search",
+                      tint = defaultOnColor(),
+                      modifier = Modifier.padding(start = 8.dp).size(40.dp))
+
+                  Spacer(Modifier.weight(1f))
+                  Text(text = stringResource(R.string.map_screen_settings_to_zone))
+                }
           }
         }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -22,13 +24,16 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -529,7 +534,7 @@ fun MapScreen(
         }
 
         if (showSettings.value) {
-          SettingsMenu(mapMode, mapViewModel)
+          SettingsMenu(mapMode, mapViewModel, navigationActions)
         }
 
         if (showSuggestions.value &&
@@ -623,21 +628,27 @@ fun SuggestionMenu(
  *
  * @param mapMode The current map mode state.
  * @param mapViewModel The ViewModel for managing map-related data and actions.
+ * @param navigationActions The actions to navigate to different screens.
  */
 @Composable
-fun SettingsMenu(mapMode: State<MapViewModel.MapMode>, mapViewModel: MapViewModel) {
+fun SettingsMenu(
+    mapMode: State<MapViewModel.MapMode>,
+    mapViewModel: MapViewModel,
+    navigationActions: NavigationActions
+) {
   Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.TopEnd) {
     Card(
         modifier =
             Modifier.width(300.dp).height(400.dp).align(Alignment.Center).testTag("SettingsMenu")) {
-          Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = stringResource(R.string.settings))
+          Column(
+              modifier = Modifier.padding(16.dp),
+              horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            Text(text = stringResource(R.string.settings), style = MaterialTheme.typography.headlineMedium)
             Spacer(modifier = Modifier.height(16.dp))
-
             // Advanced Mode
             Row(verticalAlignment = Alignment.CenterVertically) {
-              Text(text = stringResource(R.string.map_screen_mode_switch_label))
-              Spacer(modifier = Modifier.weight(1f))
+
               Switch(
                   modifier = Modifier.padding(start = 8.dp).testTag("advancedModeSwitch"),
                   checked = mapMode.value.isAdvancedMode,
@@ -652,6 +663,26 @@ fun SettingsMenu(mapMode: State<MapViewModel.MapMode>, mapViewModel: MapViewMode
                           .copy(
                               uncheckedTrackColor = disabledColor(),
                           ))
+                Spacer(modifier = Modifier.weight(1f))
+                Text(text = stringResource(R.string.map_screen_mode_switch_label))
+
+            }
+              HorizontalDivider(thickness = 1.dp, modifier = Modifier.fillMaxWidth(0.9f).padding(16.dp), color= MaterialTheme.colorScheme.onBackground)
+            // Offline Map Management
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable {
+                 navigationActions.navigateTo(Route.ZONE)
+                })
+             {
+                // Icon with offline world
+                Icon(
+                    imageVector = Icons.Filled.CloudDownload,
+                    contentDescription = "Search",
+                    tint = defaultOnColor(),
+                    modifier = Modifier.padding(start = 8.dp).size(40.dp))
+                Spacer(Modifier.weight(1f))
+              Text(text = stringResource(R.string.map_screen_settings_to_zone))
             }
           }
         }

--- a/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/navigation/NavigationActions.kt
@@ -14,9 +14,8 @@ object Route {
   const val ADD_SPOTS = "Add Spots"
   const val VIEW_PROFILE = "Profile"
   const val REVIEW = "Review"
-  const val PARKING_REPORT = "Report"
-  const val REVIEW_REPORT = "Report"
   const val GAMBLING = "Gambling"
+  const val ZONE = "Zone"
 }
 
 object Screen {
@@ -36,6 +35,8 @@ object Screen {
   const val GAMBLING = "Gambling Screen"
   const val ADMIN = "Admin Screen"
   const val VIEW_REPORTS = "View Reports Screen"
+  const val ZONE_SELECTION = "Zone Selection Screen"
+  const val ZONE_MANAGER = "Zone Manager Screen"
 }
 
 /**

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -1,0 +1,11 @@
+package com.github.se.cyrcle.ui.zone
+
+import androidx.compose.runtime.Composable
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.theme.atoms.Text
+
+/** Screen where users can manage their downloaded zones. and access the zone selection screen. */
+@Composable
+fun ZoneManagerScreen(navigationActions: NavigationActions) {
+  Text("Zone Manager")
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -1,11 +1,53 @@
 package com.github.se.cyrcle.ui.zone
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.navigation.Screen
+import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.atoms.IconButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 /** Screen where users can manage their downloaded zones. and access the zone selection screen. */
 @Composable
 fun ZoneManagerScreen(navigationActions: NavigationActions) {
-  Text("Zone Manager")
+    Scaffold(
+        topBar = {TopAppBar(title = stringResource(R.string.zone_manager_screen_title), navigationActions = navigationActions)}
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+            AddZoneButton(navigationActions)
+            Text("TODO")
+        }
+    }
+}
+
+
+@Composable
+fun AddZoneButton(navigationActions: NavigationActions) {
+    Box(modifier = Modifier.fillMaxSize())
+    {
+        IconButton(
+            icon = Icons.Default.Add,
+            contentDescription = "Add new Zone",
+            modifier =
+            Modifier.align(Alignment.BottomStart)
+                .scale(1.2f)
+                .padding(bottom = 25.dp, start = 16.dp),
+            onClick = { navigationActions.navigateTo(Screen.ZONE_SELECTION) },
+            colorLevel = ColorLevel.PRIMARY,
+            testTag = "addButton"
+        )
+    }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -23,31 +23,31 @@ import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 /** Screen where users can manage their downloaded zones. and access the zone selection screen. */
 @Composable
 fun ZoneManagerScreen(navigationActions: NavigationActions) {
-    Scaffold(
-        topBar = {TopAppBar(title = stringResource(R.string.zone_manager_screen_title), navigationActions = navigationActions)}
-    ) { padding ->
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = stringResource(R.string.zone_manager_screen_title),
+            navigationActions = navigationActions)
+      }) { padding ->
         Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-            AddZoneButton(navigationActions)
-            Text("TODO")
+          AddZoneButton(navigationActions)
+          Text("TODO")
         }
-    }
+      }
 }
-
 
 @Composable
 fun AddZoneButton(navigationActions: NavigationActions) {
-    Box(modifier = Modifier.fillMaxSize())
-    {
-        IconButton(
-            icon = Icons.Default.Add,
-            contentDescription = "Add new Zone",
-            modifier =
+  Box(modifier = Modifier.fillMaxSize()) {
+    IconButton(
+        icon = Icons.Default.Add,
+        contentDescription = "Add new Zone",
+        modifier =
             Modifier.align(Alignment.BottomStart)
                 .scale(1.2f)
                 .padding(bottom = 25.dp, start = 16.dp),
-            onClick = { navigationActions.navigateTo(Screen.ZONE_SELECTION) },
-            colorLevel = ColorLevel.PRIMARY,
-            testTag = "addButton"
-        )
-    }
+        onClick = { navigationActions.navigateTo(Screen.ZONE_SELECTION) },
+        colorLevel = ColorLevel.PRIMARY,
+        testTag = "AddButton")
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -16,16 +16,11 @@ import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 @Composable
 fun ZoneSelectionScreen(navigationActions: NavigationActions) {
   Scaffold(
-    topBar = {
-      TopAppBar(title = stringResource(R.string.zone_selection_screen_title), navigationActions = navigationActions)
-    }
-  ) { padding ->
-    Box(
-      modifier = Modifier.padding(padding).fillMaxSize()
-    ) {
-      Text("TODO")
-    }
-  }
+      topBar = {
+        TopAppBar(
+            title = stringResource(R.string.zone_selection_screen_title),
+            navigationActions = navigationActions)
+      }) { padding ->
+        Box(modifier = Modifier.padding(padding).fillMaxSize()) { Text("TODO") }
+      }
 }
-
-

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -1,0 +1,11 @@
+package com.github.se.cyrcle.ui.zone
+
+import androidx.compose.runtime.Composable
+import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.theme.atoms.Text
+
+/** Screen where users can select a new zone to download. */
+@Composable
+fun ZoneSelectionScreen(navigationActions: NavigationActions) {
+  Text("New Zone Selection")
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -1,11 +1,31 @@
 package com.github.se.cyrcle.ui.zone
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.github.se.cyrcle.R
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 /** Screen where users can select a new zone to download. */
 @Composable
 fun ZoneSelectionScreen(navigationActions: NavigationActions) {
-  Text("New Zone Selection")
+  Scaffold(
+    topBar = {
+      TopAppBar(title = stringResource(R.string.zone_selection_screen_title), navigationActions = navigationActions)
+    }
+  ) { padding ->
+    Box(
+      modifier = Modifier.padding(padding).fillMaxSize()
+    ) {
+      Text("TODO")
+    }
+  }
 }
+
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <!-- Map Screen -->
     <string name="map_screen_capacity">Capacity is %s</string>
     <string name="map_screen_mode_switch_label">Advanced Mode</string>
+    <string name="map_screen_settings_to_zone">Offline Map</string>
     <string name="settings">Settings</string>
     <string name="search_bar_placeholder">Search for a location</string>
 
@@ -248,6 +249,10 @@
     <string name="admin_reason">Reason: %s</string>
     <string name="admin_reportedBy">Reported By: %s</string>
     <string name="admin_description">Description: %s</string>
+
+    <!-- Zone Screens -->
+    <string name="zone_manager_screen_title">Offline Maps</string>
+    <string name="zone_selection_screen_title">Select Zone</string>
 
 
 


### PR DESCRIPTION
- closes : #328 
- closes : #329 
## What
#### This PR includes the preliminary changes to make the zone management, necessary for our offline mode.
The only notable change for the app is on the settings popup : 
<img width="182" alt="image" src="https://github.com/user-attachments/assets/8b7527e5-ab77-4cc1-bf06-2efb1010f499">

## How
-  `Zone` Data class (unused for now) 
A zone is an area of the map the user has selected for download.
- `ZoneManagerScreen`, the screen from which a user will be able to manage all of his zones stored on his deviced.
- `ZoneSelectionScreen` the screen accessible from `ZoneManagerScreen` to allow user to create new zone.
-  new Row on the settings of mapScreen to access the `ZoneManagerScreen`.

_I will not submit this PR for grading as it does not bring any functionality, this PR is all the boilerplate, boring code so that the next ones can be centered around functionnality_ 

-- -

## Code coverage
ui.zone : 74%
model.zone : 0% 
(Obviously as this is only boilerplate code and the zones are not used the cc is really low)

<img width="245" alt="image" src="https://github.com/user-attachments/assets/057b4abb-2fb4-4fe2-ad8e-b8a5edf9735f"> how are we at 80%, can anybody check?
