### PR TITLE
Add Tab Layout for User Profile Screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -13,11 +13,9 @@ import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
-import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.swipeLeft
-import androidx.compose.ui.test.swipeUp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.MockAuthenticationRepository
 import com.github.se.cyrcle.di.mocks.MockImageRepository
@@ -244,7 +242,12 @@ class ViewProfileScreenTest {
   fun testFavoriteParkingsDisplay() {
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("FavoriteParkingsTitle").assertIsDisplayed()
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").onChildren().assertCountEquals(3)
     composeTestRule
@@ -260,6 +263,13 @@ class ViewProfileScreenTest {
 
   @Test
   fun testStarIconClickDisplaysConfirmationDialog() {
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+
     composeTestRule.waitForIdle()
 
     composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
@@ -274,6 +284,12 @@ class ViewProfileScreenTest {
   @Test
   fun testConfirmRemoveFavoriteParking() {
     composeTestRule.waitForIdle()
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     // Click the star icon to show the confirmation dialog
     composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
@@ -290,6 +306,12 @@ class ViewProfileScreenTest {
   @Test
   fun testCancelRemoveFavoriteParking() {
     composeTestRule.waitForIdle()
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     // Click the star icon to show the confirmation dialog
     composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
@@ -306,6 +328,12 @@ class ViewProfileScreenTest {
   @Test
   fun testRemoveAllFavoriteParkings() {
     composeTestRule.waitForIdle()
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     // Remove the first parking
     composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
@@ -330,6 +358,12 @@ class ViewProfileScreenTest {
   @Test
   fun testRemoveFavoriteParkingsAndCheckIndexes() {
     composeTestRule.waitForIdle()
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     // Remove the middle parking
     composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
@@ -362,6 +396,13 @@ class ViewProfileScreenTest {
   @Test
   fun testAddParkingAndScrollFavorites() {
     composeTestRule.waitForIdle()
+
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabFavoriteParkings")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     val parking4 =
         Parking(
@@ -433,10 +474,12 @@ class ViewProfileScreenTest {
   fun whenNoReviews_showsEmptyMessage() {
     composeTestRule.waitForIdle()
 
-    // Scroll to the reviews section using swipe
-    composeTestRule.onNodeWithTag("ProfileContentSections").performTouchInput { swipeUp() }
-
-    composeTestRule.onNodeWithTag("UserReviewsTitle").assertIsDisplayed()
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabMyReviews")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
 
     composeTestRule
         .onNodeWithTag("NoReviewsMessage")
@@ -446,6 +489,13 @@ class ViewProfileScreenTest {
 
   @Test
   fun whenUserHasReviews_showsReviewsList() {
+    // We display the parking tabs
+    composeTestRule
+        .onNodeWithTag("TabMyReviews")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+
     // Add test parkings to mock repository
     mockParkingRepository.addParking(TestInstancesParking.parking1, {}, {}) // For review5
     mockParkingRepository.addParking(TestInstancesParking.parking2, {}, {}) // For review1
@@ -459,10 +509,6 @@ class ViewProfileScreenTest {
 
     composeTestRule.waitForIdle()
 
-    repeat(3) {
-      composeTestRule.onNodeWithTag("ProfileContentSections").performTouchInput { swipeUp() }
-    }
-
     // Verify first review content (review1)
     composeTestRule.onNodeWithTag("ParkingName_1").assertTextEquals("Rude épais")
     composeTestRule.onNodeWithTag("RatingText_1").assertTextEquals("You rated this parking: 5.0 ⭐")
@@ -472,7 +518,7 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithTag("DislikesCount_1").assertIsDisplayed()
 
     // Scroll horizontally to see the second review
-    repeat(3) { composeTestRule.onNodeWithTag("UserReviewsList").performTouchInput { swipeLeft() } }
+    composeTestRule.onNodeWithTag("ReviewCard_5").performScrollTo()
 
     // Verify second review content (review5)
     composeTestRule.onNodeWithTag("ParkingName_5").assertTextEquals("Rue de la paix")

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -366,7 +366,11 @@ class ViewProfileScreenTest {
         .performClick()
 
     // Remove the middle parking
-    composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
+    composeTestRule
+        .onNodeWithTag("ParkingItem_1", useUnmergedTree = true)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag("FavoriteToggle_1").assertIsDisplayed().performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
@@ -491,26 +495,24 @@ class ViewProfileScreenTest {
   fun whenUserHasReviews_showsReviewsList() {
     myReviewsTestHelper()
     composeTestRule.waitForIdle()
-    composeTestRule
-        .onNodeWithTag("UserReviewsList")
-        .assertIsDisplayed()
-        .onChildren()
-        .assertCountEquals(2)
+    composeTestRule.onNodeWithTag("UserReviewsList").assertIsDisplayed()
 
-    // Make sure he sees the two reviews. We first scroll to them
-    composeTestRule.onNodeWithTag("ReviewCard0").performScrollTo().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("ReviewCard0", useUnmergedTree = true)
+        .performScrollTo()
+        .assertIsDisplayed()
 
     composeTestRule
         .onNodeWithTag("ReviewTitle0", useUnmergedTree = true)
         .assertIsDisplayed()
         .assertTextEquals(TestInstancesParking.parking2.optName!!)
 
-    composeTestRule.onNodeWithTag("ReviewCard1").performScrollTo().assertIsDisplayed()
+    // Ensure the card is clickable and it takes us the all reviews screen
+    composeTestRule.onNodeWithTag("ReviewCard0").assertHasClickAction().performClick()
+    composeTestRule.waitForIdle()
 
-    composeTestRule
-        .onNodeWithTag("ReviewTitle1", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .assertTextEquals(TestInstancesParking.parking1.optName!!)
+    verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)
+    assert(parkingViewModel.selectedParking.value == TestInstancesParking.parking2)
   }
 
   /**

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -489,6 +488,23 @@ class ViewProfileScreenTest {
 
   @Test
   fun whenUserHasReviews_showsReviewsList() {
+    myReviewsTestHelper()
+    composeTestRule.waitForIdle()
+    composeTestRule
+        .onNodeWithTag("UserReviewsList")
+        .assertIsDisplayed()
+        .onChildren()
+        .assertCountEquals(2)
+  }
+
+  /**
+   * Helper function to set up the test environment for the "My Reviews" tab.
+   * - Select the "My Reviews" tab
+   * - Add test parkings to the mock repository
+   * - Add user1's reviews from TestInstancesReview
+   * - Trigger review fetch for user1
+   */
+  private fun myReviewsTestHelper() {
     // We display the parking tabs
     composeTestRule
         .onNodeWithTag("TabMyReviews")
@@ -506,29 +522,5 @@ class ViewProfileScreenTest {
 
     // Trigger review fetch for user1
     reviewViewModel.getReviewsByOwnerId("user1")
-
-    composeTestRule.waitForIdle()
-
-    // Verify first review content (review1)
-    composeTestRule.onNodeWithTag("ParkingName_1").assertTextEquals("Rude épais")
-    composeTestRule.onNodeWithTag("RatingText_1").assertTextEquals("You rated this parking: 5.0 ⭐")
-    composeTestRule.onNodeWithTag("YouSaidText_1").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("ReviewText_1").assertTextEquals("\"Great parking!\"")
-    composeTestRule.onNodeWithTag("LikesCount_1").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("DislikesCount_1").assertIsDisplayed()
-
-    // Scroll horizontally to see the second review
-    composeTestRule.onNodeWithTag("ReviewCard_5").performScrollTo()
-
-    // Verify second review content (review5)
-    composeTestRule.onNodeWithTag("ParkingName_5").assertTextEquals("Rue de la paix")
-    composeTestRule.onNodeWithTag("RatingText_5").assertTextEquals("You rated this parking: 5.0 ⭐")
-    composeTestRule.onNodeWithTag("YouSaidText_5").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("ReviewText_5")
-        .assertTextEquals(
-            "\"You know what's crazy is that that low taper fade like meme it is...\"")
-    composeTestRule.onNodeWithTag("LikesCount_5").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("DislikesCount_5").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -495,6 +496,21 @@ class ViewProfileScreenTest {
         .assertIsDisplayed()
         .onChildren()
         .assertCountEquals(2)
+
+    // Make sure he sees the two reviews. We first scroll to them
+    composeTestRule.onNodeWithTag("ReviewCard0").performScrollTo().assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag("ReviewTitle0", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextEquals(TestInstancesParking.parking2.optName!!)
+
+    composeTestRule.onNodeWithTag("ReviewCard1").performScrollTo().assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag("ReviewTitle1", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextEquals(TestInstancesParking.parking1.optName!!)
   }
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
@@ -26,8 +26,8 @@ class ReviewViewModel(
   private val _parkingReviews = MutableStateFlow<List<Review>>(emptyList())
   val parkingReviews: StateFlow<List<Review>> = _parkingReviews
 
-  private val _userReviews = MutableStateFlow<List<Review?>>(emptyList())
-  val userReviews: StateFlow<List<Review?>> = _userReviews
+  private val _userReviews = MutableStateFlow<List<Review>>(emptyList())
+  val userReviews: StateFlow<List<Review>> = _userReviews
 
   /** Selected parking has already been reported by current user */
   private val _hasAlreadyReported = MutableStateFlow<Boolean>(false)

--- a/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/ReviewViewModel.kt
@@ -81,6 +81,7 @@ class ReviewViewModel(
         {
           _parkingReviews.value =
               _parkingReviews.value.map { if (it.uid == review.uid) review else it }
+          _userReviews.value = _userReviews.value.map { if (it.uid == review.uid) review else it }
         },
         { Log.e("ReviewViewModel", "Error adding review", it) })
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/DisplayProfileComponent.kt
@@ -36,35 +36,38 @@ fun DisplayProfileComponent(user: User?, extras: @Composable () -> Unit) {
   val profilePictureUrl = user.localSession?.profilePictureUrl ?: ""
 
   Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ProfileContent"),
+      modifier = Modifier.fillMaxSize().testTag("ProfileContent"),
       horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            text = firstName,
-            style = MaterialTheme.typography.headlineMedium,
-            testTag = "DisplayFirstName")
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Text(
+                  text = firstName,
+                  style = MaterialTheme.typography.headlineMedium,
+                  testTag = "DisplayFirstName")
 
-        Text(
-            text = lastName,
-            style = MaterialTheme.typography.headlineMedium,
-            testTag = "DisplayLastName")
+              Text(
+                  text = lastName,
+                  style = MaterialTheme.typography.headlineMedium,
+                  testTag = "DisplayLastName")
 
-        Spacer(modifier = Modifier.height(16.dp))
+              Spacer(modifier = Modifier.height(16.dp))
 
-        ProfileImageComponent(
-            url = profilePictureUrl,
-            onClick = {},
-            isEditable = false,
-            modifier = Modifier.testTag("ProfileImage"))
+              ProfileImageComponent(
+                  url = profilePictureUrl,
+                  onClick = {},
+                  isEditable = false,
+                  modifier = Modifier.testTag("ProfileImage"))
 
-        Spacer(modifier = Modifier.height(8.dp))
+              Spacer(modifier = Modifier.height(8.dp))
 
-        Text(
-            text = stringResource(R.string.view_profile_screen_display_username, username),
-            style = MaterialTheme.typography.bodyMedium,
-            testTag = "DisplayUsername")
+              Text(
+                  text = stringResource(R.string.view_profile_screen_display_username, username),
+                  style = MaterialTheme.typography.bodyMedium,
+                  testTag = "DisplayUsername")
 
-        Spacer(modifier = Modifier.height(16.dp))
-
+              Spacer(modifier = Modifier.height(16.dp))
+            }
         extras()
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -198,7 +199,7 @@ private fun TabLayout(
     reviewViewModel: ReviewViewModel,
     navigationActions: NavigationActions
 ) {
-  var selectedTabIndex by remember { mutableIntStateOf(0) }
+  var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
   val tabs = listOf("Favorite Parkings", "My Reviews")
 
   Column(
@@ -348,14 +349,22 @@ private fun UserReviewsSection(
           items(items = userReviews, key = { it.uid }) { curReview ->
             val index = userReviews.indexOf(curReview)
             val isExpanded = true
-            ReviewCard(
-                review = curReview,
-                index = index,
-                isExpanded = isExpanded,
-                onCardClick = {},
-                options = mapOf(),
-                userViewModel = userViewModel,
-                reviewViewModel = reviewViewModel)
+            var parking by remember { mutableStateOf<Parking?>(null) }
+            parkingViewModel.getParkingById(curReview.parking, { parking = it }, {})
+
+            parking?.let {
+              ReviewCard(
+                  review = curReview,
+                  index = index,
+                  isExpanded = isExpanded,
+                  onCardClick = {
+                    parkingViewModel.selectParking(it)
+                    navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                  },
+                  options = mapOf(),
+                  userViewModel = userViewModel,
+                  reviewViewModel = reviewViewModel)
+            }
           }
         }
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -353,8 +353,10 @@ private fun UserReviewsSection(
             parkingViewModel.getParkingById(curReview.parking, { parking = it }, {})
 
             parking?.let {
+              val defaultUsername = stringResource(R.string.undefined_username)
               ReviewCard(
                   review = curReview,
+                  ownerUsername = userState?.public?.username ?: defaultUsername,
                   index = index,
                   isExpanded = isExpanded,
                   onCardClick = {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
@@ -60,6 +59,7 @@ import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.Red
 import com.github.se.cyrcle.ui.theme.atoms.Button
+import com.github.se.cyrcle.ui.theme.atoms.IconButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 
@@ -102,14 +102,14 @@ fun ViewProfileScreen(
         }
       }) { innerPadding ->
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
-          com.github.se.cyrcle.ui.theme.atoms.IconButton(
+          IconButton(
               modifier = Modifier.padding(10.dp).align(Alignment.TopEnd),
               icon = Icons.Filled.Outbox,
               contentDescription = "Sign Out",
               testTag = "SignOutButton",
               onClick = { signOut = true })
 
-          com.github.se.cyrcle.ui.theme.atoms.IconButton(
+          IconButton(
               modifier = Modifier.padding(10.dp).align(Alignment.TopStart),
               icon =
                   Icons.Filled.Diamond, // or Icons.Filled.Paid or Icons.Filled.AttachMoney etc...
@@ -239,10 +239,10 @@ private fun FavoriteParkingsSection(
     Text(
         text = stringResource(R.string.view_profile_screen_no_favorite_parking),
         style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("NoFavoritesMessage"))
+        modifier = Modifier.testTag("NoFavoritesMessage").padding(16.dp))
   } else {
     LazyColumn(
-        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
+        modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("FavoriteParkingList"),
         verticalArrangement = Arrangement.spacedBy(8.dp)) {
           itemsIndexed(favoriteParkings) { index, parking ->
             FavoriteParkingCard(
@@ -283,7 +283,7 @@ private fun FavoriteParkingCard(
               modifier =
                   Modifier.align(Alignment.Center).padding(8.dp).testTag("ParkingItem_$index"))
 
-          IconButton(
+          androidx.compose.material3.IconButton(
               onClick = { showConfirmDialog = true },
               modifier =
                   Modifier.align(Alignment.TopEnd).size(32.dp).testTag("FavoriteToggle_$index")) {
@@ -345,10 +345,10 @@ private fun UserReviewsSection(
     Text(
         text = stringResource(R.string.view_profile_screen_no_reviews_message),
         style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("NoReviewsMessage"))
+        modifier = Modifier.padding(16.dp).testTag("NoReviewsMessage"))
   } else {
     LazyColumn(
-        modifier = Modifier.fillMaxWidth().testTag("UserReviewsList"),
+        modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("UserReviewsList"),
         verticalArrangement = Arrangement.spacedBy(8.dp)) {
           itemsIndexed(userReviews) { _, review ->
             review?.let { ReviewCard(review = it, parkingViewModel = parkingViewModel) }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -200,7 +200,10 @@ private fun TabLayout(
     navigationActions: NavigationActions
 ) {
   var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
-  val tabs = listOf("Favorite Parkings", "My Reviews")
+  val tabs =
+      listOf(
+          stringResource(R.string.view_profile_screen_favorite_parkings),
+          stringResource(R.string.view_profile_screen_my_reviews))
 
   Column(
       modifier = Modifier.fillMaxWidth().padding(top = 56.dp) // Adjust based on button height
@@ -355,10 +358,11 @@ private fun UserReviewsSection(
             parkingViewModel.getParkingById(curReview.parking, { parking = it }, {})
 
             // We only display the review if the parking exists in the database
+            val defaultName = stringResource(R.string.default_parking_name)
             parking?.let {
               ReviewCard(
                   review = curReview,
-                  title = it.optName ?: "",
+                  title = it.optName ?: defaultName,
                   index = index,
                   isExpanded = isExpanded,
                   onCardClick = {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -349,14 +349,16 @@ private fun UserReviewsSection(
           items(items = userReviews, key = { it.uid }) { curReview ->
             val index = userReviews.indexOf(curReview)
             val isExpanded = true
+
+            // We need to get the parking associated with the review to allow clicking on the card
             var parking by remember { mutableStateOf<Parking?>(null) }
             parkingViewModel.getParkingById(curReview.parking, { parking = it }, {})
 
+            // We only display the review if the parking exists in the database
             parking?.let {
-              val defaultUsername = stringResource(R.string.undefined_username)
               ReviewCard(
                   review = curReview,
-                  ownerUsername = userState?.public?.username ?: defaultUsername,
+                  title = it.optName ?: "",
                   index = index,
                   isExpanded = isExpanded,
                   onCardClick = {

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -205,26 +206,22 @@ private fun TabLayout(
           stringResource(R.string.view_profile_screen_favorite_parkings),
           stringResource(R.string.view_profile_screen_my_reviews))
 
-  Column(
-      modifier = Modifier.fillMaxWidth().padding(top = 56.dp) // Adjust based on button height
-      ) {
-        TabRow(selectedTabIndex = selectedTabIndex, modifier = Modifier.testTag("TabRow")) {
-          tabs.forEachIndexed { index, title ->
-            Tab(
-                text = { Text(title) },
-                selected = selectedTabIndex == index,
-                onClick = { selectedTabIndex = index },
-                modifier = Modifier.testTag("Tab${title.replace(" ", "")}"))
-          }
-        }
-
-        when (selectedTabIndex) {
-          0 -> FavoriteParkingsSection(userViewModel, parkingViewModel, navigationActions)
-          1 ->
-              UserReviewsSection(
-                  reviewViewModel, userViewModel, parkingViewModel, navigationActions)
-        }
+  Column(modifier = Modifier.fillMaxWidth().padding(top = 24.dp)) {
+    TabRow(selectedTabIndex = selectedTabIndex, modifier = Modifier.testTag("TabRow")) {
+      tabs.forEachIndexed { index, title ->
+        Tab(
+            text = { Text(title) },
+            selected = selectedTabIndex == index,
+            onClick = { selectedTabIndex = index },
+            modifier = Modifier.testTag("Tab${title.replace(" ", "")}"))
       }
+    }
+
+    when (selectedTabIndex) {
+      0 -> FavoriteParkingsSection(userViewModel, parkingViewModel, navigationActions)
+      1 -> UserReviewsSection(reviewViewModel, userViewModel, parkingViewModel, navigationActions)
+    }
+  }
 }
 
 @Composable
@@ -241,9 +238,9 @@ private fun FavoriteParkingsSection(
         style = MaterialTheme.typography.bodyMedium,
         modifier = Modifier.testTag("NoFavoritesMessage").padding(16.dp))
   } else {
-    LazyColumn(
+    LazyRow(
         modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("FavoriteParkingList"),
-        verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        horizontalArrangement = Arrangement.spacedBy(8.dp)) {
           itemsIndexed(favoriteParkings) { index, parking ->
             FavoriteParkingCard(
                 parking = parking,

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -226,7 +226,7 @@ fun AllReviewsScreen(
                         userReview?.let {
                           ReviewCard(
                               review = it,
-                              ownerUsername = currentUser?.public?.username ?: defaultUsername,
+                              title = currentUser?.public?.username ?: defaultUsername,
                               index = -1,
                               isExpanded = true,
                               onCardClick = {},
@@ -294,7 +294,7 @@ fun AllReviewsScreen(
 
                       ReviewCard(
                           review = curReview,
-                          ownerUsername = "",
+                          title = ownerUsername,
                           index = index,
                           isExpanded = isExpanded,
                           onCardClick = { selectedCardIndex = if (isExpanded) -1 else index },
@@ -322,7 +322,7 @@ fun AllReviewsScreen(
 @Composable
 fun ReviewCard(
     review: Review,
-    ownerUsername: String,
+    title: String,
     index: Int,
     isExpanded: Boolean,
     onCardClick: () -> Unit,
@@ -353,9 +353,9 @@ fun ReviewCard(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically) {
                       androidx.compose.material3.Text(
-                          text = stringResource(R.string.by_text).format(ownerUsername),
+                          text = title,
                           style = MaterialTheme.typography.bodySmall,
-                          modifier = Modifier.weight(1f).testTag("ReviewOwner$index"),
+                          modifier = Modifier.weight(1f).testTag("ReviewTitle$index"),
                           maxLines = 1,
                           overflow = TextOverflow.Ellipsis)
 

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -205,6 +205,7 @@ fun AllReviewsScreen(
                 selectedSortingOption = selectedOption
               })
 
+          val defaultUsername = stringResource(R.string.undefined_username)
           // Scrollable Review Cards
           LazyColumn(
               modifier = Modifier.weight(1f).padding(horizontal = 16.dp).testTag("ReviewList"),
@@ -225,6 +226,7 @@ fun AllReviewsScreen(
                         userReview?.let {
                           ReviewCard(
                               review = it,
+                              ownerUsername = currentUser?.public?.username ?: defaultUsername,
                               index = -1,
                               isExpanded = true,
                               onCardClick = {},
@@ -285,8 +287,14 @@ fun AllReviewsScreen(
                       val index = sortedReviews.indexOf(curReview)
                       val isExpanded = selectedCardIndex == index
                       val signInToReport = stringResource(R.string.sign_in_to_report_review)
+
+                      var ownerUsername by remember { mutableStateOf(defaultUsername) }
+                      userViewModel.getUserById(
+                          curReview.owner, onSuccess = { ownerUsername = it.public.username })
+
                       ReviewCard(
                           review = curReview,
+                          ownerUsername = "",
                           index = index,
                           isExpanded = isExpanded,
                           onCardClick = { selectedCardIndex = if (isExpanded) -1 else index },
@@ -314,6 +322,7 @@ fun AllReviewsScreen(
 @Composable
 fun ReviewCard(
     review: Review,
+    ownerUsername: String,
     index: Int,
     isExpanded: Boolean,
     onCardClick: () -> Unit,
@@ -343,13 +352,8 @@ fun ReviewCard(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically) {
-                      val defaultUsername = stringResource(R.string.undefined_username)
-                      val ownerUsername = remember { mutableStateOf(defaultUsername) }
-                      userViewModel.getUserById(
-                          review.owner, onSuccess = { ownerUsername.value = it.public.username })
-
                       androidx.compose.material3.Text(
-                          text = stringResource(R.string.by_text).format(ownerUsername.value),
+                          text = stringResource(R.string.by_text).format(ownerUsername),
                           style = MaterialTheme.typography.bodySmall,
                           modifier = Modifier.weight(1f).testTag("ReviewOwner$index"),
                           maxLines = 1,

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -422,7 +422,9 @@ fun ReviewCard(
                                   testTag = "DislikeCount$index")
                             }
 
-                            OptionsMenu(options = options, testTag = "MoreOptions$index")
+                            // More options button
+                            if (options.isNotEmpty())
+                                OptionsMenu(options = options, testTag = "MoreOptions$index")
                           }
                     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,12 +175,7 @@
     <string name="view_profile_screen_sign_out_dialog_action_button">Sign Out</string>
     <string name="view_profile_screen_sign_out_dialog_cancel_button">Cancel</string>
 
-    <string name="view_profile_screen_my_reviews_title">My Reviews</string>
     <string name="view_profile_screen_no_reviews_message">You haven\'t written any reviews yet</string>
-    <string name="view_profile_screen_you_rated_parking">You rated this parking: %1$s ⭐</string>
-    <string name="view_profile_screen_you_said">You said:</string>
-    <string name="view_profile_screen_likes_count">👍 %1$d</string>
-    <string name="view_profile_screen_dislikes_count">👎 %1$d</string>
 
     <!-- All Reviews Screen -->
     <string name="all_review_title">All Reviews For %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,7 +161,6 @@
     <string name="view_profile_screen_default_profile_picture">Default Profile Picture</string>
     <string name="view_profile_screen_profile_picture">Profile Picture</string>
     <string name="view_profile_screen_edit_profile_picture">Edit Profile Picture</string>
-    <string name="view_profile_screen_favorite_parking_title">Favorite Parkings</string>
     <string name="view_profile_screen_no_favorite_parking">No favorite parking</string>
     <string name="view_profile_screen_remove_from_favorite">Remove from Favorites</string>
     <string name="view_profile_screen_remove_favorite_dialog_title">Remove favorite</string>
@@ -174,6 +173,8 @@
     <string name="view_profile_screen_sign_out_dialog_message">Are you sure you want to sign out?</string>
     <string name="view_profile_screen_sign_out_dialog_action_button">Sign Out</string>
     <string name="view_profile_screen_sign_out_dialog_cancel_button">Cancel</string>
+    <string name="view_profile_screen_favorite_parkings">Favorite Parkings</string>
+    <string name="view_profile_screen_my_reviews">My Reviews</string>
 
     <string name="view_profile_screen_no_reviews_message">You haven\'t written any reviews yet</string>
 


### PR DESCRIPTION
This PR introduces a new tab layout for the user profile screen, improving the organization and display of favorite parkings and user reviews. The changes enhance the user experience by providing a more structured and navigable interface.


<img width="250" alt="image" src="https://github.com/user-attachments/assets/f8217c51-426f-4cb5-b132-5e2032887d86">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/6ae3c813-547d-437a-b1a0-9ee5888e7743">

### Key Changes:
1. Tab Layout Implementation:
   - Added a new `TabLayout` composable to handle the display of "Favorite Parkings" and "My Reviews" sections.
   - Implemented tab selection logic using `rememberSaveable` to persist the selected tab across recompositions.

2. Favorite Parkings Section:
   - Moved the favorite parkings display into its own tab.
   - Updated the layout to use a vertical `LazyColumn` instead of a horizontal `LazyRow` for better space utilization.

3. User Reviews Section:
   - Replaced the custom review card with the `ReviewCard` component from the All Reviews screen.
   - Implemented navigation to the parking details screen when a review card is clicked.
   
### Future Improvements:
1. Parking Cards Redesign:
   - The cards for each parking will be reworked in the future, using a design similar to (but not identical to) the cards in the ListScreen. This will be done by myself in a subsequent PR

2. Additional Tabs:
   - Plans to add new tabs for:
     a. Images posted by the user (@LouisJamesVasseur)
     b. User's parking contributions (maybe)

### Notes:
- The implementation ensures that only existing parkings are displayed in the reviews section, preventing potential null pointer exceptions in the case of a desynchronisation in the database
- The use of `rememberSaveable` for tab selection ensures a consistent user experience across recompositions.
- Small change was made in the viewmodel to ensure that the state is updated upon update (like/dislikes are updates)

### Design choices
#### Review Navigation
Clicking a review in the user profile now leads to the parking details screen instead of the All Reviews screen. This choice was made because from the parking details, users can navigate to the All Reviews screen, but not vice versa. This ensures users can easily remind themselves of the parking context for their review, which wouldn't be possible if they could only access the All Reviews screen.

#### Not implementing Delete and Modify Options
Immediate options for deleting or modifying reviews have been removed from the user profile screen's review cards. This encourages users to revisit the parking details and review context before making changes, promoting more informed decisions about their reviews.


### Coverage
![image](https://github.com/user-attachments/assets/8184d03f-f981-4f3a-bdcb-7779c4b9a5bd)
-- -
- Closes #374
- Closes #375