### PR TITLE
Improve serializers when dealing with legacy

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/io/serializer/ParkingAdapter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/io/serializer/ParkingAdapter.kt
@@ -123,15 +123,13 @@ class ParkingAdapter : JsonSerializer<Parking>, JsonDeserializer<Parking> {
    */
   fun deserializeParking(map: Map<String, Any>): Parking {
     val json = gson.toJson(map)
-    val tempParking = gson.fromJson(json, Parking::class.java)
-    // Older versions of parking don't have the tile field
-    return if (tempParking.tile == null)
-        tempParking.copy(
-            tile = TileUtils.getTileFromPoint(tempParking.location.center),
-            uid = tempParking.uid ?: "", // Default to empty string if null
-            owner = tempParking.owner ?: "Unknown Owner", // Replace with your default owner value
-            reportingUsers = tempParking.reportingUsers ?: emptyList()) // Default to empty list)
-    else tempParking
+    val parking = gson.fromJson(json, Parking::class.java)
+
+    // FIXME: update the default values if the Firestore parking object is missing some fields
+    return parking.copy(
+        tile = parking.tile ?: TileUtils.getTileFromPoint(parking.location.center),
+        owner = parking.owner ?: "Unknown Owner", // Replace with your default owner value
+        reportingUsers = parking.reportingUsers ?: emptyList()) // Default to empty list
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/io/serializer/StringListAdapter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/io/serializer/StringListAdapter.kt
@@ -19,8 +19,8 @@ class StringListAdapter {
    * @return The serialized Json object.
    */
   @TypeConverter
-  fun serializeStringList(strList: List<String>): String {
-    return gson.toJson(strList)
+  fun serializeStringList(strList: List<String>?): String {
+    return if (strList == null) "" else gson.toJson(strList)
   }
 
   /**
@@ -31,6 +31,6 @@ class StringListAdapter {
    */
   @TypeConverter
   fun deserializeStringList(data: String): List<String> {
-    return gson.fromJson(data, stringListType)
+    return if (data.isBlank()) emptyList() else gson.fromJson(data, stringListType)
   }
 }


### PR DESCRIPTION
## What is this PR?

This PR aims to reduce bugs caused by legacy parkings that lack certain attributes in Firestore (the gson deserializer sets it to `null` and that causes `NullPointerExceptions`).

### How?
By adding checks to the newer attributes when deserializing parkings.

### Code coverage:
NO NEED MOUHAHAAHAHAHAH