### PR TITLE
Polish the MapBoxMap

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -49,6 +49,7 @@ class ParkingViewModel(
   // ================== Parkings ==================
   /** List of parkings within the designated area */
   private val _rectParkings = MutableStateFlow<List<Parking>>(emptyList())
+  val rectParkings: StateFlow<List<Parking>> = _rectParkings
 
   /**
    * List of parkings within the designated area, filtered by the selected options. The flow is

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPicker.kt
@@ -53,7 +53,7 @@ fun LocationPicker(
   var pLabelAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
 
   // Collect the list of parkings from the ParkingViewModel as a state
-  val listOfParkings by parkingViewModel.filteredRectParkings.collectAsState(emptyList())
+  val listOfParkings by parkingViewModel.rectParkings.collectAsState(emptyList())
 
   // Draw the markers on the map when the list of parkings changes
   LaunchedEffect(listOfParkings) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -103,8 +103,10 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
+import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.gestures
+import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
 import com.mapbox.maps.plugin.viewport.data.FollowPuckViewportStateOptions
 import com.mapbox.maps.plugin.viewport.data.OverviewViewportStateOptions
 import com.mapbox.maps.viewannotation.annotatedLayerFeature
@@ -238,7 +240,14 @@ fun MapScreen(
             })
       }) { padding ->
         MapboxMap(
-            Modifier.fillMaxSize().padding(padding).testTag("MapScreen"),
+            compass = {
+              // height of setting icon is hardcoded to 56dp so we put the compass down by more than
+              // 56dp.
+              Compass(alignment = Alignment.TopEnd, modifier = Modifier.padding(top = 60.dp))
+            },
+            // disable the scale bar that is anyways under the search bar.
+            scaleBar = { ScaleBarSettings.Builder().setEnabled(false).build() },
+            modifier = Modifier.fillMaxSize().padding(padding).testTag("MapScreen"),
             mapViewportState = mapViewportState,
             style = { MapConfig.DefaultStyle() }) {
               DisposableMapEffect { mapView ->


### PR DESCRIPTION
- fix : #349 
## What
- Removes the scaleBar/Ruler that was behind the search bar but sometimes overflowing
- Moves the compass icon under setting button to reset the rotation
- Display ALL parkings instead of filtered one on the location Picker
# Before 
![image](https://github.com/user-attachments/assets/ca4fd2d1-e08a-4014-b3c6-e034ce9f6b8b)
# After
![image](https://github.com/user-attachments/assets/2bf21ed8-2c36-4b00-84d6-528ba9bb8229)