### PR TITLE
Show in Map button

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -197,6 +197,9 @@ class ParkingDetailsScreenTest {
     // Scroll to the buttons section
     composeTestRule.onNodeWithTag("ButtonsColumn").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("ShowInMapButton").assertIsDisplayed()
+
+    // Verify the Show in Map button
+    composeTestRule.onNodeWithTag("ShowInMapButton").assertIsDisplayed()
   }
 
   @Test
@@ -311,5 +314,20 @@ class ParkingDetailsScreenTest {
     // After saving, the note input and save button should be hidden
     composeTestRule.onNodeWithTag("NoteInputText").assertIsNotDisplayed()
     composeTestRule.onNodeWithTag("SaveNoteIcon").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun showInMapButtonGoesToMapScreen() {
+    parkingViewModel.selectParking(TestInstancesParking.parking1)
+    composeTestRule.setContent {
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
+    }
+
+    composeTestRule
+        .onNodeWithTag("ShowInMapButton")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    verify(navigationActions).navigateTo(Screen.MAP)
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreenTest.kt
@@ -20,6 +20,7 @@ import com.github.se.cyrcle.di.mocks.MockReportedObjectRepository
 import com.github.se.cyrcle.di.mocks.MockReviewRepository
 import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.image.ImageRepository
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
@@ -53,6 +54,7 @@ class ParkingDetailsScreenTest {
   private lateinit var mockReportedObjectRepository: ReportedObjectRepository
   private lateinit var authenticator: MockAuthenticationRepository
 
+  private lateinit var mapViewModel: MapViewModel
   private lateinit var userViewModel: UserViewModel
   private lateinit var parkingViewModel: ParkingViewModel
   private lateinit var reviewViewModel: ReviewViewModel
@@ -73,6 +75,7 @@ class ParkingDetailsScreenTest {
     authenticator = MockAuthenticationRepository()
     mockReportedObjectRepository = MockReportedObjectRepository()
 
+    mapViewModel = MapViewModel()
     parkingViewModel =
         ParkingViewModel(
             imageRepository,
@@ -94,7 +97,7 @@ class ParkingDetailsScreenTest {
     userViewModel.setCurrentUser(null) // Ensure user is signed out
 
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("TopInteractionRow").assertIsDisplayed()
@@ -108,7 +111,7 @@ class ParkingDetailsScreenTest {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
 
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("PinIcon").assertIsDisplayed().performClick()
@@ -133,7 +136,7 @@ class ParkingDetailsScreenTest {
     userViewModel.signIn({}, {})
 
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
     // Initially should show outline icon
     composeTestRule.onNodeWithTag("BlackOutlinedFavoriteIcon").assertIsDisplayed()
@@ -153,7 +156,7 @@ class ParkingDetailsScreenTest {
     userViewModel.signIn({}, {})
 
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     // Initially should show filled icon
@@ -170,7 +173,7 @@ class ParkingDetailsScreenTest {
   fun displayAllComponents() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     // Verify the top app bar
@@ -200,7 +203,7 @@ class ParkingDetailsScreenTest {
   fun componentsDisplayCorrectValues() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule
@@ -227,7 +230,7 @@ class ParkingDetailsScreenTest {
   fun displayTitleAndMultipleImages() {
     parkingViewModel.selectParking(TestInstancesParking.parking2)
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("TopAppBarTitle").assertTextContains("Description of Rude épais")
@@ -238,7 +241,7 @@ class ParkingDetailsScreenTest {
   fun seeAllReviewsBehavesCorrectly() {
     parkingViewModel.selectParking(TestInstancesParking.parking1)
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("SeeAllReviewsText").performClick()
@@ -251,7 +254,7 @@ class ParkingDetailsScreenTest {
     userViewModel.setCurrentUser(TestInstancesUser.user1)
     parkingViewModel.selectParking(TestInstancesParking.parking1)
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("NoteText").assertIsDisplayed()
@@ -284,7 +287,7 @@ class ParkingDetailsScreenTest {
     userViewModel.setCurrentUser(userWithNote)
     parkingViewModel.selectParking(TestInstancesParking.parking1)
     composeTestRule.setContent {
-      ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+      ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
     }
 
     composeTestRule

--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -63,7 +63,7 @@ fun CyrcleNavHost(
         SpotListScreen(navigationActions, parkingViewModel, mapViewModel, userViewModel)
       }
       composable(Screen.PARKING_DETAILS) {
-        ParkingDetailsScreen(navigationActions, parkingViewModel, userViewModel)
+        ParkingDetailsScreen(mapViewModel, navigationActions, parkingViewModel, userViewModel)
       }
       composable(Screen.PARKING_REPORT) {
         ParkingReportScreen(navigationActions, userViewModel, parkingViewModel)

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -10,6 +10,7 @@ import com.github.se.cyrcle.model.parking.PARKING_MAX_SIDE_LENGTH
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.map.MapConfig
+import com.github.se.cyrcle.ui.map.maxZoom
 import com.github.se.cyrcle.ui.theme.molecules.DropDownableEnum
 import com.google.gson.Gson
 import com.mapbox.geojson.Point
@@ -119,6 +120,22 @@ class MapViewModel : ViewModel() {
    */
   fun updateCameraPosition(cameraState: CameraState) {
     _cameraPosition.value = cameraState
+  }
+
+  /**
+   * Set the camera to go to a specific location, with default padding, bearing and pitch. The zoom
+   * is set to the max zoom defined in the UI.
+   *
+   * @param location the location to zoom on.
+   */
+  fun zoomOnLocation(location: Location) {
+    _cameraPosition.value =
+        CameraState(
+            location.center,
+            MapConfig.defaultCameraState().padding,
+            maxZoom,
+            MapConfig.defaultCameraState().bearing,
+            MapConfig.defaultCameraState().pitch)
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.cyrcle.R
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.user.MAX_NOTE_LENGTH
 import com.github.se.cyrcle.model.user.UserViewModel
@@ -73,6 +74,7 @@ import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun ParkingDetailsScreen(
+    mapViewModel: MapViewModel,
     navigationActions: NavigationActions,
     parkingViewModel: ParkingViewModel,
     userViewModel: UserViewModel
@@ -442,11 +444,13 @@ fun ParkingDetailsScreen(
                     Button(
                         text = stringResource(R.string.card_screen_show_map),
                         onClick = {
-                          Toast.makeText(
-                                  context,
-                                  "A feature to show the parking on the map will be added later",
-                                  Toast.LENGTH_LONG)
-                              .show()
+                          parkingViewModel.selectParking(selectedParking)
+
+                          mapViewModel.updateTrackingMode(false)
+                          mapViewModel.updateMapRecentering(false) // Avoid
+                          mapViewModel.zoomOnLocation(selectedParking.location)
+
+                          navigationActions.navigateTo(Screen.MAP)
                         },
                         modifier = Modifier.fillMaxWidth(),
                         colorLevel = ColorLevel.PRIMARY,

--- a/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/parkingDetails/ParkingDetailsScreen.kt
@@ -447,7 +447,8 @@ fun ParkingDetailsScreen(
                           parkingViewModel.selectParking(selectedParking)
 
                           mapViewModel.updateTrackingMode(false)
-                          mapViewModel.updateMapRecentering(false) // Avoid
+
+                          mapViewModel.updateMapRecentering(true)
                           mapViewModel.zoomOnLocation(selectedParking.location)
 
                           navigationActions.navigateTo(Screen.MAP)

--- a/app/src/test/java/com/github/se/cyrcle/model/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/github/se/cyrcle/model/map/MapViewModelTest.kt
@@ -71,4 +71,16 @@ class MapViewModelTest {
     mapViewModel.updateScreenCoordinates(screenCoordinates)
     assert(mapViewModel.screenCoordinates.value == screenCoordinates)
   }
+
+  @Test
+  fun mapViewModelTestZoomOnLocation() {
+    assert(mapViewModel.screenCoordinates.value.isEmpty())
+    val expected = Location(Point.fromLngLat(6.566, 46.519))
+    mapViewModel.zoomOnLocation(expected)
+
+    val actual =
+        mapViewModel.cameraPosition.value?.center
+            ?: Point.fromLngLat(0.0, 0.0) // Default to somewhere not expected
+    assert(expected.center == actual)
+  }
 }


### PR DESCRIPTION
# Content of this PR

## How
- Modify the `onClick` lambda in the button "Show in Map" in the `ParkingDetailsScreen`.
- Add a function in MapViewModel to zoom on a location. Allow to move the camera without getting the `_cameraState`.
- ParkingDetailsScreen now require the MapViewModel to navigate to a particular position.

## Small note
The documentation of the `MapViewModel` , while existing, was a bit hard to read. Maybe some clarification could be done in the polish sprint.

## Code coverage
<img src="https://github.com/user-attachments/assets/7cf43522-ec39-4efc-ada1-aa2a504c630f" width="300">

### Changes in code coverage
- `ui/parkingDetails` 84% to 84%
- `model/map` 82% to 82%
- *general* 82% to 82%

## Close
Close #348 