### PR TITLE
Feature offline mapbox

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapConfig.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapConfig.kt
@@ -1,10 +1,18 @@
 package com.github.se.cyrcle.ui.map
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import com.github.se.cyrcle.model.map.MapViewModel
+import com.github.se.cyrcle.model.zone.Zone
+import com.mapbox.common.NetworkRestriction
+import com.mapbox.common.TileRegionLoadOptions
+import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
+import com.mapbox.geojson.Polygon
 import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.OfflineManager
+import com.mapbox.maps.TilesetDescriptorOptions
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mapbox.maps.extension.compose.style.MapStyle
@@ -32,5 +40,72 @@ object MapConfig {
   @Composable
   fun DefaultStyle() {
     return MapStyle("mapbox://styles/seanprz/cm27wh9ff00jl01r21jz3hcb1")
+  }
+
+  fun getAllTilesDownloaded() {
+    val tileStore = TileStore.create()
+    // Get a list of tile regions that are currently available.
+    tileStore.getAllTileRegions { expected ->
+      if (expected.isValue) {
+        expected.value?.let { tileRegionList ->
+          Log.d("MapScreen", "Existing tile regions: $tileRegionList")
+        }
+
+        expected.error?.let { tileRegionError ->
+          Log.e("MapScreen", "TileRegionError: $tileRegionError")
+        }
+      }
+    }
+  }
+
+  fun downloadZone(zone: Zone) {
+    val tileStore = TileStore.create()
+
+    val offlineManager = OfflineManager()
+    val tilesetDescriptor =
+        offlineManager.createTilesetDescriptor(
+            TilesetDescriptorOptions.Builder()
+                .styleURI("mapbox://styles/seanprz/cm27wh9ff00jl01r21jz3hcb1")
+                .minZoom(minZoom.toInt().toByte())
+                .maxZoom(maxZoom.toInt().toByte())
+                .build())
+    // create a geometry for lausanne
+    val GEOMETRY =
+        Polygon.fromLngLats(
+            listOf(
+                listOf(
+                    zone.boundingBox.southwest(),
+                    zone.boundingBox.northeast(),
+                )))
+
+    tileStore.loadTileRegion(
+        zone.uid,
+        TileRegionLoadOptions.Builder()
+            .geometry(GEOMETRY)
+            .descriptors(listOf(tilesetDescriptor))
+            .acceptExpired(false)
+            .networkRestriction(NetworkRestriction.NONE)
+            .build(),
+        { progress ->
+          // Handle progress updates
+          Log.d("MapScreen", "Progress: $progress")
+        }) { expected ->
+          if (expected.isValue) {
+            // Tile region download finishes successfully
+            expected.value?.let { Log.d("ZoneSelection", "Tile region downloaded: $it") }
+          }
+          expected.error?.let { Log.e("ZoneSelection", "Tile region download error: $it") }
+        }
+  }
+
+  fun deleteZone(zone: Zone) {
+    val tileStore = TileStore.create()
+    tileStore.removeTileRegion(zone.uid) { expected ->
+      if (expected.isValue) {
+        // Tile region removal finishes successfully
+        Log.d("MapScreen", "Tile region removed")
+      }
+      expected.error?.let { Log.e("MapScreen", "Tile region removal error: $it") }
+    }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -95,6 +95,7 @@ import com.github.se.cyrcle.ui.theme.molecules.BottomNavigationBar
 import com.github.se.cyrcle.ui.theme.molecules.FilterPanel
 import com.google.gson.Gson
 import com.mapbox.android.gestures.MoveGestureDetector
+import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraBoundsOptions
 import com.mapbox.maps.EdgeInsets
@@ -140,7 +141,6 @@ fun MapScreen(
 ) {
   // Collect the list of parkings from the ParkingViewModel as a state
   val listOfParkings by parkingViewModel.filteredRectParkings.collectAsState(emptyList())
-
   // Create a remember state to store the search query of the search bar as a mutable state
   val searchQuery = remember { mutableStateOf("") }
 
@@ -258,7 +258,6 @@ fun MapScreen(
             mapViewportState = mapViewportState,
             style = { MapConfig.DefaultStyle() }) {
               DisposableMapEffect { mapView ->
-
                 // ======================= GLOBAL SETTINGS =======================
                 // Set camera bounds options
                 val cameraBoundsOptions =
@@ -273,6 +272,14 @@ fun MapScreen(
                 // the
                 // location component
                 if (locationEnabled) mapViewModel.initLocationComponent(mapView)
+
+                TileStore.create().clearAmbientCache { expected ->
+                  if (expected.isValue) {
+                    Log.d("MapScreen", "Cache cleared successfully")
+                  } else {
+                    Log.e("MapScreen", "Error clearing cache: ${expected.error}")
+                  }
+                }
                 // ======================= GLOBAL SETTINGS =======================
 
                 // ======================= ANNOTATIONS =======================

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -39,6 +39,7 @@ import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.zone.Zone
+import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.ColorLevel
@@ -132,6 +133,7 @@ fun ZoneCard(parkingViewModel: ParkingViewModel, zone: Zone, zones: MutableState
                   Zone.refreshZone(zone, context)
                   zones.value = Zone.loadZones(context)
                   parkingViewModel.downloadZone(zone, {}, {})
+                    MapConfig.downloadZone(zone)
                   // Call functions to update map tiles and parking data here.
                 })
         Icon(
@@ -142,7 +144,7 @@ fun ZoneCard(parkingViewModel: ParkingViewModel, zone: Zone, zones: MutableState
                   Zone.deleteZone(zone, context)
                   zones.value = Zone.loadZones(context)
                   parkingViewModel.deleteZone(zone, zones.value)
-                  // Call functions here to delete the map tiles and the paraking datas.
+                  MapConfig.deleteZoneFromStorage(zone)
                 })
       }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneSelectionScreen.kt
@@ -113,6 +113,7 @@ fun ZoneSelectionScreen(
           zoneName.value = it
           coroutineScope.launch {
             val zone = Zone.createZone(boundingBox.value!!, it, context)
+              MapConfig.downloadZone(zone)
             parkingViewModel.downloadZone(
                 zone,
                 { navigationActions.goBack() },


### PR DESCRIPTION

## What


This PR ensures the following : 
- The Mapbox tiles are now downloaded when the user adds a new zone
- The Mapbox tiles are deleted when the user deletes a zone
- When Mapbox can't fetch the tiles from the server, it will automatically uses the tiles in the storage. 

## How

**Disclaimer** I mostly followed and copied the documentation from MapBox on how to do this, so if you want to understand whats happening read : https://docs.mapbox.com/android/maps/guides/offline/
#### Mapconfig.downloadZone() & Mapconfig.deleteZone()

This functions are  in MapConfig, rather than MapviewModel,
I felt like it didn't belong in a Viewmodel, since it doesn't have any states or any interactions with the UI.

#### Managing downloaded zones 
These two functions are called when the user adds/refreshes/deletes a new zone, from the zone manager/selection screens.

#### Switching between online/offline tiles
This is done automatically by Mapbox, 

## Why
This is the last PR to make our offline mode functional on the side of the map data.

## Note for reviewers

You can test the feature by downloading a zone and then reloading the app offline and check that the area is visible, downloaded in high quality.

To make the distinction between the cached data and persistent storage you can add this code snippet that deletes the cache (!= the downloaded tiles from the zones)

In the global settings section of the MapScreen : 

```
TileStore.create().clearAmbientCache { expected ->  
  if (expected.isValue) {  
    Log.d("MapScreen", "Cache cleared successfully")  
  } else {  
    Log.e("MapScreen", "Error clearing cache: ${expected.error}")  
  }  
}
```


