### PR TITLE
Add and Manage zones

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
@@ -1,13 +1,18 @@
 package com.github.se.cyrcle.ui.zone
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
+import com.mapbox.geojson.BoundingBox
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,12 +30,42 @@ class ZoneManagerScreenTest {
 
   @OptIn(ExperimentalTestApi::class)
   @Test
-  fun checkAllUIElementsAreDisplayed() {
+  fun checkAllUIElementsAreDisplayedWithNoZones() {
     composeTestRule.setContent { ZoneManagerScreen(navigationActions) }
 
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("TopAppBar"))
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("AddButton").assertIsDisplayed().performClick()
     verify(navigationActions).navigateTo(Screen.ZONE_SELECTION)
+
+    composeTestRule.onNodeWithTag("ZoneManagerHeader").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ZoneCard").assertDoesNotExist()
+  }
+
+  @Test
+  fun verifyDisplayOfZoneCard() {
+    val zone =
+        Zone(
+            BoundingBox.fromLngLats(0.0, 0.0, 1.0, 1.0),
+            "Test Zone",
+        )
+    val zonesState = mutableStateOf(listOf(zone))
+    composeTestRule.setContent { ZoneCard(zone, zonesState) }
+    composeTestRule
+        .onNodeWithContentDescription("Refresh")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+    composeTestRule
+        .onNodeWithContentDescription("Delete")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+  }
+
+  @Test
+  fun verifyHeader() {
+    composeTestRule.setContent { ZoneHeader() }
+    composeTestRule.onNodeWithTag("ZoneManagerHeaderArea").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ZoneManagerHeaderLastRefreshed").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("Refresh").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
@@ -22,6 +23,7 @@ import org.mockito.kotlin.verify
 class ZoneManagerScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
   private lateinit var navigationActions: NavigationActions
+  val mapViewModel = MapViewModel()
 
   @Before
   fun setUp() {
@@ -31,7 +33,7 @@ class ZoneManagerScreenTest {
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun checkAllUIElementsAreDisplayedWithNoZones() {
-    composeTestRule.setContent { ZoneManagerScreen(navigationActions) }
+    composeTestRule.setContent { ZoneManagerScreen(mapViewModel, navigationActions) }
 
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("TopAppBar"))
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreenTest.kt
@@ -44,7 +44,7 @@ class ZoneSelectionScreenTest {
   fun verifyAlertDialog() {
     composeTestRule.setContent { AlertDialogPickZoneName() }
     composeTestRule.onNodeWithTag("AlertDialogTitle").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("InputText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ConditionCheckingInputText").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("AlertDialogButtonAccept")
         .assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreenTest.kt
@@ -1,10 +1,14 @@
 package com.github.se.cyrcle.ui.zone
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.github.se.cyrcle.di.mocks.MockAddressRepository
+import com.github.se.cyrcle.model.address.AddressViewModel
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import org.junit.Before
 import org.junit.Rule
@@ -14,18 +18,40 @@ import org.mockito.Mockito.mock
 class ZoneSelectionScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
   private lateinit var navigationActions: NavigationActions
+  private lateinit var mapViewModel: MapViewModel
+  private lateinit var addressViewModel: AddressViewModel
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    mapViewModel = MapViewModel()
+    val addressRepository = MockAddressRepository()
+    addressViewModel = AddressViewModel(addressRepository)
   }
 
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun checkAllUIElementsAreDisplayed() {
-    composeTestRule.setContent { ZoneSelectionScreen(navigationActions) }
+    composeTestRule.setContent {
+      ZoneSelectionScreen(navigationActions, mapViewModel, addressViewModel)
+    }
 
     composeTestRule.waitUntilExactlyOneExists(hasTestTag("TopAppBar"))
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
+  }
+
+  @Test
+  fun verifyAlertDialog() {
+    composeTestRule.setContent { AlertDialogPickZoneName() }
+    composeTestRule.onNodeWithTag("AlertDialogTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("InputText").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("AlertDialogButtonAccept")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+    composeTestRule
+        .onNodeWithTag("AlertDialogButtonCancel")
+        .assertIsDisplayed()
+        .assertHasClickAction()
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -134,7 +134,7 @@ fun CyrcleNavHost(
         route = Route.ZONE,
     ) {
       composable(Screen.ZONE_MANAGER) { ZoneManagerScreen(navigationActions) }
-      composable(Screen.ZONE_SELECTION) { ZoneSelectionScreen(navigationActions) }
+      composable(Screen.ZONE_SELECTION) { ZoneSelectionScreen(navigationActions, mapViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -134,7 +134,7 @@ fun CyrcleNavHost(
         route = Route.ZONE,
     ) {
       composable(Screen.ZONE_MANAGER) { ZoneManagerScreen(navigationActions) }
-      composable(Screen.ZONE_SELECTION) { ZoneSelectionScreen(navigationActions, mapViewModel) }
+      composable(Screen.ZONE_SELECTION) { ZoneSelectionScreen(navigationActions, mapViewModel, addressViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -133,7 +133,7 @@ fun CyrcleNavHost(
         startDestination = Screen.ZONE_MANAGER,
         route = Route.ZONE,
     ) {
-      composable(Screen.ZONE_MANAGER) { ZoneManagerScreen(navigationActions) }
+      composable(Screen.ZONE_MANAGER) { ZoneManagerScreen(mapViewModel, navigationActions) }
       composable(Screen.ZONE_SELECTION) {
         ZoneSelectionScreen(navigationActions, mapViewModel, addressViewModel)
       }

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -134,7 +134,9 @@ fun CyrcleNavHost(
         route = Route.ZONE,
     ) {
       composable(Screen.ZONE_MANAGER) { ZoneManagerScreen(navigationActions) }
-      composable(Screen.ZONE_SELECTION) { ZoneSelectionScreen(navigationActions, mapViewModel, addressViewModel) }
+      composable(Screen.ZONE_SELECTION) {
+        ZoneSelectionScreen(navigationActions, mapViewModel, addressViewModel)
+      }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 
+const val DEFAULT_ZOOM_FOR_ZONE_SELECTION = 10.0
+
 class MapViewModel : ViewModel() {
 
   private val _cameraPosition = MutableStateFlow<CameraState?>(MapConfig.defaultCameraState())
@@ -142,10 +144,19 @@ class MapViewModel : ViewModel() {
     _cameraPosition.value = newCameraState
   }
 
-  fun unZoomActualCamera() {
+  /**
+   * Unzooms the camera, to show a large are of the map to the user selecting a zone to download
+   * offline.
+   */
+  fun setCameraForZoneSelection() {
     val actualCamera = _cameraPosition.value!!
     _cameraPosition.value =
-        CameraState(actualCamera.center, EdgeInsets(0.0, 0.0, 0.0, 0.0), 10.0, 0.0, 0.0)
+        CameraState(
+            actualCamera.center,
+            EdgeInsets(0.0, 0.0, 0.0, 0.0),
+            DEFAULT_ZOOM_FOR_ZONE_SELECTION,
+            0.0,
+            0.0)
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -142,6 +142,12 @@ class MapViewModel : ViewModel() {
     _cameraPosition.value = newCameraState
   }
 
+  fun unZoomActualCamera() {
+    val actualCamera = _cameraPosition.value!!
+    _cameraPosition.value =
+        CameraState(actualCamera.center, EdgeInsets(0.0, 0.0, 0.0, 0.0), 10.0, 0.0, 0.0)
+  }
+
   /**
    * Update the screen coordinates states
    *

--- a/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
@@ -1,34 +1,35 @@
 package com.github.se.cyrcle.model.zone
 
+import android.content.Context
 import com.mapbox.geojson.BoundingBox
-import org.json.JSONObject
 import java.io.File
-import java.time.LocalTime
+import java.time.LocalDate
 import java.util.UUID
+import org.json.JSONObject
+
+const val ZONE_DIR = "zones"
 
 data class Zone(
     val boundingBox: BoundingBox,
     val name: String,
-    val lastRefreshed: LocalTime,
+    val lastRefreshed: LocalDate,
     val uid: String
 ) {
-    /**
-     * Zone constructor that set the time of the last refresh to the current time, and generates a new
-     * UID.
-     *
-     * @param boundingBox The bounding box of the zone.
-     * @name The name of the zone chosen by the user.
-     */
-    constructor(
-        boundingBox: BoundingBox,
-        name: String
-    ) : this(boundingBox, name, LocalTime.now(), generateZoneUid())
+  /**
+   * Zone constructor that set the time of the last refresh to the current time, and generates a new
+   * UID.
+   *
+   * @param boundingBox The bounding box of the zone.
+   * @name The name of the zone chosen by the user.
+   */
+  constructor(
+      boundingBox: BoundingBox,
+      name: String
+  ) : this(boundingBox, name, LocalDate.now(), generateZoneUid())
 
-    /**
-     * Returns a JSON representation of the zone.
-     */
-    fun toJson(): String {
-        return """
+  /** Returns a JSON representation of the zone. */
+  fun toJson(): String {
+    return """
             {
                 "boundingBox": {
                     "south": ${boundingBox.south()},
@@ -40,53 +41,89 @@ data class Zone(
                 "lastRefreshed": "$lastRefreshed",
                 "uid": "$uid"
             }
-        """.trimIndent()
-    }
-    companion object {
-        /**
-         * Creates a new zone from a JSON representation.
-         * @param json The JSON representation of the zone.
-         */
-        fun fromJson(json: String): Zone {
-            val jsonObject = JSONObject(json)
-            val boundingBox = BoundingBox.fromLngLats(
+        """
+        .trimIndent()
+  }
+
+  companion object {
+    /**
+     * Creates a new zone from a JSON representation.
+     *
+     * @param json The JSON representation of the zone.
+     */
+    private fun fromJson(json: String): Zone? {
+      return try {
+        val jsonObject = JSONObject(json)
+        val boundingBox =
+            BoundingBox.fromLngLats(
                 jsonObject.getJSONObject("boundingBox").getDouble("west"),
                 jsonObject.getJSONObject("boundingBox").getDouble("south"),
                 jsonObject.getJSONObject("boundingBox").getDouble("east"),
-                jsonObject.getJSONObject("boundingBox").getDouble("north")
-            )
-            val name = jsonObject.getString("name")
-            val lastRefreshed = LocalTime.parse(jsonObject.getString("lastRefreshed"))
-            val uid = jsonObject.getString("uid")
-            return Zone(boundingBox, name, lastRefreshed, uid)
-        }
-
-        /**
-         * Store a zone as a JSON file inside the directory passed as a parameter.
-         * @param zone The zone to store.
-         * @param zoneDir The directory where the zone will be stored.
-         */
-        fun storeZone(zone: Zone, zoneDir: File) {
-            if (!zoneDir.exists()) {
-                zoneDir.mkdirs()
-            }
-            File(zoneDir, "${zone.uid}.json").writeText(zone.toJson())
-        }
-
-        /**
-         * Load all the zones stored in the directory passed as a parameter.
-         * @param zoneDir The directory where the zones are stored.
-         */
-        fun loadZones(zoneDir: File): List<Zone> {
-            if (!zoneDir.exists()) {
-               zoneDir.mkdirs()
-            }
-            return zoneDir.listFiles()?.map { file -> fromJson(file.readText()) } ?: emptyList()
-        }
+                jsonObject.getJSONObject("boundingBox").getDouble("north"))
+        val name = jsonObject.getString("name")
+        val lastRefreshed = LocalDate.parse(jsonObject.getString("lastRefreshed"))
+        val uid = jsonObject.getString("uid")
+        Zone(boundingBox, name, lastRefreshed, uid)
+      } catch (e: Exception) {
+        null
+      }
     }
+
+    /**
+     * Store a zone as a JSON file inside the directory passed as a parameter.
+     *
+     * @param zone The zone to store.
+     * @param context The context of the application, necessary to access the file system.
+     */
+    fun storeZone(zone: Zone, context: Context) {
+      val zoneDir = File(context.filesDir, ZONE_DIR)
+      if (!zoneDir.exists()) {
+        zoneDir.mkdirs()
+      }
+      File(zoneDir, "${zone.uid}.json").writeText(zone.toJson())
+    }
+
+    /**
+     * Load all the zones stored in the directory.
+     *
+     * @param context The context of the application, necessary to access the file system.
+     */
+    fun loadZones(context: Context): List<Zone> {
+      val zoneDir = File(context.filesDir, ZONE_DIR)
+      if (!zoneDir.exists()) {
+        zoneDir.mkdirs()
+      }
+      return zoneDir.listFiles()?.map { file -> fromJson(file.readText()) }?.filterNotNull()
+          ?: emptyList()
+    }
+
+    /**
+     * Delete a zone from the directory passed as a parameter.
+     *
+     * @param zone The zone to delete.
+     */
+    fun deleteZone(zone: Zone, context: Context) {
+      val zoneDir = File(context.filesDir, ZONE_DIR)
+      if (!zoneDir.exists()) return
+      try {
+        File(zoneDir, "${zone.uid}.json").delete()
+      } catch (e: Exception) { // If the file can't be deleted, we just ignore the exception.
+        return
+      }
+    }
+
+    /**
+     * Refreshs a zone by just replacing the lastRefreshed field with the current time. and stores
+     * the updated zone.
+     */
+    fun refreshZone(zone: Zone, context: Context) {
+      val updatedZone = zone.copy(lastRefreshed = LocalDate.now())
+      storeZone(updatedZone, context)
+    }
+  }
 }
 
 /** Generates a new UID for a zone. */
 private fun generateZoneUid(): String {
-    return UUID.randomUUID().toString()
+  return UUID.randomUUID().toString()
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
@@ -1,6 +1,8 @@
 package com.github.se.cyrcle.model.zone
 
 import com.mapbox.geojson.BoundingBox
+import org.json.JSONObject
+import java.io.File
 import java.time.LocalTime
 import java.util.UUID
 
@@ -10,20 +12,81 @@ data class Zone(
     val lastRefreshed: LocalTime,
     val uid: String
 ) {
-  /**
-   * Zone constructor that set the time of the last refresh to the current time, and generates a new
-   * UID.
-   *
-   * @param boundingBox The bounding box of the zone.
-   * @name The name of the zone chosen by the user.
-   */
-  constructor(
-      boundingBox: BoundingBox,
-      name: String
-  ) : this(boundingBox, name, LocalTime.now(), generateZoneUid())
+    /**
+     * Zone constructor that set the time of the last refresh to the current time, and generates a new
+     * UID.
+     *
+     * @param boundingBox The bounding box of the zone.
+     * @name The name of the zone chosen by the user.
+     */
+    constructor(
+        boundingBox: BoundingBox,
+        name: String
+    ) : this(boundingBox, name, LocalTime.now(), generateZoneUid())
+
+    /**
+     * Returns a JSON representation of the zone.
+     */
+    fun toJson(): String {
+        return """
+            {
+                "boundingBox": {
+                    "south": ${boundingBox.south()},
+                    "west": ${boundingBox.west()},
+                    "north": ${boundingBox.north()},
+                    "east": ${boundingBox.east()}
+                },
+                "name": "$name",
+                "lastRefreshed": "$lastRefreshed",
+                "uid": "$uid"
+            }
+        """.trimIndent()
+    }
+    companion object {
+        /**
+         * Creates a new zone from a JSON representation.
+         * @param json The JSON representation of the zone.
+         */
+        fun fromJson(json: String): Zone {
+            val jsonObject = JSONObject(json)
+            val boundingBox = BoundingBox.fromLngLats(
+                jsonObject.getJSONObject("boundingBox").getDouble("west"),
+                jsonObject.getJSONObject("boundingBox").getDouble("south"),
+                jsonObject.getJSONObject("boundingBox").getDouble("east"),
+                jsonObject.getJSONObject("boundingBox").getDouble("north")
+            )
+            val name = jsonObject.getString("name")
+            val lastRefreshed = LocalTime.parse(jsonObject.getString("lastRefreshed"))
+            val uid = jsonObject.getString("uid")
+            return Zone(boundingBox, name, lastRefreshed, uid)
+        }
+
+        /**
+         * Store a zone as a JSON file inside the directory passed as a parameter.
+         * @param zone The zone to store.
+         * @param zoneDir The directory where the zone will be stored.
+         */
+        fun storeZone(zone: Zone, zoneDir: File) {
+            if (!zoneDir.exists()) {
+                zoneDir.mkdirs()
+            }
+            File(zoneDir, "${zone.uid}.json").writeText(zone.toJson())
+        }
+
+        /**
+         * Load all the zones stored in the directory passed as a parameter.
+         * @param zoneDir The directory where the zones are stored.
+         */
+        fun loadZones(zoneDir: File): List<Zone> {
+            if (!zoneDir.exists()) {
+               zoneDir.mkdirs()
+            }
+            return zoneDir.listFiles()?.map { file -> fromJson(file.readText()) } ?: emptyList()
+        }
+    }
 }
 
 /** Generates a new UID for a zone. */
 private fun generateZoneUid(): String {
-  return UUID.randomUUID().toString()
+    return UUID.randomUUID().toString()
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/zone/Zone.kt
@@ -93,8 +93,7 @@ data class Zone(
       if (!zoneDir.exists()) {
         zoneDir.mkdirs()
       }
-      return zoneDir.listFiles()?.map { file -> fromJson(file.readText()) }?.filterNotNull()
-          ?: emptyList()
+      return zoneDir.listFiles()?.mapNotNull { file -> fromJson(file.readText()) } ?: emptyList()
     }
 
     /**

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
@@ -44,72 +44,76 @@ fun LocationPickerBottomBar(
 ) {
   val locationPickerState by mapViewModel.locationPickerState.collectAsState()
   val isLocationValid by mapViewModel.isLocationValid.collectAsState(true)
-  Box(Modifier.background(Color.White).height(100.dp).testTag("LocationPickerBottomBar")) {
-    Row(
-        Modifier.fillMaxWidth()
-            .wrapContentHeight()
-            .padding(16.dp)
-            .background(MaterialTheme.colorScheme.background),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically) {
-          Button(
-              {
-                mapViewModel.updateCameraPositionWithoutBearing(
-                    mapView.value?.mapboxMap?.cameraState!!)
-                navigationActions.navigateTo(Screen.MAP)
-              },
-              modifier = Modifier.testTag("cancelButton"),
-              colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
-                Text(
-                    stringResource(R.string.location_picker_bottom_bar_cancel_button),
-                    modifier = Modifier.width(100.dp),
-                    color = MaterialTheme.colorScheme.primary,
-                    style = Typography.headlineMedium,
-                    textAlign = TextAlign.Center)
-              }
-          VerticalDivider(
-              color = MaterialTheme.colorScheme.primary,
-              modifier = Modifier.height(32.dp).width(1.dp),
-              thickness = 2.dp)
-
-          if (locationPickerState == LocationPickerState.NONE_SET) {
-            Button(
-                { onTopLeftSelected(mapViewModel) },
-                modifier = Modifier.testTag("nextButton"),
-                colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
-                  Text(
-                      stringResource(R.string.location_picker_bottom_bar_next_button),
-                      modifier = Modifier.width(100.dp),
-                      color = MaterialTheme.colorScheme.primary,
-                      style = Typography.headlineMedium,
-                      textAlign = TextAlign.Center)
-                }
-          } else if (locationPickerState == LocationPickerState.TOP_LEFT_SET) {
-            Button(
-                {
-                  if (isLocationValid) {
-                    onBottomRightSelected(mapViewModel)
-                  } else {
-                    Toast.makeText(
-                            mapView.value?.context,
-                            R.string.location_picker_invalid_area,
-                            Toast.LENGTH_SHORT)
-                        .show()
+  Box(
+      Modifier.background(Color.White).height(100.dp).testTag("LocationPickerBottomBar"),
+      contentAlignment = Alignment.Center) {
+        Row(
+            Modifier.fillMaxWidth()
+                .wrapContentHeight()
+                .padding(16.dp)
+                .background(MaterialTheme.colorScheme.background),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically) {
+              Button(
+                  {
+                    mapViewModel.updateCameraPositionWithoutBearing(
+                        mapView.value?.mapboxMap?.cameraState!!)
+                    navigationActions.navigateTo(Screen.MAP)
+                  },
+                  modifier = Modifier.testTag("cancelButton"),
+                  colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                    Text(
+                        stringResource(R.string.location_picker_bottom_bar_cancel_button),
+                        modifier = Modifier.width(100.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                        style = Typography.headlineMedium,
+                        textAlign = TextAlign.Center)
                   }
-                },
-                modifier = Modifier.testTag("nextButton"),
-                colors = ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
-                  Log.d("LocationPickerBottomBar", "isLocationValid: $isLocationValid")
-                  Text(
-                      stringResource(R.string.location_picker_bottom_bar_next_button),
-                      modifier = Modifier.width(100.dp),
-                      color =
-                          if (isLocationValid) MaterialTheme.colorScheme.primary
-                          else disabledColor(),
-                      style = Typography.headlineMedium,
-                      textAlign = TextAlign.Center)
-                }
-          }
-        }
-  }
+              VerticalDivider(
+                  color = MaterialTheme.colorScheme.primary,
+                  modifier = Modifier.height(32.dp).width(1.dp),
+                  thickness = 2.dp)
+
+              if (locationPickerState == LocationPickerState.NONE_SET) {
+                Button(
+                    { onTopLeftSelected(mapViewModel) },
+                    modifier = Modifier.testTag("nextButton"),
+                    colors =
+                        ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                      Text(
+                          stringResource(R.string.location_picker_bottom_bar_next_button),
+                          modifier = Modifier.width(100.dp),
+                          color = MaterialTheme.colorScheme.primary,
+                          style = Typography.headlineMedium,
+                          textAlign = TextAlign.Center)
+                    }
+              } else if (locationPickerState == LocationPickerState.TOP_LEFT_SET) {
+                Button(
+                    {
+                      if (isLocationValid) {
+                        onBottomRightSelected(mapViewModel)
+                      } else {
+                        Toast.makeText(
+                                mapView.value?.context,
+                                R.string.location_picker_invalid_area,
+                                Toast.LENGTH_SHORT)
+                            .show()
+                      }
+                    },
+                    modifier = Modifier.testTag("nextButton"),
+                    colors =
+                        ButtonDefaults.buttonColors().copy(containerColor = Color.Transparent)) {
+                      Log.d("LocationPickerBottomBar", "isLocationValid: $isLocationValid")
+                      Text(
+                          stringResource(R.string.location_picker_bottom_bar_next_button),
+                          modifier = Modifier.width(100.dp),
+                          color =
+                              if (isLocationValid) MaterialTheme.colorScheme.primary
+                              else disabledColor(),
+                          style = Typography.headlineMedium,
+                          textAlign = TextAlign.Center)
+                    }
+              }
+            }
+      }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -38,10 +39,14 @@ import com.mapbox.maps.ScreenCoordinate
 fun RectangleSelection(
     mapViewModel: MapViewModel,
     paddingValues: PaddingValues,
-    mapView: MapView?
+    mapView: MapView?,
+    restrictSelectionSize: Boolean = true
 ) {
   val locationPickerState by mapViewModel.locationPickerState.collectAsState()
-  val isLocationValid by mapViewModel.isLocationValid.collectAsState(true)
+  val isLocationValid by
+      mapViewModel.isLocationValid.collectAsState(initial = true).let { locationValidState ->
+        derivedStateOf { !restrictSelectionSize || locationValidState.value }
+      }
   val center = Offset(0.5f, 0.5f)
   var touchPosition by remember { mutableStateOf(Offset.Unspecified) }
   val hasDragged = remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -438,6 +438,7 @@ fun MapScreen(
                   markerAnnotationManager?.deleteAll()
                   mapViewModel.removePreviewCard()
                   mapViewModel.updateViewAnnotationManager(null)
+                  mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
                 }
               }
             }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/atoms/Input.kt
@@ -104,6 +104,7 @@ fun ConditionCheckingInputText(
     maxCharacters: Int = Int.MAX_VALUE,
     maxLines: Int = Int.MAX_VALUE,
     hasClearIcon: Boolean = true,
+    smallText: Boolean = false,
     testTag: String = "ConditionCheckingInputText"
 ) {
   Column {
@@ -121,20 +122,30 @@ fun ConditionCheckingInputText(
     // Display error message below the text field if the input is not valid
     if (isError) {
       Row(
-          modifier = Modifier.padding(top = 4.dp).testTag("${testTag}ErrorRow"),
+          modifier = modifier.padding(top = 4.dp).testTag("${testTag}ErrorRow"),
           verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.Filled.WarningAmber,
-                contentDescription = "Error",
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(16.dp),
-            )
+            if (!smallText) {
+              Icon(
+                  imageVector = Icons.Filled.WarningAmber,
+                  contentDescription = "Error",
+                  tint = MaterialTheme.colorScheme.error,
+                  modifier = Modifier.size(16.dp),
+              )
+            }
             Text(
                 text =
                     if (value.length < minCharacters) {
-                      stringResource(R.string.input_min_characters, minCharacters, value.length)
+                      if (smallText) {
+                        stringResource(R.string.input_min_characters_small, minCharacters)
+                      } else {
+                        stringResource(R.string.input_min_characters, minCharacters, value.length)
+                      }
                     } else {
-                      stringResource(R.string.input_max_characters, maxCharacters, value.length)
+                      if (smallText) {
+                        stringResource(R.string.input_max_characters_small, maxCharacters)
+                      } else {
+                        stringResource(R.string.input_max_characters, maxCharacters, value.length)
+                      }
                     },
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
@@ -44,7 +45,7 @@ import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
 /** Screen where users can manage their downloaded zones. and access the zone selection screen. */
 @Composable
-fun ZoneManagerScreen(navigationActions: NavigationActions) {
+fun ZoneManagerScreen(mapViewModel: MapViewModel, navigationActions: NavigationActions) {
   val context = LocalContext.current
   val zones = remember { mutableStateOf<List<Zone>>(emptyList()) }
   LaunchedEffect(Unit) {
@@ -60,7 +61,7 @@ fun ZoneManagerScreen(navigationActions: NavigationActions) {
       }) { padding ->
         Box(modifier = Modifier.padding(padding).fillMaxSize()) {
           // === Overlay ===
-          AddZoneButton(navigationActions)
+          AddZoneButton(mapViewModel, navigationActions)
           // ===  === ===  ===
 
           // === Content ===
@@ -90,7 +91,7 @@ fun ZoneManagerScreen(navigationActions: NavigationActions) {
 }
 // The overlaid button that allows the user to add a new zone.
 @Composable
-fun AddZoneButton(navigationActions: NavigationActions) {
+fun AddZoneButton(mapViewModel: MapViewModel, navigationActions: NavigationActions) {
   Box(modifier = Modifier.fillMaxSize()) {
     IconButton(
         icon = Icons.Default.Add,
@@ -99,7 +100,10 @@ fun AddZoneButton(navigationActions: NavigationActions) {
             Modifier.align(Alignment.BottomStart)
                 .scale(1.2f)
                 .padding(bottom = 25.dp, start = 16.dp),
-        onClick = { navigationActions.navigateTo(Screen.ZONE_SELECTION) },
+        onClick = {
+          mapViewModel.updateLocationPickerState(MapViewModel.LocationPickerState.NONE_SET)
+          navigationActions.navigateTo(Screen.ZONE_SELECTION)
+        },
         colorLevel = ColorLevel.PRIMARY,
         testTag = "AddButton")
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
@@ -60,10 +62,6 @@ fun ZoneManagerScreen(mapViewModel: MapViewModel, navigationActions: NavigationA
             navigationActions = navigationActions)
       }) { padding ->
         Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-          // === Overlay ===
-          AddZoneButton(mapViewModel, navigationActions)
-          // ===  === ===  ===
-
           // === Content ===
           Column(Modifier.fillMaxWidth()) {
             ZoneHeader()
@@ -72,20 +70,24 @@ fun ZoneManagerScreen(mapViewModel: MapViewModel, navigationActions: NavigationA
                   text = stringResource(R.string.zone_manager_no_zones),
                   modifier = Modifier.padding(16.dp))
             }
-            zones.value.forEach { zone ->
-              ZoneCard(zone, zones)
-              if (zone != zones.value.last()) {
-                HorizontalDivider(
-                    color = MaterialTheme.colorScheme.onBackground.copy(0.5f),
-                    thickness = 1.dp,
-                    modifier =
-                        Modifier.padding(horizontal = 16.dp)
-                            .fillMaxWidth(0.75f)
-                            .align(Alignment.CenterHorizontally))
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(bottom = 8.dp)) {
+              items(zones.value) { zone ->
+                ZoneCard(zone, zones)
+                if (zone != zones.value.last()) {
+                  HorizontalDivider(
+                      color = MaterialTheme.colorScheme.onBackground.copy(0.5f),
+                      thickness = 1.dp,
+                      modifier =
+                          Modifier.padding(horizontal = 16.dp)
+                              .fillMaxWidth(0.75f)
+                              .align(Alignment.CenterHorizontally))
+                }
               }
             }
           }
-          // ===  ===  ===  ===
+          // === Overlay ===
+          AddZoneButton(mapViewModel, navigationActions)
+          // ===  === ===  ===
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -1,28 +1,44 @@
 package com.github.se.cyrcle.ui.zone
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.IconButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+import java.io.File
 
 /** Screen where users can manage their downloaded zones. and access the zone selection screen. */
 @Composable
 fun ZoneManagerScreen(navigationActions: NavigationActions) {
+   val context = LocalContext.current
+    val zones = remember { mutableStateOf<List<Zone>>(emptyList()) }
+    LaunchedEffect(Unit) {
+        val zoneDir = File(context.filesDir, "zones")
+        zones.value = Zone.loadZones(zoneDir)
+        Log.d("ZoneManagerScreen", "Zones: ${zones.value}")
+    }
+
   Scaffold(
       topBar = {
         TopAppBar(
@@ -31,7 +47,11 @@ fun ZoneManagerScreen(navigationActions: NavigationActions) {
       }) { padding ->
         Box(modifier = Modifier.padding(padding).fillMaxSize()) {
           AddZoneButton(navigationActions)
-          Text("TODO")
+         Column {
+            zones.value.forEach { zone ->
+              Text(text = zone.name, modifier = Modifier.padding(16.dp))
+            }
+          }
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -108,7 +109,7 @@ fun AddZoneButton(navigationActions: NavigationActions) {
 fun ZoneCard(zone: Zone, zones: MutableState<List<Zone>>) {
   val context = LocalContext.current
   Row(
-      modifier = Modifier.padding(16.dp).fillMaxWidth(),
+      modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("ZoneCard"),
       horizontalArrangement = Arrangement.SpaceBetween) {
         Text(text = zone.name, textAlign = TextAlign.Left, modifier = Modifier.weight(2f))
         Text(text = zone.lastRefreshed.toString(), modifier = Modifier.weight(1f))
@@ -123,7 +124,7 @@ fun ZoneCard(zone: Zone, zones: MutableState<List<Zone>>) {
                 })
         Icon(
             Icons.Outlined.Delete,
-            contentDescription = "Add",
+            contentDescription = "Delete",
             modifier =
                 Modifier.weight(0.2f).clickable {
                   Zone.deleteZone(zone, context)
@@ -136,16 +137,16 @@ fun ZoneCard(zone: Zone, zones: MutableState<List<Zone>>) {
 @Composable
 fun ZoneHeader() {
   Row(
-      modifier = Modifier.padding(16.dp).fillMaxWidth(),
+      modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("ZoneManagerHeader"),
       horizontalArrangement = Arrangement.SpaceBetween) {
         Text(
             text = stringResource(R.string.zone_manager_header_area),
             textAlign = TextAlign.Left,
-            modifier = Modifier.weight(2f),
+            modifier = Modifier.weight(2f).testTag("ZoneManagerHeaderArea"),
             style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
         Text(
             text = stringResource(R.string.zone_manager_header_lastRefreshed),
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).testTag("ZoneManagerHeaderLastRefreshed"),
             style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold))
         Icon(
             Icons.Filled.Refresh,
@@ -153,7 +154,7 @@ fun ZoneHeader() {
             modifier = Modifier.weight(0.2f).alpha(0.0f))
         Icon(
             Icons.Filled.Delete,
-            contentDescription = "Add",
+            contentDescription = "Delete",
             modifier = Modifier.weight(0.2f).alpha(0.0f))
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -51,7 +51,7 @@ import com.mapbox.maps.plugin.gestures.gestures
 fun ZoneSelectionScreen(
     navigationActions: NavigationActions,
     mapViewModel: MapViewModel,
-    addressViewModel: AddressViewModel
+    addressViewModel: AddressViewModel // Possibility to use this to suggest a name for the zone.
 ) {
   val showAlertDialogPickName = remember { mutableStateOf(false) }
   val boundingBox = remember { mutableStateOf<BoundingBox?>(null) }
@@ -60,10 +60,10 @@ fun ZoneSelectionScreen(
   val locationPickerState by
       mapViewModel.locationPickerState
           .collectAsState() // state representing where the user is in the location selection
-                            // process
+  // process
   mapViewModel
       .unZoomActualCamera() // automatically zoom out and reset bearing, because no one want to
-                            // download a zone that is too zoomed in.
+  // download a zone that is too zoomed in.
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
   LaunchedEffect(Unit) {
     // Needs to be in a launchedEffect to not be called every time the locationPickerState changes,
@@ -151,9 +151,10 @@ fun ZoneSelectionButton(mapViewModel: MapViewModel, locationPickerState: Locatio
   // Define the text of the button depending on the state of the location picker.
   val buttonText =
       when (locationPickerState) {
-        LocationPickerState.NONE_SET -> "Set top left corner"
-        LocationPickerState.TOP_LEFT_SET -> "Download Area "
-        else -> "Please wait..."
+        LocationPickerState.NONE_SET -> stringResource(R.string.zone_selection_button_when_none_set)
+        LocationPickerState.TOP_LEFT_SET ->
+            stringResource(R.string.zone_selection_button_when_top_left_set)
+        else -> stringResource(R.string.zone_selection_button_when_both_set)
       }
   // The button itself
   Box(modifier = Modifier.fillMaxSize()) {
@@ -183,9 +184,9 @@ fun AlertDialogPickZoneName(
                 Modifier.padding(16.dp)
                     .background(MaterialTheme.colorScheme.background, MaterialTheme.shapes.small)) {
               Text(
-                  text = "Please name the Area you are about to download",
+                  text = stringResource(R.string.zone_selection_alert_tilte),
                   style = MaterialTheme.typography.bodyLarge,
-                  modifier = Modifier.padding(16.dp))
+                  modifier = Modifier.padding(16.dp).testTag("AlertDialogTitle"))
               Spacer(modifier = Modifier.padding(8.dp))
               InputText(
                   value = zoneName.value,
@@ -197,10 +198,14 @@ fun AlertDialogPickZoneName(
                   modifier = Modifier.padding(16.dp).fillMaxWidth(),
                   horizontalArrangement = Arrangement.SpaceEvenly) {
                     Button(
-                        text = "Cancel",
+                        text = stringResource(R.string.zone_selection_button_cancel),
+                        modifier = Modifier.testTag("AlertDialogButtonCancel"),
                         onClick = { onDismiss() },
                     )
-                    Button(text = "Confirm", onClick = { onConfirm(zoneName.value) })
+                    Button(
+                        text = stringResource(R.string.zone_selection_button_accept),
+                        modifier = Modifier.testTag("AlertDialogButtonAccept"),
+                        onClick = { onConfirm(zoneName.value) })
                   }
             }
       })

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -1,6 +1,19 @@
 package com.github.se.cyrcle.ui.zone
 
+import android.content.Context
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -8,40 +21,73 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.map.MapViewModel.LocationPickerState
+import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.addParking.location.overlay.Crosshair
 import com.github.se.cyrcle.ui.addParking.location.overlay.RectangleSelection
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.navigation.NavigationActions
+import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.InputText
+import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+import com.mapbox.geojson.BoundingBox
 import com.mapbox.maps.MapView
 import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.plugin.gestures.gestures
+import kotlinx.coroutines.channels.ticker
+import java.io.File
 
 /** Screen where users can select a new zone to download. */
 @Composable
-fun ZoneSelectionScreen(navigationActions: NavigationActions, mapViewModel: MapViewModel) {
+fun ZoneSelectionScreen(navigationActions: NavigationActions, mapViewModel: MapViewModel, addressViewModel: AddressViewModel) {
+    val showAlertDialogPickName = remember { mutableStateOf(false) }
+    val boundingBox = remember { mutableStateOf<BoundingBox?>(null) }
+    val zoneName = remember { mutableStateOf("") }
   val mapView = remember { mutableStateOf<MapView?>(null) }
   val locationPickerState by mapViewModel.locationPickerState.collectAsState() // state representing where the user is in the location selection process
   mapViewModel.unZoomActualCamera() // automatically zoom out and reset bearing, because no one want to download a zone that is too zoomed in.
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
-  mapViewModel.updateLocation(null) // This is not related to the camera position.
-  mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET) // reset the location picker state
-
+    LaunchedEffect(Unit) {
+        // Needs to be in a launchedEffect to not be called every time the locationPickerState changes, otherwise it would override the locationPickerState.
+        mapViewModel.updateLocation(null) // This is not related to the camera position.
+        mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET) // reset the location picker state
+    }
   LaunchedEffect(locationPickerState) {
-    if (locationPickerState == LocationPickerState.RECTANGLE_SET) {
-      val screenCoordsList = mapViewModel.screenCoordinates.value
-      val pointsList = mapView.value?.mapboxMap?.coordinatesForPixels(screenCoordsList)!!
-      // handle the location submitted then navigate somewhere else?
-        // FIXME
+      // Once the composabe RectangleSelection is done setting the rectangle, we show the alert dialog to pick the name of the zone.
+      if (locationPickerState == LocationPickerState.RECTANGLE_SET) {
+          // Firs get the screen Coords from the viewmodel, computed by the RectangleSelection composable.
+          val screenCoordsList = mapViewModel.screenCoordinates.value
+          // Then convert the screen coords to map coords.
+          val pointsList = mapView.value?.mapboxMap?.coordinatesForPixels(screenCoordsList)!!
+          // Then find the bottom left and top right points of the bounding box.
+            val bottomLeft = pointsList.minByOrNull { it.latitude() + it.longitude() }!! // The point with the smallest latitude is the bottom left.
+            val topRight = pointsList.maxByOrNull { it.latitude() + it.longitude()}!! // The point with the biggest latitude is the top right.
+          // Store the bounding box in a state.
+          boundingBox.value = BoundingBox.fromPoints(bottomLeft, topRight)
+          // Show the alert dialog to pick the name of the zone.
+            showAlertDialogPickName.value = true
     }
   }
+
+    if(showAlertDialogPickName.value) {
+        val context = LocalContext.current
+        AlertDialogPickZoneName(
+            onConfirm = { zoneName.value = it; createZone(boundingBox.value!!, it,context, navigationActions) },
+            onDismiss = { showAlertDialogPickName.value = false; mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET) }
+        )
+    }
+
   Scaffold(
       topBar = {
         TopAppBar(navigationActions, title = stringResource(R.string.zone_selection_screen_title))
@@ -59,9 +105,95 @@ fun ZoneSelectionScreen(navigationActions: NavigationActions, mapViewModel: MapV
         }
         RectangleSelection(mapViewModel, padding, mapView.value, restrictSelectionSize = false)
         Crosshair(mapViewModel, padding)
+      ZoneSelectionButton(mapViewModel, locationPickerState)
       }
 }
 
 // Make a button that first say "Set top left corner" and then "Set bottom right corner" when clicked, then navigate to the next screen (or alert dialog), where the user name the zone. then he will finally click on download.
+@Composable
+fun ZoneSelectionButton(mapViewModel: MapViewModel, locationPickerState: LocationPickerState) {
+    // Define the click action for the button of the zone selection screen.
+    fun onClick() {
+        when (locationPickerState) {
+            LocationPickerState.NONE_SET ->
+                { mapViewModel.updateLocationPickerState(LocationPickerState.TOP_LEFT_SET) }
+            LocationPickerState.TOP_LEFT_SET ->
+                { mapViewModel.updateLocationPickerState(LocationPickerState.BOTTOM_RIGHT_SET) }
+            else ->
+                {}
+        }
+    }
+    // Define the text of the button depending on the state of the location picker.
+    val buttonText = when (locationPickerState) {
+        LocationPickerState.NONE_SET -> "Set top left corner"
+        LocationPickerState.TOP_LEFT_SET -> "Download Area "
+        else -> "Please wait..."
+    }
+    // The button itself
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Button(
+            text=buttonText,
+            onClick = { onClick() },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 16.dp, bottom = 32.dp)
+                .testTag("SetTopLeftCornerButton")
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlertDialogPickZoneName(defaultName : String ="", onConfirm: (zoneName : String) -> Unit = {}, onDismiss : () -> Unit = {}) {
+    val zoneName = remember { mutableStateOf(defaultName) }
+    BasicAlertDialog(
+        onDismissRequest = {onDismiss()},
+        content =
+        {
+            Column(
+                modifier = Modifier.padding(16.dp).background(MaterialTheme.colorScheme.background, MaterialTheme.shapes.small)
+            ) {
+                Text(
+                    text = "Please name the Area you are about to download",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(16.dp)
+                )
+                Spacer(modifier = Modifier.padding(8.dp))
+                InputText(
+                    value = zoneName.value,
+                    onValueChange = { zoneName.value = it },
+                    label = "Zone name",
+                    modifier = Modifier.padding(16.dp)
+                )
+                Spacer(modifier = Modifier.padding(8.dp))
+                Row(
+                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    Button(
+                        text = "Cancel",
+                        onClick = { onDismiss() },
+                    )
+                    Button(
+                        text = "Confirm",
+                        onClick = { onConfirm(zoneName.value) }
+                    )
+                }
+            }
+        })
+}
+
+
+private fun createZone(boundingBox: BoundingBox, zoneName: String, context: Context, navigationActions: NavigationActions) {
+    val zone = Zone(boundingBox, zoneName)
+    Log.d("ZoneSelectionScreen", "Zone created: $zone")
+   val zoneDir = File(context.filesDir, "zones")
+    Zone.storeZone(zone, zoneDir)
+    // Add calls to function to download the tiles corresponding and the data corresponding to the zone.
+    navigationActions.goBack()
+}
+
 
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -64,7 +64,8 @@ fun ZoneSelectionScreen(
           .collectAsState() // state representing where the user is in the location selection
   // process
   mapViewModel
-      .unZoomActualCamera() // automatically zoom out and reset bearing, because no one want to
+      .setCameraForZoneSelection() // automatically zoom out and reset bearing, because no one want
+  // to
   // download a zone that is too zoomed in.
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
   LaunchedEffect(Unit) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -37,7 +37,7 @@ import com.github.se.cyrcle.ui.addParking.location.overlay.RectangleSelection
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.atoms.Button
-import com.github.se.cyrcle.ui.theme.atoms.InputText
+import com.github.se.cyrcle.ui.theme.atoms.ConditionCheckingInputText
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 import com.mapbox.geojson.BoundingBox
@@ -46,6 +46,8 @@ import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.plugin.gestures.gestures
 
+const val MAX_ZONE_NAME_LENGTH = 32
+const val MIN_ZONE_NAME_LENGTH = 1
 /** Screen where users can select a new zone to download. */
 @Composable
 fun ZoneSelectionScreen(
@@ -176,6 +178,7 @@ fun AlertDialogPickZoneName(
     onDismiss: () -> Unit = {}
 ) {
   val zoneName = remember { mutableStateOf(defaultName) }
+  val isNameValid = zoneName.value.length in MIN_ZONE_NAME_LENGTH..MAX_ZONE_NAME_LENGTH
   BasicAlertDialog(
       onDismissRequest = { onDismiss() },
       content = {
@@ -188,11 +191,17 @@ fun AlertDialogPickZoneName(
                   style = MaterialTheme.typography.bodyLarge,
                   modifier = Modifier.padding(16.dp).testTag("AlertDialogTitle"))
               Spacer(modifier = Modifier.padding(8.dp))
-              InputText(
+
+              ConditionCheckingInputText(
                   value = zoneName.value,
                   onValueChange = { zoneName.value = it },
                   label = "Zone name",
-                  modifier = Modifier.padding(16.dp))
+                  modifier = Modifier.padding(horizontal = 16.dp),
+                  maxLines = 1,
+                  minCharacters = MIN_ZONE_NAME_LENGTH,
+                  maxCharacters = MAX_ZONE_NAME_LENGTH,
+                  smallText = true,
+              )
               Spacer(modifier = Modifier.padding(8.dp))
               Row(
                   modifier = Modifier.padding(16.dp).fillMaxWidth(),
@@ -205,6 +214,7 @@ fun AlertDialogPickZoneName(
                     Button(
                         text = stringResource(R.string.zone_selection_button_accept),
                         modifier = Modifier.testTag("AlertDialogButtonAccept"),
+                        enabled = isNameValid,
                         onClick = { onConfirm(zoneName.value) })
                   }
             }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -45,48 +45,70 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.plugin.gestures.gestures
-import kotlinx.coroutines.channels.ticker
-import java.io.File
 
 /** Screen where users can select a new zone to download. */
 @Composable
-fun ZoneSelectionScreen(navigationActions: NavigationActions, mapViewModel: MapViewModel, addressViewModel: AddressViewModel) {
-    val showAlertDialogPickName = remember { mutableStateOf(false) }
-    val boundingBox = remember { mutableStateOf<BoundingBox?>(null) }
-    val zoneName = remember { mutableStateOf("") }
+fun ZoneSelectionScreen(
+    navigationActions: NavigationActions,
+    mapViewModel: MapViewModel,
+    addressViewModel: AddressViewModel
+) {
+  val showAlertDialogPickName = remember { mutableStateOf(false) }
+  val boundingBox = remember { mutableStateOf<BoundingBox?>(null) }
+  val zoneName = remember { mutableStateOf("") }
   val mapView = remember { mutableStateOf<MapView?>(null) }
-  val locationPickerState by mapViewModel.locationPickerState.collectAsState() // state representing where the user is in the location selection process
-  mapViewModel.unZoomActualCamera() // automatically zoom out and reset bearing, because no one want to download a zone that is too zoomed in.
+  val locationPickerState by
+      mapViewModel.locationPickerState
+          .collectAsState() // state representing where the user is in the location selection
+                            // process
+  mapViewModel
+      .unZoomActualCamera() // automatically zoom out and reset bearing, because no one want to
+                            // download a zone that is too zoomed in.
   val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
-    LaunchedEffect(Unit) {
-        // Needs to be in a launchedEffect to not be called every time the locationPickerState changes, otherwise it would override the locationPickerState.
-        mapViewModel.updateLocation(null) // This is not related to the camera position.
-        mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET) // reset the location picker state
-    }
+  LaunchedEffect(Unit) {
+    // Needs to be in a launchedEffect to not be called every time the locationPickerState changes,
+    // otherwise it would override the locationPickerState.
+    mapViewModel.updateLocation(null) // This is not related to the camera position.
+    mapViewModel.updateLocationPickerState(
+        LocationPickerState.NONE_SET) // reset the location picker state
+  }
   LaunchedEffect(locationPickerState) {
-      // Once the composabe RectangleSelection is done setting the rectangle, we show the alert dialog to pick the name of the zone.
-      if (locationPickerState == LocationPickerState.RECTANGLE_SET) {
-          // Firs get the screen Coords from the viewmodel, computed by the RectangleSelection composable.
-          val screenCoordsList = mapViewModel.screenCoordinates.value
-          // Then convert the screen coords to map coords.
-          val pointsList = mapView.value?.mapboxMap?.coordinatesForPixels(screenCoordsList)!!
-          // Then find the bottom left and top right points of the bounding box.
-            val bottomLeft = pointsList.minByOrNull { it.latitude() + it.longitude() }!! // The point with the smallest latitude is the bottom left.
-            val topRight = pointsList.maxByOrNull { it.latitude() + it.longitude()}!! // The point with the biggest latitude is the top right.
-          // Store the bounding box in a state.
-          boundingBox.value = BoundingBox.fromPoints(bottomLeft, topRight)
-          // Show the alert dialog to pick the name of the zone.
-            showAlertDialogPickName.value = true
+    // Once the composabe RectangleSelection is done setting the rectangle, we show the alert dialog
+    // to pick the name of the zone.
+    if (locationPickerState == LocationPickerState.RECTANGLE_SET) {
+      // Firs get the screen Coords from the viewmodel, computed by the RectangleSelection
+      // composable.
+      val screenCoordsList = mapViewModel.screenCoordinates.value
+      // Then convert the screen coords to map coords.
+      val pointsList = mapView.value?.mapboxMap?.coordinatesForPixels(screenCoordsList)!!
+      // Then find the bottom left and top right points of the bounding box.
+      val bottomLeft =
+          pointsList.minByOrNull {
+            it.latitude() + it.longitude()
+          }!! // The point with the smallest latitude is the bottom left.
+      val topRight =
+          pointsList.maxByOrNull {
+            it.latitude() + it.longitude()
+          }!! // The point with the biggest latitude is the top right.
+      // Store the bounding box in a state.
+      boundingBox.value = BoundingBox.fromPoints(bottomLeft, topRight)
+      // Show the alert dialog to pick the name of the zone.
+      showAlertDialogPickName.value = true
     }
   }
 
-    if(showAlertDialogPickName.value) {
-        val context = LocalContext.current
-        AlertDialogPickZoneName(
-            onConfirm = { zoneName.value = it; createZone(boundingBox.value!!, it,context, navigationActions) },
-            onDismiss = { showAlertDialogPickName.value = false; mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET) }
-        )
-    }
+  if (showAlertDialogPickName.value) {
+    val context = LocalContext.current
+    AlertDialogPickZoneName(
+        onConfirm = {
+          zoneName.value = it
+          createZone(boundingBox.value!!, it, context, navigationActions)
+        },
+        onDismiss = {
+          showAlertDialogPickName.value = false
+          mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET)
+        })
+  }
 
   Scaffold(
       topBar = {
@@ -105,95 +127,95 @@ fun ZoneSelectionScreen(navigationActions: NavigationActions, mapViewModel: MapV
         }
         RectangleSelection(mapViewModel, padding, mapView.value, restrictSelectionSize = false)
         Crosshair(mapViewModel, padding)
-      ZoneSelectionButton(mapViewModel, locationPickerState)
+        ZoneSelectionButton(mapViewModel, locationPickerState)
       }
 }
 
-// Make a button that first say "Set top left corner" and then "Set bottom right corner" when clicked, then navigate to the next screen (or alert dialog), where the user name the zone. then he will finally click on download.
+// Make a button that first say "Set top left corner" and then "Set bottom right corner" when
+// clicked, then navigate to the next screen (or alert dialog), where the user name the zone. then
+// he will finally click on download.
 @Composable
 fun ZoneSelectionButton(mapViewModel: MapViewModel, locationPickerState: LocationPickerState) {
-    // Define the click action for the button of the zone selection screen.
-    fun onClick() {
-        when (locationPickerState) {
-            LocationPickerState.NONE_SET ->
-                { mapViewModel.updateLocationPickerState(LocationPickerState.TOP_LEFT_SET) }
-            LocationPickerState.TOP_LEFT_SET ->
-                { mapViewModel.updateLocationPickerState(LocationPickerState.BOTTOM_RIGHT_SET) }
-            else ->
-                {}
-        }
+  // Define the click action for the button of the zone selection screen.
+  fun onClick() {
+    when (locationPickerState) {
+      LocationPickerState.NONE_SET -> {
+        mapViewModel.updateLocationPickerState(LocationPickerState.TOP_LEFT_SET)
+      }
+      LocationPickerState.TOP_LEFT_SET -> {
+        mapViewModel.updateLocationPickerState(LocationPickerState.BOTTOM_RIGHT_SET)
+      }
+      else -> {}
     }
-    // Define the text of the button depending on the state of the location picker.
-    val buttonText = when (locationPickerState) {
+  }
+  // Define the text of the button depending on the state of the location picker.
+  val buttonText =
+      when (locationPickerState) {
         LocationPickerState.NONE_SET -> "Set top left corner"
         LocationPickerState.TOP_LEFT_SET -> "Download Area "
         else -> "Please wait..."
-    }
-    // The button itself
-    Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Button(
-            text=buttonText,
-            onClick = { onClick() },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
+      }
+  // The button itself
+  Box(modifier = Modifier.fillMaxSize()) {
+    Button(
+        text = buttonText,
+        onClick = { onClick() },
+        modifier =
+            Modifier.align(Alignment.BottomEnd)
                 .padding(end = 16.dp, bottom = 32.dp)
-                .testTag("SetTopLeftCornerButton")
-        )
-    }
+                .testTag("SetTopLeftCornerButton"))
+  }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AlertDialogPickZoneName(defaultName : String ="", onConfirm: (zoneName : String) -> Unit = {}, onDismiss : () -> Unit = {}) {
-    val zoneName = remember { mutableStateOf(defaultName) }
-    BasicAlertDialog(
-        onDismissRequest = {onDismiss()},
-        content =
-        {
-            Column(
-                modifier = Modifier.padding(16.dp).background(MaterialTheme.colorScheme.background, MaterialTheme.shapes.small)
-            ) {
-                Text(
-                    text = "Please name the Area you are about to download",
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(16.dp)
-                )
-                Spacer(modifier = Modifier.padding(8.dp))
-                InputText(
-                    value = zoneName.value,
-                    onValueChange = { zoneName.value = it },
-                    label = "Zone name",
-                    modifier = Modifier.padding(16.dp)
-                )
-                Spacer(modifier = Modifier.padding(8.dp))
-                Row(
-                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly
-                ) {
+fun AlertDialogPickZoneName(
+    defaultName: String = "",
+    onConfirm: (zoneName: String) -> Unit = {},
+    onDismiss: () -> Unit = {}
+) {
+  val zoneName = remember { mutableStateOf(defaultName) }
+  BasicAlertDialog(
+      onDismissRequest = { onDismiss() },
+      content = {
+        Column(
+            modifier =
+                Modifier.padding(16.dp)
+                    .background(MaterialTheme.colorScheme.background, MaterialTheme.shapes.small)) {
+              Text(
+                  text = "Please name the Area you are about to download",
+                  style = MaterialTheme.typography.bodyLarge,
+                  modifier = Modifier.padding(16.dp))
+              Spacer(modifier = Modifier.padding(8.dp))
+              InputText(
+                  value = zoneName.value,
+                  onValueChange = { zoneName.value = it },
+                  label = "Zone name",
+                  modifier = Modifier.padding(16.dp))
+              Spacer(modifier = Modifier.padding(8.dp))
+              Row(
+                  modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceEvenly) {
                     Button(
                         text = "Cancel",
                         onClick = { onDismiss() },
                     )
-                    Button(
-                        text = "Confirm",
-                        onClick = { onConfirm(zoneName.value) }
-                    )
-                }
+                    Button(text = "Confirm", onClick = { onConfirm(zoneName.value) })
+                  }
             }
-        })
+      })
 }
 
-
-private fun createZone(boundingBox: BoundingBox, zoneName: String, context: Context, navigationActions: NavigationActions) {
-    val zone = Zone(boundingBox, zoneName)
-    Log.d("ZoneSelectionScreen", "Zone created: $zone")
-   val zoneDir = File(context.filesDir, "zones")
-    Zone.storeZone(zone, zoneDir)
-    // Add calls to function to download the tiles corresponding and the data corresponding to the zone.
-    navigationActions.goBack()
+private fun createZone(
+    boundingBox: BoundingBox,
+    zoneName: String,
+    context: Context,
+    navigationActions: NavigationActions
+) {
+  val zone = Zone(boundingBox, zoneName)
+  Log.d("ZoneSelectionScreen", "Zone created: $zone")
+  Zone.storeZone(zone, context)
+  // Add calls to function to download the tiles corresponding and the data corresponding to the
+  // zone.
+  navigationActions.goBack()
 }
-
-
-

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -1,26 +1,67 @@
 package com.github.se.cyrcle.ui.zone
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.map.MapViewModel
+import com.github.se.cyrcle.model.map.MapViewModel.LocationPickerState
+import com.github.se.cyrcle.ui.addParking.location.overlay.Crosshair
+import com.github.se.cyrcle.ui.addParking.location.overlay.RectangleSelection
+import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
+import com.mapbox.maps.MapView
+import com.mapbox.maps.extension.compose.DisposableMapEffect
+import com.mapbox.maps.extension.compose.MapboxMap
+import com.mapbox.maps.plugin.gestures.gestures
 
 /** Screen where users can select a new zone to download. */
 @Composable
-fun ZoneSelectionScreen(navigationActions: NavigationActions) {
+fun ZoneSelectionScreen(navigationActions: NavigationActions, mapViewModel: MapViewModel) {
+  val mapView = remember { mutableStateOf<MapView?>(null) }
+  val locationPickerState by mapViewModel.locationPickerState.collectAsState() // state representing where the user is in the location selection process
+  mapViewModel.unZoomActualCamera() // automatically zoom out and reset bearing, because no one want to download a zone that is too zoomed in.
+  val mapViewportState = MapConfig.createMapViewPortStateFromViewModel(mapViewModel)
+  mapViewModel.updateLocation(null) // This is not related to the camera position.
+  mapViewModel.updateLocationPickerState(LocationPickerState.NONE_SET) // reset the location picker state
+
+  LaunchedEffect(locationPickerState) {
+    if (locationPickerState == LocationPickerState.RECTANGLE_SET) {
+      val screenCoordsList = mapViewModel.screenCoordinates.value
+      val pointsList = mapView.value?.mapboxMap?.coordinatesForPixels(screenCoordsList)!!
+      // handle the location submitted then navigate somewhere else?
+        // FIXME
+    }
+  }
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = stringResource(R.string.zone_selection_screen_title),
-            navigationActions = navigationActions)
+        TopAppBar(navigationActions, title = stringResource(R.string.zone_selection_screen_title))
       }) { padding ->
-        Box(modifier = Modifier.padding(padding).fillMaxSize()) { Text("TODO") }
+        MapboxMap(
+            mapViewportState = mapViewportState,
+            style = { MapConfig.DefaultStyle() },
+            modifier = Modifier.testTag("LocationPickerScreen").padding(padding),
+        ) {
+          DisposableMapEffect { mapViewInstance ->
+            mapView.value = mapViewInstance
+            mapViewInstance.gestures.getGesturesManager().rotateGestureDetector.isEnabled = false
+            onDispose {}
+          }
+        }
+        RectangleSelection(mapViewModel, padding, mapView.value, restrictSelectionSize = false)
+        Crosshair(mapViewModel, padding)
       }
 }
+
+// Make a button that first say "Set top left corner" and then "Set bottom right corner" when clicked, then navigate to the next screen (or alert dialog), where the user name the zone. then he will finally click on download.
+
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,8 @@
     <!-- Error Messages -->
     <string name="input_min_characters">Minimum %1$d characters required (current: %2$d)</string>
     <string name="input_max_characters">Maximum %1$d characters allowed (current: %2$d)</string>
-
+    <string name="input_min_characters_small">Minimum %1$d characters required </string>
+    <string name="input_max_characters_small">Maximum %1$d characters allowed </string>
     <!-- Attributes Picker -->
     <string name="attributes_picker_title_label">Title</string>
     <string name="attributes_picker_protection_label">How protected from the weather is the spot?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,12 @@
     <string name ="zone_manager_no_zones">Nothing downloaded yet</string>
     <string name ="zone_manager_header_area">Map Name</string>
     <string name ="zone_manager_header_lastRefreshed">Last Refreshed</string>
+    <string name ="zone_selection_alert_tilte">Please name the Area you are about to download</string>
+    <string name ="zone_selection_button_when_none_set">Set top left corner</string>
+    <string name ="zone_selection_button_when_top_left_set">Download Area</string>
+    <string name ="zone_selection_button_when_both_set">Please wait...</string>
+    <string name ="zone_selection_button_accept">Confirm</string>
+    <string name ="zone_selection_button_cancel">Cancel</string>
 
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,9 @@
     <!-- Zone Screens -->
     <string name="zone_manager_screen_title">Offline Maps</string>
     <string name="zone_selection_screen_title">Select Zone</string>
+    <string name ="zone_manager_no_zones">Nothing downloaded yet</string>
+    <string name ="zone_manager_header_area">Map Name</string>
+    <string name ="zone_manager_header_lastRefreshed">Last Refreshed</string>
 
 
 


### PR DESCRIPTION
- fix:  #317 
- fix: #335 
## What

#### Users can now manage (add/refresh/delete) offline portions of the map called Zone. 
The informations about the zones, is downloaded on the local file storage, meaning the user can access this data, no matter what account, he's logged in, even as guest mode.


<img width="295" alt="image" src="https://github.com/user-attachments/assets/a497e8aa-b138-4ba3-83f1-5eb710de9117">
<img width="301" alt="image" src="https://github.com/user-attachments/assets/c84d15cc-1c96-44ca-af85-57f57156b761">



## How
- The `ZoneManagerScreen` load from files all zones and displays it, with possibility to refresh or delete it.
- The `ZoneSelectionScreen` allow user to add a new zone with code copied from `LocationPicker` and a dialog box to pick the name.
- The `ZoneSelectionScreen` write to the local storage the information about the zone.
- All the IOs are done in the `Zone.kt` file. Ensurint that the path and naming is standarised
- The `Zone` Object are stored as json object in` appDir/zones/${zone.uid}.json`

**Important** Currently when adding a zone, the tile and parking data is not downloaded, same for deletion and refresh. => Only the Zone Data Class is managed not the Parkings and not the Map. 
(Once we have implemented the function we should call them in the callbacks of the button, that add/refresh/delete.)

## Why
#### This is one of the first step in order to have an offline mode. We now have the interface to manage our offline plans. 


-- -
Overall: 80%
ui zone : 75%
model zone : 25%
<img width="151" alt="image" src="https://github.com/user-attachments/assets/ce6cd40d-19c1-4d1c-9ef8-d4a3b25d3d64">

