### PR TITLE
Bugfix 343: Replace XML-based preview cards with Composable overlay

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/map/MapScreenTest.kt
@@ -23,6 +23,7 @@ import com.github.se.cyrcle.di.mocks.MockUserRepository
 import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.model.report.ReportedObjectRepository
 import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserViewModel
@@ -284,5 +285,26 @@ class MapScreenTest {
         .onNodeWithTag("suggestionCardMock City 2")
         .assertIsDisplayed()
         .assertHasClickAction()
+  }
+
+  @Test
+  fun testPreviewCard() {
+    composeTestRule.setContent {
+      PreviewCard(navigationActions = mockNavigation, parkingViewModel = parkingViewModel)
+      parkingViewModel.selectParking(TestInstancesParking.parking1)
+    }
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("PreviewCard").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("PreviewCardTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("PreviewCardRackType").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("PreviewCardProtection").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("PreviewCardCapacity").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("PreviewCardDetailsButton")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    verify(mockNavigation).navigateTo(Screen.PARKING_DETAILS)
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -24,7 +24,6 @@ import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.mapbox.maps.plugin.locationcomponent.createDefault2DPuck
 import com.mapbox.maps.plugin.locationcomponent.location
-import com.mapbox.maps.viewannotation.ViewAnnotationManager
 import com.mapbox.turf.TurfMeasurement
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -323,26 +322,6 @@ class MapViewModel : ViewModel() {
     // draw the polygons via the polygonAnnotationManager
     polygonAnnotationManager?.create(annotations)
   }
-
-  // ================== ViewAnnotationManager ==================
-  // State to manage the preview cards on the map screen
-
-  private val _viewAnnotationManager = MutableStateFlow<ViewAnnotationManager?>(null)
-  val viewAnnotationManager: StateFlow<ViewAnnotationManager?> = _viewAnnotationManager
-  /**
-   * To call once on the creation on the map screen to initialize the ViewAnnotationManager
-   *
-   * @param viewAnnotationManager the ViewAnnotationManager to update
-   */
-  fun updateViewAnnotationManager(viewAnnotationManager: ViewAnnotationManager?) {
-    _viewAnnotationManager.value = viewAnnotationManager
-  }
-
-  /** Remove the preview card from the map screen */
-  fun removePreviewCard() {
-    _viewAnnotationManager.value?.removeAllViewAnnotations()
-  }
-  // ===============  End Of  ViewAnnotationManager ==================
 
   /**
    * Enum class to represent the state of the location picker, This state is used to determine which

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPicker.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPicker.kt
@@ -17,7 +17,6 @@ import com.github.se.cyrcle.model.parking.Location
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.ui.addParking.location.overlay.Crosshair
 import com.github.se.cyrcle.ui.addParking.location.overlay.RectangleSelection
-import com.github.se.cyrcle.ui.map.LAYER_ID_RECT
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
@@ -75,8 +74,7 @@ fun LocationPicker(
             rectangleAnnotationManager =
                 mapView.value!!
                     .annotations
-                    .createPolygonAnnotationManager(
-                        annotationConfig = AnnotationConfig().copy(layerId = LAYER_ID_RECT))
+                    .createPolygonAnnotationManager(annotationConfig = AnnotationConfig())
 
             // Create point annotation manager to draw parking labels
             pLabelAnnotationManager =

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -397,6 +397,12 @@ fun MapScreen(
                     mapViewModel.updateMapMode(userMapMode.value)
                   }
 
+                  // If the zoom level changes, hide the preview card. This is to avoid the card
+                  // being displayed when the user taps to zoom in/out.
+                  if (zoomState.value != mapView.mapboxMap.cameraState.zoom) {
+                    showPreviewCard = false
+                  }
+
                   // Store the zoom level
                   // This must stay at the end of the listener.
                   zoomState.value = mapView.mapboxMap.cameraState.zoom

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -770,7 +770,8 @@ fun PreviewCard(navigationActions: NavigationActions, parkingViewModel: ParkingV
                     val yOffset = -placeable.height / 2 - 50.dp.roundToPx()
                     placeable.placeRelative(0, yOffset)
                   }
-                },
+                }
+                .testTag("PreviewCard"),
         colors =
             cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,
@@ -785,7 +786,8 @@ fun PreviewCard(navigationActions: NavigationActions, parkingViewModel: ParkingV
                     text = parking.optName ?: stringResource(R.string.default_parking_name),
                     style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
                     color = MaterialTheme.colorScheme.onSurface,
-                    textAlign = TextAlign.Left)
+                    textAlign = TextAlign.Left,
+                    testTag = "PreviewCardTitle")
                 ScoreStars(
                     score = parking.avgScore,
                     text =
@@ -802,7 +804,8 @@ fun PreviewCard(navigationActions: NavigationActions, parkingViewModel: ParkingV
                     text =
                         stringResource(R.string.map_screen_rack_type, parking.rackType.description),
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Left)
+                    textAlign = TextAlign.Left,
+                    testTag = "PreviewCardRackType")
 
                 // Text for protection
                 Text(
@@ -810,20 +813,23 @@ fun PreviewCard(navigationActions: NavigationActions, parkingViewModel: ParkingV
                         stringResource(
                             R.string.map_screen_protection, parking.protection.description),
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Left)
+                    textAlign = TextAlign.Left,
+                    testTag = "PreviewCardProtection")
 
                 // Text for description
                 Text(
                     text =
                         stringResource(R.string.map_screen_capacity, parking.capacity.description),
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Left)
+                    textAlign = TextAlign.Left,
+                    testTag = "PreviewCardCapacity")
 
                 // Go to parking details button
                 Button(
                     onClick = { navigationActions.navigateTo(Screen.PARKING_DETAILS) },
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                    text = stringResource(R.string.map_screen_details_button))
+                    text = stringResource(R.string.map_screen_details_button),
+                    testTag = "PreviewCardDetailsButton")
               }
         }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -164,6 +164,7 @@ fun MapScreen(
   // Mutable state to store the PointAnnotationManager for parking labels
   var pLabelAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
 
+  // Mutable state to store the visibility of the preview card
   var showPreviewCard by remember { mutableStateOf(false) }
 
   Log.d("MapScreen", "showPreviewCard: $showPreviewCard")
@@ -326,7 +327,15 @@ fun MapScreen(
                 // ======================= MOVE LISTENER =======================
 
                 // ======================= ANNOTATION CLICK LISTENER =======================
-                // Define a common click handler function
+                /**
+                 * Function to handle the click on an annotation. It will center the camera on the
+                 * annotation and enable the preview card with the parking information.
+                 *
+                 * @param annotation The annotation clicked.
+                 * @param mapViewportState The viewport state of the map to center the camera on the
+                 * @param parkingViewModel The ViewModel for managing parking-related data and
+                 *   actions.
+                 */
                 fun handleAnnotationClick(
                     annotation: Any,
                     mapViewportState: MapViewportState,

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -112,7 +112,6 @@ import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
-import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
@@ -124,8 +123,6 @@ const val defaultZoom = 16.0
 const val maxZoom = 18.0
 const val minZoom = 8.0
 const val thresholdDisplayZoom = 13.0
-const val LAYER_ID = "0128"
-const val LAYER_ID_RECT = "0129"
 const val ADVANCED_MODE_ZOOM_THRESHOLD = 15.5
 const val CLUSTER_COLORS = "#1A4988"
 const val MAX_SUGGESTION_DISPLAY_NAME_LENGTH_MAP = 100
@@ -286,12 +283,11 @@ fun MapScreen(
                                                     Pair(
                                                         1,
                                                         android.graphics.Color.parseColor(
-                                                            CLUSTER_COLORS))))),
-                            layerId = LAYER_ID))
+                                                            CLUSTER_COLORS)))))))
                 // Create polygon annotation manager to draw rectangles
                 rectangleAnnotationManager =
                     mapView.annotations.createPolygonAnnotationManager(
-                        annotationConfig = AnnotationConfig().copy(layerId = LAYER_ID_RECT))
+                        annotationConfig = AnnotationConfig())
                 // Create point annotation manager to draw parking labels
                 pLabelAnnotationManager =
                     mapView.annotations.createPointAnnotationManager(AnnotationConfig())
@@ -827,7 +823,7 @@ fun PreviewCard(navigationActions: NavigationActions, parkingViewModel: ParkingV
                 Button(
                     onClick = { navigationActions.navigateTo(Screen.PARKING_DETAILS) },
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                    text = "See details")
+                    text = stringResource(R.string.map_screen_details_button))
               }
         }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -213,6 +213,10 @@ fun MapScreen(
             mapViewModel.drawRectangles(
                 rectangleAnnotationManager, pLabelAnnotationManager, listOfParkings)
         else mapViewModel.drawMarkers(markerAnnotationManager, listOfParkings, resizedBitmap)
+
+        // This is so that when we filter the parkings and the list is updated, the preview card
+        // stays open only if the selected parking is still in the list of parkings
+        showPreviewCard = showPreviewCard && listOfParkings.contains(selectedParking)
       }
 
   // Center the camera on th puck and transition to the follow puck state. Update the user

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -3,11 +3,13 @@ package com.github.se.cyrcle.ui.map
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Log
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -31,6 +33,8 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardDefaults.cardColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -54,16 +58,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
-import com.github.se.cyrcle.databinding.ItemCalloutViewBinding
 import com.github.se.cyrcle.model.address.Address
 import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
@@ -76,7 +82,9 @@ import com.github.se.cyrcle.ui.navigation.Route
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.Black
 import com.github.se.cyrcle.ui.theme.ColorLevel
+import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.IconButton
+import com.github.se.cyrcle.ui.theme.atoms.ScoreStars
 import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.defaultOnColor
@@ -89,7 +97,6 @@ import com.mapbox.android.gestures.MoveGestureDetector
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraBoundsOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.ViewAnnotationAnchor
 import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
@@ -99,7 +106,9 @@ import com.mapbox.maps.plugin.annotation.ClusterOptions
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPolygonAnnotationClickListener
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
@@ -109,10 +118,6 @@ import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
 import com.mapbox.maps.plugin.viewport.data.FollowPuckViewportStateOptions
 import com.mapbox.maps.plugin.viewport.data.OverviewViewportStateOptions
-import com.mapbox.maps.viewannotation.annotatedLayerFeature
-import com.mapbox.maps.viewannotation.annotationAnchor
-import com.mapbox.maps.viewannotation.geometry
-import com.mapbox.maps.viewannotation.viewAnnotationOptions
 import kotlinx.coroutines.runBlocking
 
 const val defaultZoom = 16.0
@@ -135,7 +140,6 @@ fun MapScreen(
     addressViewModel: AddressViewModel,
     zoomState: MutableState<Double> = remember { mutableDoubleStateOf(defaultZoom) }
 ) {
-
   // Collect the list of parkings from the ParkingViewModel as a state
   val listOfParkings by parkingViewModel.filteredRectParkings.collectAsState(emptyList())
 
@@ -162,6 +166,10 @@ fun MapScreen(
 
   // Mutable state to store the PointAnnotationManager for parking labels
   var pLabelAnnotationManager by remember { mutableStateOf<PointAnnotationManager?>(null) }
+
+  var showPreviewCard by remember { mutableStateOf(false) }
+
+  Log.d("MapScreen", "showPreviewCard: $showPreviewCard")
 
   // Collect the selected parking from the ParkingViewModel as a state
   val selectedParking by parkingViewModel.selectedParking.collectAsState()
@@ -194,10 +202,6 @@ fun MapScreen(
   // Chosen location by the user
   val chosenLocation = addressViewModel.address.collectAsState()
 
-  // initialize the Gson object that will deserialize and serialize the parking to bind it to the
-  // marker
-  val gson = Gson()
-  val screenCapacityString = stringResource(R.string.map_screen_capacity)
   val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.dot)
   val resizedBitmap = Bitmap.createScaledBitmap(bitmap, 80, 80, false)
 
@@ -293,18 +297,14 @@ fun MapScreen(
                     mapView.annotations.createPointAnnotationManager(AnnotationConfig())
                 // ======================= ANNOTATIONS =======================
 
-                val viewAnnotationManager = mapView.viewAnnotationManager
-                // upload the view annotation manager to the view model
-                mapViewModel.updateViewAnnotationManager(viewAnnotationManager)
                 // ======================= MOVE LISTENER =======================
                 // Add a move listener to the map to deactivate tracking mode when the user moves
-                // the
-                // map
+                // the map
                 val moveListener =
                     object : OnMoveListener {
                       override fun onMoveBegin(detector: MoveGestureDetector) {
                         // Remove any preview card displayed
-                        mapViewModel.removePreviewCard()
+                        showPreviewCard = false
 
                         // remove focus on the Search Bar
                         focusManager.clearFocus()
@@ -329,89 +329,46 @@ fun MapScreen(
                 mapView.gestures.addOnMoveListener(moveListener)
                 // ======================= MOVE LISTENER =======================
 
-                // ======================= MARKERS CLICK =======================
+                // ======================= ANNOTATION CLICK LISTENER =======================
+                // Define a common click handler function
+                fun handleAnnotationClick(
+                    annotation: Any,
+                    mapViewportState: MapViewportState,
+                    parkingViewModel: ParkingViewModel
+                ) {
+                  val parkingData =
+                      when (annotation) {
+                        is PointAnnotation -> annotation.getData()?.asJsonObject
+                        is PolygonAnnotation -> annotation.getData()?.asJsonObject
+                        else -> null
+                      }
+
+                  // If the data is not null, deserialize it to a Parking object, select it in the
+                  // ViewModel to show the preview card and center the camera on it
+                  parkingData?.let {
+                    val parking = Gson().fromJson(it, Parking::class.java)
+
+                    parkingViewModel.selectParking(parking)
+                    showPreviewCard = true
+
+                    mapViewportState.setCameraOptions { center(parking.location.center) }
+                  }
+                }
+
+                // Use the common handler for markers
                 markerAnnotationManager?.addClickListener(
                     OnPointAnnotationClickListener { pointAnnotation ->
-                      mapViewModel.removePreviewCard()
-                      // get the data from the PointAnnotation and deserialize it
-                      val parkingData = pointAnnotation.getData()?.asJsonObject
-                      val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
-                      // move the camera to the selected parking
-                      mapViewportState.setCameraOptions {
-                        center(parkingDeserialized.location.center)
-                      }
-
-                      // Add the new view annotation
-                      val viewAnnotation =
-                          viewAnnotationManager.addViewAnnotation(
-                              resId = R.layout.item_callout_view,
-                              options =
-                                  viewAnnotationOptions {
-                                    annotatedLayerFeature(LAYER_ID) {
-                                      featureId(pointAnnotation.id)
-                                      geometry(pointAnnotation.geometry)
-                                      annotationAnchor {
-                                        anchor(ViewAnnotationAnchor.BOTTOM)
-                                        offsetY(
-                                            (pointAnnotation.iconImageBitmap?.height!!.toDouble()))
-                                      }
-                                    }
-                                  })
-
-                      // Set the text and the button of the view annotation
-                      ItemCalloutViewBinding.bind(viewAnnotation).apply {
-                        textNativeView.text =
-                            screenCapacityString.format(parkingDeserialized.capacity.description)
-                        selectButton.setOnClickListener {
-                          parkingViewModel.selectParking(parkingDeserialized)
-                          navigationActions.navigateTo(Screen.PARKING_DETAILS)
-                        }
-                      }
+                      handleAnnotationClick(pointAnnotation, mapViewportState, parkingViewModel)
                       true
                     })
-                // ======================= MARKERS CLICK =======================
 
-                // ======================= RECTANGLES CLICK =======================
+                // Use the common handler for rectangles
                 rectangleAnnotationManager?.addClickListener(
-                    OnPolygonAnnotationClickListener {
-                      // Remove any preview card displayed
-                      mapViewModel.removePreviewCard()
-                      // get the data from the PointAnnotation and deserialize it
-                      val parkingData = it.getData()?.asJsonObject
-                      val parkingDeserialized = gson.fromJson(parkingData, Parking::class.java)
-                      // move the camera to the selected parking
-                      mapViewportState.setCameraOptions {
-                        center(parkingDeserialized.location.center)
-                      }
-
-                      // Add the new view annotation
-                      val viewAnnotation =
-                          viewAnnotationManager.addViewAnnotation(
-                              resId = R.layout.item_callout_view,
-                              options =
-                                  viewAnnotationOptions {
-                                    annotatedLayerFeature(LAYER_ID_RECT) {
-                                      featureId(it.id)
-                                      geometry(it.geometry)
-                                      annotationAnchor {
-                                        anchor(ViewAnnotationAnchor.BOTTOM)
-                                        offsetY(0.0)
-                                      }
-                                    }
-                                  })
-
-                      // Set the text and the button of the view annotation
-                      ItemCalloutViewBinding.bind(viewAnnotation).apply {
-                        textNativeView.text =
-                            screenCapacityString.format(parkingDeserialized.capacity.description)
-                        selectButton.setOnClickListener {
-                          parkingViewModel.selectParking(parkingDeserialized)
-                          navigationActions.navigateTo(Screen.PARKING_DETAILS)
-                        }
-                      }
+                    OnPolygonAnnotationClickListener { polygonAnnotation ->
+                      handleAnnotationClick(polygonAnnotation, mapViewportState, parkingViewModel)
                       true
                     })
-                // ======================= RECTANGLES CLICK =======================
+                // ======================= ANNOTATION CLICK LISTENER =======================
 
                 // =======================  CAMERA  LISTENER  =======================
                 mapView.mapboxMap.subscribeCameraChanged {
@@ -429,13 +386,13 @@ fun MapScreen(
                       zoomState.value >= ADVANCED_MODE_ZOOM_THRESHOLD) {
                     mapViewModel.updateMapMode(MapViewModel.MapMode.MARKERS)
                   }
-                  // On zoomin in past the threshold, switch to the user's selected mode
+                  // On zoom-in in past the threshold, switch to the user's selected mode
                   if (mapView.mapboxMap.cameraState.zoom >= ADVANCED_MODE_ZOOM_THRESHOLD &&
                       zoomState.value < ADVANCED_MODE_ZOOM_THRESHOLD) {
                     mapViewModel.updateMapMode(userMapMode.value)
                   }
 
-                  // store the zoom level
+                  // Store the zoom level
                   // This must stay at the end of the listener.
                   zoomState.value = mapView.mapboxMap.cameraState.zoom
                 }
@@ -445,8 +402,7 @@ fun MapScreen(
                   pLabelAnnotationManager?.deleteAll()
                   rectangleAnnotationManager?.deleteAll()
                   markerAnnotationManager?.deleteAll()
-                  mapViewModel.removePreviewCard()
-                  mapViewModel.updateViewAnnotationManager(null)
+                  showPreviewCard = false
                   mapViewModel.updateCameraPosition(mapViewportState.cameraState!!)
                 }
               }
@@ -454,6 +410,9 @@ fun MapScreen(
 
         // ======================= OVERLAY =======================
         Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+          if (showPreviewCard) {
+            PreviewCard(navigationActions, parkingViewModel)
+          }
           // Center button if location is enabled
           if (locationEnabled) {
             IconButton(
@@ -465,7 +424,7 @@ fun MapScreen(
                         .scale(1.2f)
                         .testTag("recenterButton"),
                 onClick = {
-                  mapViewModel.removePreviewCard()
+                  showPreviewCard = false
                   mapViewModel.updateTrackingMode(true)
                   mapViewportState.transitionToFollowPuckState(
                       FollowPuckViewportStateOptions.Builder()
@@ -796,4 +755,80 @@ fun FilterDialog(
       tonalElevation = 8.dp,
       modifier = Modifier.testTag("FilterMenu"),
       shape = RoundedCornerShape(24.dp))
+}
+
+@Composable
+fun PreviewCard(navigationActions: NavigationActions, parkingViewModel: ParkingViewModel) {
+  Box(modifier = Modifier.fillMaxSize()) {
+    // Get the selected parking from the ViewModel
+    val parking = parkingViewModel.selectedParking.collectAsState().value ?: return
+    // Card displaying the parking overview information
+    Card(
+        modifier =
+            Modifier.width(250.dp)
+                .align(Alignment.Center)
+                // Note: The .layout modifier was generated by a LLM
+                .layout { measurable, constraints ->
+                  val placeable = measurable.measure(constraints)
+                  layout(placeable.width, placeable.height) {
+                    val yOffset = -placeable.height / 2 - 50.dp.roundToPx()
+                    placeable.placeRelative(0, yOffset)
+                  }
+                },
+        colors =
+            cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(4.dp),
+        border = BorderStroke(2.dp, MaterialTheme.colorScheme.primary)) {
+          Column(
+              modifier = Modifier.fillMaxWidth().padding(16.dp),
+              verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = parking.optName ?: stringResource(R.string.default_parking_name),
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Left)
+                ScoreStars(
+                    score = parking.avgScore,
+                    text =
+                        pluralStringResource(R.plurals.reviews_count, count = parking.nbReviews)
+                            .format(parking.nbReviews),
+                    scale = 0.6f)
+                HorizontalDivider(
+                    thickness = 1.dp,
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
+                Spacer(modifier = Modifier.height(8.dp))
+                // Text for rack type
+                Text(
+                    text =
+                        stringResource(R.string.map_screen_rack_type, parking.rackType.description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Left)
+
+                // Text for protection
+                Text(
+                    text =
+                        stringResource(
+                            R.string.map_screen_protection, parking.protection.description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Left)
+
+                // Text for description
+                Text(
+                    text =
+                        stringResource(R.string.map_screen_capacity, parking.capacity.description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Left)
+
+                // Go to parking details button
+                Button(
+                    onClick = { navigationActions.navigateTo(Screen.PARKING_DETAILS) },
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    text = "See details")
+              }
+        }
+  }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="map_screen_settings_to_zone">Offline Map</string>
     <string name="settings">Settings</string>
     <string name="search_bar_placeholder">Search for a location</string>
+    <string name="map_screen_details_button">See Details</string>
 
     <!-- Profile Commons -->
     <string name="profile_account_already_exists">Your account is already linked, please try with another email</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,9 @@
     <string name="zoom_out">Zoom Out</string>
 
     <!-- Map Screen -->
-    <string name="map_screen_capacity">Capacity is %s</string>
+    <string name="map_screen_capacity">Capacity: %s</string>
+    <string name="map_screen_rack_type">Rack Type: %s</string>
+    <string name="map_screen_protection">Protection: %s</string>
     <string name="map_screen_mode_switch_label">Advanced Mode</string>
     <string name="map_screen_settings_to_zone">Offline Map</string>
     <string name="settings">Settings</string>


### PR DESCRIPTION
This PR addresses an intermittent issue where preview cards, previously implemented as XML resources, were not consistently displayed when the markers were clicked. This solution replaces the XML-based approach with a Composable overlay, improving reliability and maintainability.

### Changes

1. **Removed ViewAnnotationManager in the MapViewModel:**
   - Eliminated `ViewAnnotationManager` and related code.
   - Removed calls to `mapViewModel.updateViewAnnotationManager()` and `mapViewModel.removePreviewCard()`.

2. **Introduced Composable PreviewCard:**
   - Created a new `PreviewCard` Composable function to display parking information.
   - The card is positioned using a custom layout modifier
   - Introduced `showPreviewCard` state to control the visibility of the preview card.
   - Updated click listeners to set `showPreviewCard = true` when a parking is selected.

3. **Refactored Click Handlers:**
   - Created a common `handleAnnotationClick` function for both point and polygon annotations.
   - This function updates the selected parking, shows the preview card, and centers the map.
   
### Benefits

- **Improved Reliability:** Eliminates issues related to XML-based view annotations not displaying correctly.
- **Enhanced Information:** Users now see more details about each parking spot in the preview.
- **Modification potential:** Having a composable instead of a string resource makes it much easier to customize the card

### New Preview Card's UI
<img width="250" alt="image" src="https://github.com/user-attachments/assets/f6c41149-118a-422d-8c05-bfd5b4ad69d8">

### Testing and coverage
As you all know, it is not possible to interact with the map in the tests to select a parking. This makes it impossible to test the interaction with the markers and ensure the correct dispaly of the card. However, given that the card is now a composable, it was possible to test it in isolation by setting it as content of the compose test rule.
![image](https://github.com/user-attachments/assets/9626f116-dc72-4889-b455-468d9fcf4176)

-- -
- Closes #343 