### PR TITLE
Filters on MapScreen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -1,17 +1,10 @@
 package com.github.se.cyrcle.ui.list
 
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertAll
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasClickAction
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
@@ -25,9 +18,6 @@ import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.authentication.AuthenticationRepository
 import com.github.se.cyrcle.model.image.ImageRepository
 import com.github.se.cyrcle.model.map.MapViewModel
-import com.github.se.cyrcle.model.parking.ParkingCapacity
-import com.github.se.cyrcle.model.parking.ParkingProtection
-import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingRepository
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.parking.TestInstancesParking
@@ -278,18 +268,6 @@ class ListScreenTest {
   }
 
   @Test
-  fun testCCTVCheckboxInteraction() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
-
-    // Show filters first
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-
-    // Check both checkbox and label are displayed
-    composeTestRule.onNodeWithTag("CCTVCheckbox").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("CCTVCheckboxLabel").assertIsDisplayed()
-  }
-
-  @Test
   fun testSpotListScreenStructure() {
     composeTestRule.setContent {
       SpotListScreen(
@@ -370,132 +348,6 @@ class ListScreenTest {
 
     verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
     assertEquals(TestInstancesParking.parking2, parkingViewModel.selectedParking.value)
-  }
-
-  @Test
-  fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
-
-    // Act & Assert
-    composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testShowFiltersButtonTogglesFilterSection() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
-
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
-
-    // Assert that clear all and apply all buttons are displayed and behave as expected
-    composeTestRule.onNodeWithTag("ClearAllFiltersButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedCapacities.value.isEmpty())
-    assert(parkingViewModel.selectedProtection.value.isEmpty())
-    assert(parkingViewModel.selectedRackTypes.value.isEmpty())
-    composeTestRule.onNodeWithTag("ApplyAllFiltersButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedCapacities.value.isNotEmpty())
-    assert(parkingViewModel.selectedProtection.value.isNotEmpty())
-    assert(parkingViewModel.selectedRackTypes.value.isNotEmpty())
-
-    // Act: Click to hide filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testProtectionFilters() {
-
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
-
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
-
-    composeTestRule
-        .onNodeWithTag("Protection")
-        .assertIsDisplayed()
-        .assertTextEquals("Protection")
-        .performClick()
-
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
-    composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag("ProtectionFilterItem")
-        .assertCountEquals(ParkingProtection.entries.size)
-        .assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
-    assert(
-        parkingViewModel.selectedProtection.value.containsAll(
-            ParkingProtection.entries.toSet() - ParkingProtection.entries[0]))
-
-    // Assert that clear and apply buttons work
-    composeTestRule.onNodeWithTag("ClearProtectionButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedProtection.value.isEmpty())
-    composeTestRule.onNodeWithTag("ApplyProtectionButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedProtection.value.isNotEmpty())
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testRackTypeFilters() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
-
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
-
-    composeTestRule
-        .onNodeWithTag("Rack Type")
-        .assertIsDisplayed()
-        .assertTextEquals("Rack Type")
-        .performClick()
-
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
-    composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
-
-    // Assert that the selected rack type is updated in the ParkingViewModel
-    assert(
-        parkingViewModel.selectedRackTypes.value.containsAll(
-            ParkingRackType.entries.toSet() - ParkingRackType.entries[0]))
-
-    // Assert that clear and apply buttons work
-    composeTestRule.onNodeWithTag("ClearRack TypeButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedRackTypes.value.isEmpty())
-    composeTestRule.onNodeWithTag("ApplyRack TypeButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedRackTypes.value.isNotEmpty())
-  }
-
-  @Test
-  @OptIn(ExperimentalTestApi::class)
-  fun testCapacityFilters() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
-
-    // Act: Click to show filters
-    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
-    composeTestRule
-        .onNodeWithTag("Capacity")
-        .assertIsDisplayed()
-        .assertTextEquals("Capacity")
-        .performClick()
-    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
-    composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
-    composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
-    assert(
-        parkingViewModel.selectedCapacities.value.containsAll(
-            ParkingCapacity.entries.toSet() - ParkingCapacity.entries[0]))
-
-    // Assert that clear and apply buttons work
-    composeTestRule.onNodeWithTag("ClearCapacityButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedCapacities.value.isEmpty())
-    composeTestRule.onNodeWithTag("ApplyCapacityButton").assertIsDisplayed().performClick()
-    assert(parkingViewModel.selectedCapacities.value.isNotEmpty())
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -3,6 +3,7 @@ package com.github.se.cyrcle.ui.map
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -198,6 +199,32 @@ class MapScreenTest {
     composeTestRule.onNodeWithTag("advancedModeSwitch").assertIsDisplayed()
     composeTestRule.onNodeWithTag("SettingsToZoneRow").assertIsDisplayed().performClick()
     verify(mockNavigation).navigateTo(Route.ZONE)
+  }
+
+  @Test
+  fun testFilterMenu() {
+    composeTestRule.setContent {
+      MapScreen(
+          mockNavigation,
+          parkingViewModel,
+          userViewModel,
+          mapViewModel,
+          permissionHandler,
+          addressViewModel)
+    }
+
+    composeTestRule
+        .onNodeWithTag("FilterButton")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    composeTestRule.onNodeWithTag("FilterMenu").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("FilterMenuClose")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    composeTestRule.onNodeWithTag("FilterMenu").assertIsNotDisplayed()
   }
 
   /** Test that verify that the Search Bar works */

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/FilterTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/FilterTest.kt
@@ -56,7 +56,7 @@ class FilterTest {
 
   @Test
   fun testCCTVCheckboxInteraction() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+    composeTestRule.setContent { FilterPanel(parkingViewModel, true) }
 
     // Show filters first
     composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
@@ -68,7 +68,7 @@ class FilterTest {
 
   @Test
   fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+    composeTestRule.setContent { FilterPanel(parkingViewModel, true) }
 
     // Act & Assert
     composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
@@ -77,7 +77,7 @@ class FilterTest {
   @Test
   @OptIn(ExperimentalTestApi::class)
   fun testShowFiltersButtonTogglesFilterSection() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+    composeTestRule.setContent { FilterPanel(parkingViewModel, true) }
 
     // Act: Click to show filters
     composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
@@ -102,7 +102,7 @@ class FilterTest {
   @OptIn(ExperimentalTestApi::class)
   fun testProtectionFilters() {
 
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+    composeTestRule.setContent { FilterPanel(parkingViewModel, true) }
 
     // Act: Click to show filters
     composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
@@ -135,7 +135,7 @@ class FilterTest {
   @Test
   @OptIn(ExperimentalTestApi::class)
   fun testRackTypeFilters() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+    composeTestRule.setContent { FilterPanel(parkingViewModel, true) }
 
     // Act: Click to show filters
     composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
@@ -167,7 +167,7 @@ class FilterTest {
   @Test
   @OptIn(ExperimentalTestApi::class)
   fun testCapacityFilters() {
-    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+    composeTestRule.setContent { FilterPanel(parkingViewModel, true) }
 
     // Act: Click to show filters
     composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/FilterTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/FilterTest.kt
@@ -1,0 +1,194 @@
+package com.github.se.cyrcle.ui.theme.molecules
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.cyrcle.di.mocks.MockImageRepository
+import com.github.se.cyrcle.di.mocks.MockParkingRepository
+import com.github.se.cyrcle.di.mocks.MockReportedObjectRepository
+import com.github.se.cyrcle.model.image.ImageRepository
+import com.github.se.cyrcle.model.parking.ParkingCapacity
+import com.github.se.cyrcle.model.parking.ParkingProtection
+import com.github.se.cyrcle.model.parking.ParkingRackType
+import com.github.se.cyrcle.model.parking.ParkingRepository
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.parking.TestInstancesParking
+import com.github.se.cyrcle.model.report.ReportedObjectRepository
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.MockitoAnnotations
+
+@RunWith(AndroidJUnit4::class)
+class FilterTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var mockParkingRepository: ParkingRepository
+  private lateinit var mockImageRepository: ImageRepository
+  private lateinit var mockReportedObjectRepository: ReportedObjectRepository
+  private lateinit var parkingViewModel: ParkingViewModel
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    mockParkingRepository = MockParkingRepository()
+    mockImageRepository = MockImageRepository()
+    mockReportedObjectRepository = MockReportedObjectRepository()
+
+    parkingViewModel =
+        ParkingViewModel(mockImageRepository, mockParkingRepository, mockReportedObjectRepository)
+
+    parkingViewModel.addParking(TestInstancesParking.parking2)
+    parkingViewModel.addParking(TestInstancesParking.parking3)
+  }
+
+  @Test
+  fun testCCTVCheckboxInteraction() {
+    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+
+    // Show filters first
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+
+    // Check both checkbox and label are displayed
+    composeTestRule.onNodeWithTag("CCTVCheckbox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CCTVCheckboxLabel").assertIsDisplayed()
+  }
+
+  @Test
+  fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
+    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+
+    // Act & Assert
+    composeTestRule.onNodeWithTag("ShowFiltersButton").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testShowFiltersButtonTogglesFilterSection() {
+    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+
+    // Assert that clear all and apply all buttons are displayed and behave as expected
+    composeTestRule.onNodeWithTag("ClearAllFiltersButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedCapacities.value.isEmpty())
+    assert(parkingViewModel.selectedProtection.value.isEmpty())
+    assert(parkingViewModel.selectedRackTypes.value.isEmpty())
+    composeTestRule.onNodeWithTag("ApplyAllFiltersButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedCapacities.value.isNotEmpty())
+    assert(parkingViewModel.selectedProtection.value.isNotEmpty())
+    assert(parkingViewModel.selectedRackTypes.value.isNotEmpty())
+
+    // Act: Click to hide filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ShowFiltersButton"))
+  }
+
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testProtectionFilters() {
+
+    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Protection"))
+
+    composeTestRule
+        .onNodeWithTag("Protection")
+        .assertIsDisplayed()
+        .assertTextEquals("Protection")
+        .performClick()
+
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("ProtectionFilter"))
+    composeTestRule.onNodeWithTag("ProtectionFilter").assertIsDisplayed()
+    composeTestRule
+        .onAllNodesWithTag("ProtectionFilterItem")
+        .assertCountEquals(ParkingProtection.entries.size)
+        .assertAll(hasClickAction())
+    composeTestRule.onAllNodesWithTag("ProtectionFilterItem").onFirst().performClick()
+    assert(
+        parkingViewModel.selectedProtection.value.containsAll(
+            ParkingProtection.entries.toSet() - ParkingProtection.entries[0]))
+
+    // Assert that clear and apply buttons work
+    composeTestRule.onNodeWithTag("ClearProtectionButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedProtection.value.isEmpty())
+    composeTestRule.onNodeWithTag("ApplyProtectionButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedProtection.value.isNotEmpty())
+  }
+
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testRackTypeFilters() {
+    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Rack Type"))
+
+    composeTestRule
+        .onNodeWithTag("Rack Type")
+        .assertIsDisplayed()
+        .assertTextEquals("Rack Type")
+        .performClick()
+
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("RackTypeFilter"))
+    composeTestRule.onNodeWithTag("RackTypeFilter").assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").assertAll(hasClickAction())
+    composeTestRule.onAllNodesWithTag("RackTypeFilterItem").onFirst().performClick()
+
+    // Assert that the selected rack type is updated in the ParkingViewModel
+    assert(
+        parkingViewModel.selectedRackTypes.value.containsAll(
+            ParkingRackType.entries.toSet() - ParkingRackType.entries[0]))
+
+    // Assert that clear and apply buttons work
+    composeTestRule.onNodeWithTag("ClearRack TypeButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedRackTypes.value.isEmpty())
+    composeTestRule.onNodeWithTag("ApplyRack TypeButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedRackTypes.value.isNotEmpty())
+  }
+
+  @Test
+  @OptIn(ExperimentalTestApi::class)
+  fun testCapacityFilters() {
+    composeTestRule.setContent { FilterHeader(parkingViewModel) }
+
+    // Act: Click to show filters
+    composeTestRule.onNodeWithTag("ShowFiltersButton").performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("Capacity"))
+    composeTestRule
+        .onNodeWithTag("Capacity")
+        .assertIsDisplayed()
+        .assertTextEquals("Capacity")
+        .performClick()
+    composeTestRule.waitUntilExactlyOneExists(hasTestTag("CapacityFilter"))
+    composeTestRule.onNodeWithTag("CapacityFilter").assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("CapacityFilterItem").assertAll(hasClickAction())
+    composeTestRule.onAllNodesWithTag("CapacityFilterItem").onFirst().performClick()
+    assert(
+        parkingViewModel.selectedCapacities.value.containsAll(
+            ParkingCapacity.entries.toSet() - ParkingCapacity.entries[0]))
+
+    // Assert that clear and apply buttons work
+    composeTestRule.onNodeWithTag("ClearCapacityButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedCapacities.value.isEmpty())
+    composeTestRule.onNodeWithTag("ApplyCapacityButton").assertIsDisplayed().performClick()
+    assert(parkingViewModel.selectedCapacities.value.isNotEmpty())
+  }
+}

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -274,7 +274,6 @@ class ParkingViewModel(
    * @param protection the protection to toggle the status of
    */
   fun toggleProtection(protection: ParkingProtection) {
-    Log.d("Debug not drawing", "Toggling protection: $protection")
     _selectedProtection.update { toggleSelection(it, protection) }
     updateClosestParkings(0)
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -60,7 +60,7 @@ import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
-import com.github.se.cyrcle.ui.theme.molecules.FilterHeader
+import com.github.se.cyrcle.ui.theme.molecules.FilterPanel
 import com.mapbox.turf.TurfMeasurement
 import kotlin.math.roundToInt
 
@@ -86,7 +86,7 @@ fun SpotListScreen(
       bottomBar = { BottomNavigationBar(navigationActions, selectedItem = Route.LIST) }) {
           innerPadding ->
         Column(modifier = Modifier.fillMaxSize().padding(innerPadding).padding(bottom = 16.dp)) {
-          FilterHeader(parkingViewModel = parkingViewModel)
+          FilterPanel(parkingViewModel = parkingViewModel, displayHeader = true)
           val listState = rememberLazyListState()
           LazyColumn(state = listState, modifier = Modifier.testTag("SpotListColumn")) {
             // Pinned parking spots if any (includes titles and dividers)

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -2,7 +2,6 @@ package com.github.se.cyrcle.ui.list
 
 import android.widget.Toast
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -19,29 +18,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -55,27 +47,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.Parking
-import com.github.se.cyrcle.model.parking.ParkingCapacity
-import com.github.se.cyrcle.model.parking.ParkingProtection
-import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
-import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
-import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
-import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
-import com.github.se.cyrcle.ui.theme.getCheckBoxColors
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
+import com.github.se.cyrcle.ui.theme.molecules.FilterHeader
 import com.mapbox.turf.TurfMeasurement
 import kotlin.math.roundToInt
 
@@ -156,186 +141,6 @@ fun SpotListScreen(
               }
             }
           }
-        }
-      }
-}
-
-@Composable
-fun FilterHeader(parkingViewModel: ParkingViewModel) {
-  val showProtectionOptions = remember { mutableStateOf(false) }
-  val showRackTypeOptions = remember { mutableStateOf(false) }
-  val showCapacityOptions = remember { mutableStateOf(false) }
-  var showFilters by remember { mutableStateOf(false) }
-
-  val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
-  val selectedRackTypes by parkingViewModel.selectedRackTypes.collectAsState()
-  val selectedCapacities by parkingViewModel.selectedCapacities.collectAsState()
-  val onlyWithCCTV by parkingViewModel.onlyWithCCTV.collectAsState()
-
-  val radius = parkingViewModel.radius.collectAsState()
-
-  Column(modifier = Modifier.padding(16.dp)) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.End,
-        verticalAlignment = Alignment.CenterVertically) {
-          Text(
-              text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
-              modifier = Modifier.weight(1f).padding(end = 8.dp),
-              style = MaterialTheme.typography.headlineMedium,
-              color = MaterialTheme.colorScheme.onSurface)
-
-          SmallFloatingActionButton(
-              onClick = { showFilters = !showFilters },
-              icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
-              contentDescription = "Filter",
-              testTag = "ShowFiltersButton")
-        }
-
-    if (showFilters) {
-      Row(
-          modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-          horizontalArrangement = Arrangement.SpaceBetween) {
-            ClickableText(
-                text = AnnotatedString(stringResource(R.string.list_screen_clear_all)),
-                onClick = { parkingViewModel.clearAllFilterOptions() },
-                style =
-                    MaterialTheme.typography.labelMedium.copy(
-                        color = MaterialTheme.colorScheme.primary),
-                modifier = Modifier.padding(horizontal = 8.dp).testTag("ClearAllFiltersButton"))
-            ClickableText(
-                text = AnnotatedString(stringResource(R.string.list_screen_apply_all)),
-                onClick = { parkingViewModel.selectAllFilterOptions() },
-                style =
-                    MaterialTheme.typography.labelMedium.copy(
-                        color = MaterialTheme.colorScheme.primary),
-                modifier = Modifier.padding(horizontal = 8.dp).testTag("ApplyAllFiltersButton"))
-          }
-
-      // Protection filter
-      FilterSection(
-          title = stringResource(R.string.list_screen_protection),
-          expandedState = showProtectionOptions,
-          onReset = { parkingViewModel.clearProtection() },
-          onApply = { parkingViewModel.selectAllProtection() }) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth().testTag("ProtectionFilter"),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                  items(ParkingProtection.entries.toTypedArray()) { option ->
-                    ToggleButton(
-                        text = option.description,
-                        onClick = { parkingViewModel.toggleProtection(option) },
-                        value = selectedProtection.contains(option),
-                        modifier = Modifier.padding(2.dp),
-                        testTag = "ProtectionFilterItem")
-                  }
-                }
-          }
-
-      // Rack type filter
-      FilterSection(
-          title = stringResource(R.string.list_screen_rack_type),
-          expandedState = showRackTypeOptions,
-          onReset = { parkingViewModel.clearRackType() },
-          onApply = { parkingViewModel.selectAllRackTypes() }) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth().testTag("RackTypeFilter"),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                  items(ParkingRackType.entries.toTypedArray()) { option ->
-                    ToggleButton(
-                        text = option.description,
-                        onClick = { parkingViewModel.toggleRackType(option) },
-                        value = selectedRackTypes.contains(option),
-                        modifier = Modifier.padding(2.dp),
-                        testTag = "RackTypeFilterItem")
-                  }
-                }
-          }
-
-      // Capacity filter
-      FilterSection(
-          title = stringResource(R.string.list_screen_capacity),
-          expandedState = showCapacityOptions,
-          onReset = { parkingViewModel.clearCapacity() },
-          onApply = { parkingViewModel.selectAllCapacities() }) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth().testTag("CapacityFilter"),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                  items(ParkingCapacity.entries.toTypedArray()) { option ->
-                    ToggleButton(
-                        text = option.description,
-                        onClick = { parkingViewModel.toggleCapacity(option) },
-                        value = selectedCapacities.contains(option),
-                        modifier = Modifier.padding(2.dp),
-                        testTag = "CapacityFilterItem")
-                  }
-                }
-          }
-
-      // CCTV filter with checkbox
-      Row(
-          modifier = Modifier.fillMaxWidth().padding(12.dp),
-          verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = onlyWithCCTV,
-                onCheckedChange = { parkingViewModel.setOnlyWithCCTV(it) },
-                modifier = Modifier.testTag("CCTVCheckbox"),
-                colors = getCheckBoxColors(ColorLevel.PRIMARY))
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(R.string.list_screen_display_only_cctv),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.testTag("CCTVCheckboxLabel"))
-          }
-    }
-  }
-}
-
-@Composable
-fun FilterSection(
-    title: String,
-    expandedState: MutableState<Boolean>,
-    onReset: () -> Unit,
-    onApply: () -> Unit,
-    content: @Composable () -> Unit
-) {
-  Column(
-      modifier =
-          Modifier.padding(vertical = 8.dp)
-              .border(1.dp, Color.Gray, shape = MaterialTheme.shapes.medium)
-              .background(
-                  MaterialTheme.colorScheme.surfaceBright, shape = MaterialTheme.shapes.medium)
-              .padding(8.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically) {
-              ClickableText(
-                  text = AnnotatedString(stringResource(R.string.list_screen_clear)),
-                  onClick = { onReset() },
-                  style =
-                      MaterialTheme.typography.labelSmall.copy(
-                          color = MaterialTheme.colorScheme.primary),
-                  modifier =
-                      Modifier.padding(horizontal = 4.dp).testTag("Clear" + title + "Button"))
-              Text(
-                  text = title,
-                  style = MaterialTheme.typography.titleMedium,
-                  modifier =
-                      Modifier.clickable(onClick = { expandedState.value = !expandedState.value })
-                          .padding(6.dp),
-                  testTag = title)
-              ClickableText(
-                  text = AnnotatedString(stringResource(R.string.list_screen_apply)),
-                  onClick = { onApply() },
-                  style =
-                      MaterialTheme.typography.labelSmall.copy(
-                          color = MaterialTheme.colorScheme.primary),
-                  modifier = Modifier.padding(horizontal = 4.dp).testTag("Apply${title}Button"))
-            }
-
-        if (expandedState.value) {
-          Box(modifier = Modifier.padding(top = 8.dp)) { content() }
         }
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -128,7 +128,7 @@ fun MapScreen(
 ) {
 
   // Collect the list of parkings from the ParkingViewModel as a state
-  val listOfParkings by parkingViewModel.rectParkings.collectAsState()
+  val listOfParkings by parkingViewModel.filteredRectParkings.collectAsState(emptyList())
 
   // Create a remember state to store the search query of the search bar as a mutable state
   val searchQuery = remember { mutableStateOf("") }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -26,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
@@ -171,6 +171,9 @@ fun MapScreen(
 
   // Mutable state to store the visibility of the settings menu
   val showSettings = remember { mutableStateOf(false) }
+
+  // Mutable state to store the visibility of the filter dialog
+  val showFilter = remember { mutableStateOf(false) }
 
   // Initialize FocusManager
   val focusManager = LocalFocusManager.current
@@ -516,6 +519,15 @@ fun MapScreen(
                               showSuggestions.value = true
                             }))
 
+                // Filter button
+                Box(modifier = Modifier.size(56.dp).padding(start = 5.dp)) {
+                  SmallFloatingActionButton(
+                      modifier = Modifier.matchParentSize().testTag("FilterButton"),
+                      onClick = { showFilter.value = true },
+                      icon = Icons.Default.FilterList,
+                      contentDescription = "Filter")
+                }
+
                 // Settings button
                 Box(modifier = Modifier.size(56.dp).padding(start = 5.dp)) {
                   SmallFloatingActionButton(
@@ -532,11 +544,11 @@ fun MapScreen(
 
         if (showSettings.value) {
           SettingsDialog(
-              mapMode,
-              mapViewModel,
-              navigationActions,
-              parkingViewModel,
-              onDismiss = { showSettings.value = false })
+              mapMode, mapViewModel, navigationActions, onDismiss = { showSettings.value = false })
+        }
+
+        if (showFilter.value) {
+          FilterDialog(parkingViewModel, onDismiss = { showFilter.value = false })
         }
 
         if (showSuggestions.value &&
@@ -638,7 +650,6 @@ fun SettingsDialog(
     mapMode: State<MapViewModel.MapMode>,
     mapViewModel: MapViewModel,
     navigationActions: NavigationActions,
-    parkingViewModel: ParkingViewModel,
     onDismiss: () -> Unit
 ) {
   AlertDialog(
@@ -651,13 +662,9 @@ fun SettingsDialog(
       },
       text = {
         Column(
-            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(16.dp),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-          // Filter molecule without title, icon and padding
-          FilterHeader(parkingViewModel, displayHeader = false)
-          Spacer(modifier = Modifier.height(32.dp))
-
           // Advanced Mode
           Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
             Box(modifier = Modifier.width(64.dp), contentAlignment = Alignment.CenterStart) {
@@ -705,6 +712,33 @@ fun SettingsDialog(
                     text = stringResource(R.string.map_screen_settings_to_zone),
                     style = MaterialTheme.typography.bodyLarge)
               }
+        }
+      },
+      confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+      containerColor = MaterialTheme.colorScheme.surface,
+      tonalElevation = 8.dp,
+      shape = RoundedCornerShape(24.dp))
+}
+
+/**
+ * Composable function to display the filter dialog.
+ *
+ * @param parkingViewModel The ViewModel for managing parking-related data and actions.
+ * @param onDismiss The function to dismiss the dialog.
+ */
+@Composable
+fun FilterDialog(parkingViewModel: ParkingViewModel, onDismiss: () -> Unit) {
+  AlertDialog(
+      onDismissRequest = onDismiss,
+      title = {
+        Text(
+            text = stringResource(R.string.filter),
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(bottom = 16.dp))
+      },
+      text = {
+        Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
+          FilterHeader(parkingViewModel, displayHeader = false)
         }
       },
       confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -717,6 +717,7 @@ fun SettingsDialog(
       confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
       containerColor = MaterialTheme.colorScheme.surface,
       tonalElevation = 8.dp,
+      modifier = Modifier.testTag("SettingsMenu"),
       shape = RoundedCornerShape(24.dp))
 }
 
@@ -741,8 +742,13 @@ fun FilterDialog(parkingViewModel: ParkingViewModel, onDismiss: () -> Unit) {
           FilterHeader(parkingViewModel, displayHeader = false)
         }
       },
-      confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+      confirmButton = {
+        TextButton(onClick = onDismiss, modifier = Modifier.testTag("FilterMenuClose")) {
+          Text("Close")
+        }
+      },
       containerColor = MaterialTheme.colorScheme.surface,
       tonalElevation = 8.dp,
+      modifier = Modifier.testTag("FilterMenu"),
       shape = RoundedCornerShape(24.dp))
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -542,11 +542,15 @@ fun MapScreen(
               }
         }
 
+        // Settings alert dialog is shown when the showSettings state is true, until the user
+        // dismisses it by clicking the close button or outside the dialog.
         if (showSettings.value) {
           SettingsDialog(
               mapMode, mapViewModel, navigationActions, onDismiss = { showSettings.value = false })
         }
 
+        // Filter dialog is shown when the showFilter state is true, until the user dismisses it by
+        // clicking the close button or outside the dialog.
         if (showFilter.value) {
           FilterDialog(parkingViewModel, onDismiss = { showFilter.value = false })
         }
@@ -744,7 +748,7 @@ fun FilterDialog(parkingViewModel: ParkingViewModel, onDismiss: () -> Unit) {
       },
       confirmButton = {
         TextButton(onClick = onDismiss, modifier = Modifier.testTag("FilterMenuClose")) {
-          Text("Close")
+          Text(stringResource(R.string.close))
         }
       },
       containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -480,48 +481,49 @@ fun MapScreen(
                 testTag = "addButton")
           }
 
-          // Search bar
-          OutlinedTextField(
-              value = searchQuery.value,
-              onValueChange = { searchQuery.value = it },
-              placeholder = { Text(text = stringResource(R.string.search_bar_placeholder)) },
-              modifier =
-                  Modifier.fillMaxWidth(0.9f)
-                      .padding(end = 30.dp, start = 5.dp, top = 5.dp)
-                      .align(Alignment.TopStart)
-                      .testTag("SearchBar"),
-              shape = RoundedCornerShape(16.dp),
-              colors = getOutlinedTextFieldColorsSearchBar(ColorLevel.PRIMARY),
-              trailingIcon = {
-                if (searchQuery.value.isNotEmpty()) {
-                  Icon(
-                      imageVector = Icons.Filled.Clear,
-                      contentDescription = "Clear search",
-                      tint = defaultOnColor(),
-                      modifier = Modifier.clickable { searchQuery.value = "" })
+          // Search bar and Settings button row
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(5.dp).align(Alignment.TopStart),
+              verticalAlignment = Alignment.CenterVertically) {
+                // Search bar
+                OutlinedTextField(
+                    value = searchQuery.value,
+                    onValueChange = { searchQuery.value = it },
+                    placeholder = { Text(text = stringResource(R.string.search_bar_placeholder)) },
+                    modifier = Modifier.weight(1f).height(56.dp).testTag("SearchBar"),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = getOutlinedTextFieldColorsSearchBar(ColorLevel.PRIMARY),
+                    trailingIcon = {
+                      if (searchQuery.value.isNotEmpty()) {
+                        Icon(
+                            imageVector = Icons.Filled.Clear,
+                            contentDescription = "Clear search",
+                            tint = defaultOnColor(),
+                            modifier = Modifier.clickable { searchQuery.value = "" })
+                      }
+                    },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+                    keyboardActions =
+                        KeyboardActions(
+                            onSearch = {
+                              virtualKeyboardManager?.hide()
+                              runBlocking { addressViewModel.search(searchQuery.value) }
+                              showSuggestions.value = true
+                            }))
+
+                // Settings button
+                Box(modifier = Modifier.size(56.dp).padding(start = 5.dp)) {
+                  SmallFloatingActionButton(
+                      modifier =
+                          Modifier.matchParentSize() // Fill the parent Box
+                              .testTag("SettingsMenuButton"),
+                      onClick = { showSettings.value = true },
+                      icon = Icons.Filled.Settings,
+                      contentDescription = "Settings",
+                  )
                 }
-              },
-              singleLine = true,
-              keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
-              keyboardActions =
-                  KeyboardActions(
-                      onSearch = {
-                        virtualKeyboardManager?.hide()
-
-                        runBlocking { addressViewModel.search(searchQuery.value) }
-
-                        showSuggestions.value = true
-                      }))
-
-          SmallFloatingActionButton(
-              modifier =
-                  Modifier.align(Alignment.TopEnd)
-                      .padding(top = 5.dp, end = 5.dp)
-                      .testTag("SettingsMenuButton"),
-              onClick = { showSettings.value = true },
-              icon = Icons.Filled.Settings,
-              contentDescription = "Settings",
-          )
+              }
         }
 
         if (showSettings.value) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -82,7 +82,7 @@ import com.github.se.cyrcle.ui.theme.defaultOnColor
 import com.github.se.cyrcle.ui.theme.getOutlinedTextFieldColorsSearchBar
 import com.github.se.cyrcle.ui.theme.invertColor
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
-import com.github.se.cyrcle.ui.theme.molecules.FilterHeader
+import com.github.se.cyrcle.ui.theme.molecules.FilterPanel
 import com.google.gson.Gson
 import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.geojson.Point
@@ -739,7 +739,7 @@ fun FilterDialog(parkingViewModel: ParkingViewModel, onDismiss: () -> Unit) {
       },
       text = {
         Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
-          FilterHeader(parkingViewModel, displayHeader = false)
+          FilterPanel(parkingViewModel, displayHeader = false)
         }
       },
       confirmButton = {

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -43,8 +43,21 @@ import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
 import com.github.se.cyrcle.ui.theme.getCheckBoxColors
 
+/**
+ * FilterPanel is a composable that displays the filter options for the parking list screen. It
+ * contains the following filter options:
+ * - Protection
+ * - Rack type
+ * - Capacity
+ * - CCTV
+ *
+ * @param parkingViewModel The view model that contains the filter options
+ * @param displayHeader A boolean that determines if the filter header should be displayed. If true,
+ *   a floating action button will be displayed to show/hide the filter options. If false, the
+ *   filter the filter options and sections will be expanded and not collapsible.
+ */
 @Composable
-fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = true) {
+fun FilterPanel(parkingViewModel: ParkingViewModel, displayHeader: Boolean) {
   val showProtectionOptions = remember { mutableStateOf(!displayHeader) }
   val showRackTypeOptions = remember { mutableStateOf(!displayHeader) }
   val showCapacityOptions = remember { mutableStateOf(!displayHeader) }
@@ -58,11 +71,13 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
   val radius = parkingViewModel.radius.collectAsState()
 
   Column(modifier = Modifier.padding(if (displayHeader) 16.dp else 0.dp)) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.End,
-        verticalAlignment = Alignment.CenterVertically) {
-          if (displayHeader) {
+    if (displayHeader) {
+
+      // Header. Contains the title and the show/hide filters floating action button
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+          horizontalArrangement = Arrangement.End,
+          verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
                 modifier = Modifier.weight(1f).padding(end = 8.dp),
@@ -75,8 +90,12 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
                 contentDescription = "Filter",
                 testTag = "ShowFiltersButton")
           }
-        }
+    }
 
+    // Filter options. Contains the protection, rack type, capacity, and CCTV filters.
+    // We display the filters if the showFilters is true or if the displayHeader is false. This is
+    // because if displayHeader is false, we want to display the filters expanded and not
+    // collapsible.
     if (showFilters || !displayHeader) {
       Row(
           modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
@@ -101,7 +120,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
       FilterSection(
           title = stringResource(R.string.list_screen_protection),
           expandedState = showProtectionOptions,
-          expandable = displayHeader,
+          collapsible = displayHeader,
           onReset = { parkingViewModel.clearProtection() },
           onApply = { parkingViewModel.selectAllProtection() }) {
             LazyRow(
@@ -121,7 +140,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
       FilterSection(
           title = stringResource(R.string.list_screen_rack_type),
           expandedState = showRackTypeOptions,
-          expandable = displayHeader,
+          collapsible = displayHeader,
           onReset = { parkingViewModel.clearRackType() },
           onApply = { parkingViewModel.selectAllRackTypes() }) {
             LazyRow(
@@ -141,7 +160,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
       FilterSection(
           title = stringResource(R.string.list_screen_capacity),
           expandedState = showCapacityOptions,
-          expandable = displayHeader,
+          collapsible = displayHeader,
           onReset = { parkingViewModel.clearCapacity() },
           onApply = { parkingViewModel.selectAllCapacities() }) {
             LazyRow(
@@ -177,11 +196,24 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
   }
 }
 
+/**
+ * FilterSection is a composable that displays a filter section with a title, clear and apply
+ * buttons, and the filter options. The filter options are displayed in a column and can be expanded
+ * or collapsed by clicking on the title if the collapsible parameter is true.
+ *
+ * @param title The title of the filter section
+ * @param expandedState A mutable state that determines if the filter options are expanded or
+ *   collapsed
+ * @param collapsible A boolean that determines if the filter options can be expanded or collapsed
+ * @param onReset A lambda that is called when the clear button is clicked
+ * @param onApply A lambda that is called when the apply button is clicked
+ * @param content A lambda that contains the filter options
+ */
 @Composable
 fun FilterSection(
     title: String,
     expandedState: MutableState<Boolean>,
-    expandable: Boolean,
+    collapsible: Boolean,
     onReset: () -> Unit,
     onApply: () -> Unit,
     content: @Composable () -> Unit
@@ -203,15 +235,14 @@ fun FilterSection(
                   style =
                       MaterialTheme.typography.labelSmall.copy(
                           color = MaterialTheme.colorScheme.primary),
-                  modifier =
-                      Modifier.padding(horizontal = 4.dp).testTag("Clear" + title + "Button"))
+                  modifier = Modifier.padding(horizontal = 4.dp).testTag("Clear${title}Button"))
               Text(
                   text = title,
                   style = MaterialTheme.typography.titleMedium,
                   modifier =
                       Modifier.clickable(
                               onClick = {
-                                if (expandable) expandedState.value = !expandedState.value
+                                if (collapsible) expandedState.value = !expandedState.value
                               })
                           .padding(6.dp),
                   testTag = title)
@@ -224,7 +255,7 @@ fun FilterSection(
                   modifier = Modifier.padding(horizontal = 4.dp).testTag("Apply${title}Button"))
             }
 
-        if (expandedState.value) {
+        if (expandedState.value || !collapsible) {
           Box(modifier = Modifier.padding(top = 8.dp)) { content() }
         }
       }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -1,0 +1,225 @@
+package com.github.se.cyrcle.ui.theme.molecules
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.parking.ParkingCapacity
+import com.github.se.cyrcle.model.parking.ParkingProtection
+import com.github.se.cyrcle.model.parking.ParkingRackType
+import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
+import com.github.se.cyrcle.ui.theme.atoms.Text
+import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
+import com.github.se.cyrcle.ui.theme.getCheckBoxColors
+
+@Composable
+fun FilterHeader(parkingViewModel: ParkingViewModel) {
+  val showProtectionOptions = remember { mutableStateOf(false) }
+  val showRackTypeOptions = remember { mutableStateOf(false) }
+  val showCapacityOptions = remember { mutableStateOf(false) }
+  var showFilters by remember { mutableStateOf(false) }
+
+  val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
+  val selectedRackTypes by parkingViewModel.selectedRackTypes.collectAsState()
+  val selectedCapacities by parkingViewModel.selectedCapacities.collectAsState()
+  val onlyWithCCTV by parkingViewModel.onlyWithCCTV.collectAsState()
+
+  val radius = parkingViewModel.radius.collectAsState()
+
+  Column(modifier = Modifier.padding(16.dp)) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically) {
+          Text(
+              text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
+              modifier = Modifier.weight(1f).padding(end = 8.dp),
+              style = MaterialTheme.typography.headlineMedium,
+              color = MaterialTheme.colorScheme.onSurface)
+
+          SmallFloatingActionButton(
+              onClick = { showFilters = !showFilters },
+              icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
+              contentDescription = "Filter",
+              testTag = "ShowFiltersButton")
+        }
+
+    if (showFilters) {
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+          horizontalArrangement = Arrangement.SpaceBetween) {
+            ClickableText(
+                text = AnnotatedString(stringResource(R.string.list_screen_clear_all)),
+                onClick = { parkingViewModel.clearAllFilterOptions() },
+                style =
+                    MaterialTheme.typography.labelMedium.copy(
+                        color = MaterialTheme.colorScheme.primary),
+                modifier = Modifier.padding(horizontal = 8.dp).testTag("ClearAllFiltersButton"))
+            ClickableText(
+                text = AnnotatedString(stringResource(R.string.list_screen_apply_all)),
+                onClick = { parkingViewModel.selectAllFilterOptions() },
+                style =
+                    MaterialTheme.typography.labelMedium.copy(
+                        color = MaterialTheme.colorScheme.primary),
+                modifier = Modifier.padding(horizontal = 8.dp).testTag("ApplyAllFiltersButton"))
+          }
+
+      // Protection filter
+      FilterSection(
+          title = stringResource(R.string.list_screen_protection),
+          expandedState = showProtectionOptions,
+          onReset = { parkingViewModel.clearProtection() },
+          onApply = { parkingViewModel.selectAllProtection() }) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().testTag("ProtectionFilter"),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                  items(ParkingProtection.entries.toTypedArray()) { option ->
+                    ToggleButton(
+                        text = option.description,
+                        onClick = { parkingViewModel.toggleProtection(option) },
+                        value = selectedProtection.contains(option),
+                        modifier = Modifier.padding(2.dp),
+                        testTag = "ProtectionFilterItem")
+                  }
+                }
+          }
+
+      // Rack type filter
+      FilterSection(
+          title = stringResource(R.string.list_screen_rack_type),
+          expandedState = showRackTypeOptions,
+          onReset = { parkingViewModel.clearRackType() },
+          onApply = { parkingViewModel.selectAllRackTypes() }) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().testTag("RackTypeFilter"),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                  items(ParkingRackType.entries.toTypedArray()) { option ->
+                    ToggleButton(
+                        text = option.description,
+                        onClick = { parkingViewModel.toggleRackType(option) },
+                        value = selectedRackTypes.contains(option),
+                        modifier = Modifier.padding(2.dp),
+                        testTag = "RackTypeFilterItem")
+                  }
+                }
+          }
+
+      // Capacity filter
+      FilterSection(
+          title = stringResource(R.string.list_screen_capacity),
+          expandedState = showCapacityOptions,
+          onReset = { parkingViewModel.clearCapacity() },
+          onApply = { parkingViewModel.selectAllCapacities() }) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().testTag("CapacityFilter"),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                  items(ParkingCapacity.entries.toTypedArray()) { option ->
+                    ToggleButton(
+                        text = option.description,
+                        onClick = { parkingViewModel.toggleCapacity(option) },
+                        value = selectedCapacities.contains(option),
+                        modifier = Modifier.padding(2.dp),
+                        testTag = "CapacityFilterItem")
+                  }
+                }
+          }
+
+      // CCTV filter with checkbox
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(12.dp),
+          verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = onlyWithCCTV,
+                onCheckedChange = { parkingViewModel.setOnlyWithCCTV(it) },
+                modifier = Modifier.testTag("CCTVCheckbox"),
+                colors = getCheckBoxColors(ColorLevel.PRIMARY))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.list_screen_display_only_cctv),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("CCTVCheckboxLabel"))
+          }
+    }
+  }
+}
+
+@Composable
+fun FilterSection(
+    title: String,
+    expandedState: MutableState<Boolean>,
+    onReset: () -> Unit,
+    onApply: () -> Unit,
+    content: @Composable () -> Unit
+) {
+  Column(
+      modifier =
+          Modifier.padding(vertical = 8.dp)
+              .border(1.dp, Color.Gray, shape = MaterialTheme.shapes.medium)
+              .background(
+                  MaterialTheme.colorScheme.surfaceBright, shape = MaterialTheme.shapes.medium)
+              .padding(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically) {
+              ClickableText(
+                  text = AnnotatedString(stringResource(R.string.list_screen_clear)),
+                  onClick = { onReset() },
+                  style =
+                      MaterialTheme.typography.labelSmall.copy(
+                          color = MaterialTheme.colorScheme.primary),
+                  modifier =
+                      Modifier.padding(horizontal = 4.dp).testTag("Clear" + title + "Button"))
+              Text(
+                  text = title,
+                  style = MaterialTheme.typography.titleMedium,
+                  modifier =
+                      Modifier.clickable(onClick = { expandedState.value = !expandedState.value })
+                          .padding(6.dp),
+                  testTag = title)
+              ClickableText(
+                  text = AnnotatedString(stringResource(R.string.list_screen_apply)),
+                  onClick = { onApply() },
+                  style =
+                      MaterialTheme.typography.labelSmall.copy(
+                          color = MaterialTheme.colorScheme.primary),
+                  modifier = Modifier.padding(horizontal = 4.dp).testTag("Apply${title}Button"))
+            }
+
+        if (expandedState.value) {
+          Box(modifier = Modifier.padding(top = 8.dp)) { content() }
+        }
+      }
+}

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -45,9 +45,9 @@ import com.github.se.cyrcle.ui.theme.getCheckBoxColors
 
 @Composable
 fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = true) {
-  val showProtectionOptions = remember { mutableStateOf(false) }
-  val showRackTypeOptions = remember { mutableStateOf(false) }
-  val showCapacityOptions = remember { mutableStateOf(false) }
+  val showProtectionOptions = remember { mutableStateOf(!displayHeader) }
+  val showRackTypeOptions = remember { mutableStateOf(!displayHeader) }
+  val showCapacityOptions = remember { mutableStateOf(!displayHeader) }
   var showFilters by remember { mutableStateOf(!displayHeader) }
 
   val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
@@ -101,6 +101,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
       FilterSection(
           title = stringResource(R.string.list_screen_protection),
           expandedState = showProtectionOptions,
+          expandable = displayHeader,
           onReset = { parkingViewModel.clearProtection() },
           onApply = { parkingViewModel.selectAllProtection() }) {
             LazyRow(
@@ -120,6 +121,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
       FilterSection(
           title = stringResource(R.string.list_screen_rack_type),
           expandedState = showRackTypeOptions,
+          expandable = displayHeader,
           onReset = { parkingViewModel.clearRackType() },
           onApply = { parkingViewModel.selectAllRackTypes() }) {
             LazyRow(
@@ -139,6 +141,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
       FilterSection(
           title = stringResource(R.string.list_screen_capacity),
           expandedState = showCapacityOptions,
+          expandable = displayHeader,
           onReset = { parkingViewModel.clearCapacity() },
           onApply = { parkingViewModel.selectAllCapacities() }) {
             LazyRow(
@@ -178,6 +181,7 @@ fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = tr
 fun FilterSection(
     title: String,
     expandedState: MutableState<Boolean>,
+    expandable: Boolean,
     onReset: () -> Unit,
     onApply: () -> Unit,
     content: @Composable () -> Unit
@@ -205,7 +209,10 @@ fun FilterSection(
                   text = title,
                   style = MaterialTheme.typography.titleMedium,
                   modifier =
-                      Modifier.clickable(onClick = { expandedState.value = !expandedState.value })
+                      Modifier.clickable(
+                              onClick = {
+                                if (expandable) expandedState.value = !expandedState.value
+                              })
                           .padding(6.dp),
                   testTag = title)
               ClickableText(

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -58,6 +58,9 @@ import com.github.se.cyrcle.ui.theme.getCheckBoxColors
  */
 @Composable
 fun FilterPanel(parkingViewModel: ParkingViewModel, displayHeader: Boolean) {
+  // Mutable state to determine if filters in general, and each filter section, are expanded or
+  // collapsed. Initialized to true if the displayHeader is false, as we want to display the filters
+  // expanded if the header is not displayed.
   val showProtectionOptions = remember { mutableStateOf(!displayHeader) }
   val showRackTypeOptions = remember { mutableStateOf(!displayHeader) }
   val showCapacityOptions = remember { mutableStateOf(!displayHeader) }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -7,10 +7,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.ClickableText
@@ -32,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.parking.ParkingCapacity
@@ -45,11 +44,11 @@ import com.github.se.cyrcle.ui.theme.atoms.ToggleButton
 import com.github.se.cyrcle.ui.theme.getCheckBoxColors
 
 @Composable
-fun FilterHeader(parkingViewModel: ParkingViewModel) {
+fun FilterHeader(parkingViewModel: ParkingViewModel, displayHeader: Boolean = true) {
   val showProtectionOptions = remember { mutableStateOf(false) }
   val showRackTypeOptions = remember { mutableStateOf(false) }
   val showCapacityOptions = remember { mutableStateOf(false) }
-  var showFilters by remember { mutableStateOf(false) }
+  var showFilters by remember { mutableStateOf(!displayHeader) }
 
   val selectedProtection by parkingViewModel.selectedProtection.collectAsState()
   val selectedRackTypes by parkingViewModel.selectedRackTypes.collectAsState()
@@ -58,25 +57,27 @@ fun FilterHeader(parkingViewModel: ParkingViewModel) {
 
   val radius = parkingViewModel.radius.collectAsState()
 
-  Column(modifier = Modifier.padding(16.dp)) {
+  Column(modifier = Modifier.padding(if (displayHeader) 16.dp else 0.dp)) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
-          Text(
-              text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
-              modifier = Modifier.weight(1f).padding(end = 8.dp),
-              style = MaterialTheme.typography.headlineMedium,
-              color = MaterialTheme.colorScheme.onSurface)
+          if (displayHeader) {
+            Text(
+                text = stringResource(R.string.all_parkings_radius, radius.value.toInt()),
+                modifier = Modifier.weight(1f).padding(end = 8.dp),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface)
 
-          SmallFloatingActionButton(
-              onClick = { showFilters = !showFilters },
-              icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
-              contentDescription = "Filter",
-              testTag = "ShowFiltersButton")
+            SmallFloatingActionButton(
+                onClick = { showFilters = !showFilters },
+                icon = if (showFilters) Icons.Default.Close else Icons.Default.FilterList,
+                contentDescription = "Filter",
+                testTag = "ShowFiltersButton")
+          }
         }
 
-    if (showFilters) {
+    if (showFilters || !displayHeader) {
       Row(
           modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
           horizontalArrangement = Arrangement.SpaceBetween) {
@@ -110,7 +111,6 @@ fun FilterHeader(parkingViewModel: ParkingViewModel) {
                         text = option.description,
                         onClick = { parkingViewModel.toggleProtection(option) },
                         value = selectedProtection.contains(option),
-                        modifier = Modifier.padding(2.dp),
                         testTag = "ProtectionFilterItem")
                   }
                 }
@@ -130,7 +130,6 @@ fun FilterHeader(parkingViewModel: ParkingViewModel) {
                         text = option.description,
                         onClick = { parkingViewModel.toggleRackType(option) },
                         value = selectedRackTypes.contains(option),
-                        modifier = Modifier.padding(2.dp),
                         testTag = "RackTypeFilterItem")
                   }
                 }
@@ -150,7 +149,6 @@ fun FilterHeader(parkingViewModel: ParkingViewModel) {
                         text = option.description,
                         onClick = { parkingViewModel.toggleCapacity(option) },
                         value = selectedCapacities.contains(option),
-                        modifier = Modifier.padding(2.dp),
                         testTag = "CapacityFilterItem")
                   }
                 }
@@ -158,17 +156,18 @@ fun FilterHeader(parkingViewModel: ParkingViewModel) {
 
       // CCTV filter with checkbox
       Row(
-          modifier = Modifier.fillMaxWidth().padding(12.dp),
-          verticalAlignment = Alignment.CenterVertically) {
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             Checkbox(
                 checked = onlyWithCCTV,
                 onCheckedChange = { parkingViewModel.setOnlyWithCCTV(it) },
                 modifier = Modifier.testTag("CCTVCheckbox"),
                 colors = getCheckBoxColors(ColorLevel.PRIMARY))
-            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = stringResource(R.string.list_screen_display_only_cctv),
                 style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Start,
                 modifier = Modifier.testTag("CCTVCheckboxLabel"))
           }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,9 +102,9 @@
     <string name="list_screen_rack_type">Rack Type</string>
     <string name="list_screen_capacity">Capacity</string>
     <string name="list_screen_clear_all">Clear All</string>
-    <string name="list_screen_apply_all">Apply All</string>
+    <string name="list_screen_apply_all">Select All</string>
     <string name="list_screen_clear">Clear</string>
-    <string name="list_screen_apply">Apply</string>
+    <string name="list_screen_apply">Select All</string>
     <string name="list_screen_price">%.2f $</string>
     <string name="list_screen_rating">Rating: %.1f</string>
     <string name="list_screen_display_only_cctv">Only display parkings with CCTV camera</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="already_in_favorites_toast">Parking is already in favorites</string>
     <string name="sign_in_to_add_favorites">Please sign in to add favorites</string>
     <string name="filter">Filter</string>
+    <string name="close">Close</string>
 
     <!-- Error Messages -->
     <string name="input_min_characters">Minimum %1$d characters required (current: %2$d)</string>

--- a/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/parking/ParkingViewModelTest.kt
@@ -6,6 +6,8 @@ import com.github.se.cyrcle.model.report.ReportedObject
 import com.github.se.cyrcle.model.report.ReportedObjectRepository
 import com.github.se.cyrcle.model.report.ReportedObjectType
 import com.mapbox.geojson.Point
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -65,7 +67,7 @@ class ParkingViewModelTest {
     parkingViewModel.getParkingsInRect(Point.fromLngLat(6.0, 46.0), Point.fromLngLat(6.05, 46.05))
 
     // Check if the parkings returned are the correct ones
-    val parkingsReturned = parkingViewModel.rectParkings.value
+    val parkingsReturned = runBlocking { parkingViewModel.filteredRectParkings.first() }
     assertEquals(2, parkingsReturned.size)
     assert(parkingsReturned.contains(TestInstancesParking.parking1))
     assert(parkingsReturned.contains(TestInstancesParking.parking2))
@@ -192,7 +194,7 @@ class ParkingViewModelTest {
   @Test
   fun uploadImageTest() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
-    parkingViewModel.uploadImage("localPath/image.jpg", context, {})
+    parkingViewModel.uploadImage("localPath/image.jpg", context) {}
     verify(imageRepository).uploadImage(any(), any(), any(), any(), any())
   }
 
@@ -201,7 +203,7 @@ class ParkingViewModelTest {
     // assert nothing is called when no parking is selected
     val emptyParkingViewModel =
         ParkingViewModel(imageRepository, parkingRepository, reportedObjectRepository)
-    emptyParkingViewModel.uploadImage("localPath/image.jpg", context, {})
+    emptyParkingViewModel.uploadImage("localPath/image.jpg", context) {}
     verify(imageRepository, never()).uploadImage(any(), any(), any(), any(), any())
   }
 


### PR DESCRIPTION
This PR integrates the filter functionality from the list screen into the map screen, enhancing the user experience and providing consistent filtering capabilities across the application.

## Disclaimer

The GitHub diff shows a significant number of additions and deletions due to the following reasons:

- The FilterHeader and FilterSection Composables, along with their respective test suites, have been relocated to a new file named `Filter` (and `FilterTest` for tests) in the molecules package. This accounts for approximately 350 deletions and 420 additions.

- For reviewers: Given that git recognizes everything as "new" in the `Filter` file, my advice to effectively review the changes made to the FilterHeader and FilterSection composables, is to examine the following commits (posterior to the relocation):
  1. [feat: integrate Filter molecule in MapScreen settings dialog](https://github.com/SwEnt-Fall-2024-Group-22/Cyrcle/commit/0b309f72b4cfb9787827629069a765b0210162d7)
  2. [feat: extract filters into their own AlertDialog](https://github.com/SwEnt-Fall-2024-Group-22/Cyrcle/commit/206ce91d52cdc41a088879a156fd64e9eda35eb7)

## Key Changes
### UI Enhancements
<img width="250" alt="image" src="https://github.com/user-attachments/assets/8760beda-465c-4c20-adbd-f573b66febc8">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5ed1eee8-40b7-41bd-94e4-b7f7818ea37f">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/baa2d8b8-8335-4f24-8d2f-c039e60e928d">


The map screen now features two floating icons at the top:
1. Settings Icon (existing, realigned):
   - Opens the settings in an AlertDialog (previously an overlayed box)
2. Filters Icon (new):
   - Opens an AlertDialog with filter options

The FilterHeader composable has been updated with a new `displayHeader` boolean parameter to distinguish its usage:
- In the ListScreen (true): Like before, features a floating action button that expands the content, allowing individual expansion of each FilterSection
- In the MapScreen (false): Content is pre-expanded, and padding is disabled due to the AlertDialog's inherent padding

### ViewModel Updates
A new `filteredRectParkings` flow has been implemented, which updates when:
- `_rectParking` is modified
- Any filter option is changed

The `closestParkings` stateflow is now computed from `filteredRectParkings` in a coroutine, still within the `updateClosestParkings` function.

## Test Coverage
Please note that the map package already had relatively low coverage due to its nature. The current coverage is as follows:
![image](https://github.com/user-attachments/assets/f0dad5c5-2aca-4638-9c27-4fc9173881e9)

-- -
- Closes #340.