### PR TITLE
Enhanced Favorite Parking Cards and Slideable Tab Layout

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -248,14 +248,14 @@ class ViewProfileScreenTest {
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ParkingItem0").assertIsDisplayed()
-
+    composeTestRule.onNodeWithTag("ParkingNote0", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("ParkingName0", useUnmergedTree = true)
         .assertIsDisplayed()
         .assertTextContains("Rue de la paix")
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(1)
-
+    composeTestRule.onNodeWithTag("ParkingNote1", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithTag("ParkingItem1").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("ParkingName1", useUnmergedTree = true)
@@ -264,6 +264,7 @@ class ViewProfileScreenTest {
 
     composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(2)
     composeTestRule.onNodeWithTag("ParkingItem2").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ParkingNote2", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("ParkingName2", useUnmergedTree = true)
         .assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -1,20 +1,17 @@
 package com.github.se.cyrcle.ui.profile
 
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.MockAuthenticationRepository
@@ -249,15 +246,27 @@ class ViewProfileScreenTest {
         .assertHasClickAction()
         .performClick()
 
-    composeTestRule.onNodeWithTag("FavoriteParkingList").onChildren().assertCountEquals(3)
+    composeTestRule.onNodeWithTag("FavoriteParkingList").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ParkingItem0").assertIsDisplayed()
+
     composeTestRule
-        .onNodeWithTag("ParkingItem_0", useUnmergedTree = true)
+        .onNodeWithTag("ParkingName0", useUnmergedTree = true)
+        .assertIsDisplayed()
         .assertTextContains("Rue de la paix")
+
+    composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(1)
+
+    composeTestRule.onNodeWithTag("ParkingItem1").assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag("ParkingItem_1", useUnmergedTree = true)
+        .onNodeWithTag("ParkingName1", useUnmergedTree = true)
+        .assertIsDisplayed()
         .assertTextContains("Rude épais")
+
+    composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(2)
+    composeTestRule.onNodeWithTag("ParkingItem2").assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag("ParkingItem_2", useUnmergedTree = true)
+        .onNodeWithTag("ParkingName2", useUnmergedTree = true)
+        .assertIsDisplayed()
         .assertTextContains("Rue du pet")
   }
 
@@ -272,7 +281,7 @@ class ViewProfileScreenTest {
 
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
 
     composeTestRule.onNodeWithText("Remove favorite").assertIsDisplayed()
@@ -292,7 +301,7 @@ class ViewProfileScreenTest {
         .performClick()
 
     // Click the star icon to show the confirmation dialog
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
 
     // Confirm removal
@@ -314,7 +323,7 @@ class ViewProfileScreenTest {
         .performClick()
 
     // Click the star icon to show the confirmation dialog
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
 
     // Cancel removal
@@ -336,18 +345,18 @@ class ViewProfileScreenTest {
         .performClick()
 
     // Remove the first parking
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
     // Remove the second parking
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
 
     // Remove the third parking
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
@@ -366,11 +375,9 @@ class ViewProfileScreenTest {
         .performClick()
 
     // Remove the middle parking
-    composeTestRule
-        .onNodeWithTag("ParkingItem_1", useUnmergedTree = true)
-        .performScrollTo()
-        .assertIsDisplayed()
-    composeTestRule.onNodeWithTag("FavoriteToggle_1").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(1)
+    composeTestRule.onNodeWithTag("ParkingItem1", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("FavoriteToggle1").assertIsDisplayed().performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
@@ -379,7 +386,7 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithText("Rue du pet").assertIsDisplayed()
 
     // Remove the third parking (which is now second)
-    composeTestRule.onNodeWithTag("FavoriteToggle_1").performClick()
+    composeTestRule.onNodeWithTag("FavoriteToggle1").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Remove").performClick()
     composeTestRule.waitForIdle()
@@ -394,7 +401,7 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithTag("EditButton").performClick()
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("FavoriteToggle_0").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("FavoriteToggle0").assertIsNotDisplayed()
   }
 
   @Test
@@ -428,13 +435,11 @@ class ViewProfileScreenTest {
     userViewModel.addFavoriteParkingToSelectedUser(parking4)
 
     composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithTag("FavoriteToggle_3").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("FavoriteToggle3", useUnmergedTree = true).assertDoesNotExist()
 
     composeTestRule.waitForIdle()
-    composeTestRule
-        .onNodeWithTag("FavoriteParkingList")
-        .performScrollToNode(hasTestTag("FavoriteToggle_3"))
-    composeTestRule.onNodeWithTag("FavoriteToggle_3").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(3)
+    composeTestRule.onNodeWithTag("FavoriteToggle3").assertIsDisplayed()
   }
 
   @Test
@@ -468,7 +473,7 @@ class ViewProfileScreenTest {
   fun testNavigateToParkingDetailsOnClick() {
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithTag("ParkingItem_0", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("ParkingItem0", useUnmergedTree = true).performClick()
     composeTestRule.waitForIdle()
 
     verify(mockNavigationActions).navigateTo(Screen.PARKING_DETAILS)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -13,6 +14,9 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.cyrcle.di.mocks.MockAuthenticationRepository
 import com.github.se.cyrcle.di.mocks.MockImageRepository
@@ -546,5 +550,34 @@ class ViewProfileScreenTest {
 
     // Trigger review fetch for user1
     reviewViewModel.getReviewsByOwnerId("user1")
+  }
+
+  @Test
+  fun testTabLayoutSwipeChangesTab() {
+    // Check initial state
+    composeTestRule.onNodeWithTag("TabFavoriteParkings").assertIsSelected()
+    composeTestRule.onNodeWithTag("FavoriteParkingList").assertIsDisplayed()
+
+    // Swipe left on the content area to change to Reviews tab
+    composeTestRule.onNodeWithTag("FavoriteParkingList").performTouchInput {
+      swipeLeft(startX = this.width * 0.9f, endX = this.width * 0.1f)
+    }
+    composeTestRule.waitForIdle()
+
+    // Check if Reviews tab is selected and content is displayed
+    composeTestRule.onNodeWithTag("TabMyReviews").assertIsSelected()
+  }
+
+  @Test
+  fun testTabLayoutSwipeDoesNotExceedTabCount() {
+    // Try to swipe right when already on the first tab
+    composeTestRule.onNodeWithTag("FavoriteParkingList").performTouchInput {
+      swipeRight(startX = this.width * 0.1f, endX = this.width * 0.9f)
+    }
+    composeTestRule.waitForIdle()
+
+    // Check that we're still on the first tab
+    composeTestRule.onNodeWithTag("TabFavoriteParkings").assertIsSelected()
+    composeTestRule.onNodeWithTag("FavoriteParkingList").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/profile/ViewProfileScreenTest.kt
@@ -440,9 +440,6 @@ class ViewProfileScreenTest {
     userViewModel.addFavoriteParkingToSelectedUser(parking4)
 
     composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithTag("FavoriteToggle3", useUnmergedTree = true).assertDoesNotExist()
-
-    composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag("FavoriteParkingList").performScrollToIndex(3)
     composeTestRule.onNodeWithTag("FavoriteToggle3").assertIsDisplayed()
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -256,18 +256,21 @@ private fun FavoriteParkingsSection(
 ) {
   val favoriteParkings = userViewModel.favoriteParkings.collectAsState().value
 
-  Box(modifier = Modifier.fillMaxSize().testTag("FavoriteParkingList")) {
+  Box(modifier = Modifier.fillMaxSize()) {
     if (favoriteParkings.isEmpty()) {
       Text(
           text = stringResource(R.string.view_profile_screen_no_favorite_parking),
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.testTag("NoFavoritesMessage").padding(16.dp))
     } else {
-      LazyColumn(modifier = Modifier.fillMaxWidth(), contentPadding = PaddingValues(16.dp)) {
-        itemsIndexed(favoriteParkings) { index, parking ->
-          FavoriteParkingCard(navigationActions, parkingViewModel, userViewModel, parking, index)
-        }
-      }
+      LazyColumn(
+          modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
+          contentPadding = PaddingValues(16.dp)) {
+            itemsIndexed(favoriteParkings) { index, parking ->
+              FavoriteParkingCard(
+                  navigationActions, parkingViewModel, userViewModel, parking, index)
+            }
+          }
     }
   }
 }
@@ -406,38 +409,40 @@ private fun UserReviewsSection(
     }
   }
 
-  Box(modifier = Modifier.fillMaxSize().testTag("UserReviewsList")) {
+  Box(modifier = Modifier.fillMaxSize()) {
     if (userReviews.isEmpty()) {
       Text(
           text = stringResource(R.string.view_profile_screen_no_reviews_message),
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.padding(16.dp).testTag("NoReviewsMessage"))
     } else {
-      LazyColumn(modifier = Modifier.fillMaxWidth(), contentPadding = PaddingValues(16.dp)) {
-        items(
-            // Filter out reviews that do not have a corresponding parking (desynced data)
-            items = userReviews.filter { reviewToParkingMap.containsKey(it.uid) },
-            key = { it.uid }) { curReview ->
-              val index = userReviews.indexOf(curReview)
-              val isExpanded = true
+      LazyColumn(
+          modifier = Modifier.fillMaxWidth().testTag("UserReviewsList"),
+          contentPadding = PaddingValues(16.dp)) {
+            items(
+                // Filter out reviews that do not have a corresponding parking (desynced data)
+                items = userReviews.filter { reviewToParkingMap.containsKey(it.uid) },
+                key = { it.uid }) { curReview ->
+                  val index = userReviews.indexOf(curReview)
+                  val isExpanded = true
 
-              // We can assert parking is not null thanks to the filter above
-              val parking = reviewToParkingMap[curReview.uid]!!
+                  // We can assert parking is not null thanks to the filter above
+                  val parking = reviewToParkingMap[curReview.uid]!!
 
-              ReviewCard(
-                  review = curReview,
-                  title = parking.optName ?: stringResource(R.string.default_parking_name),
-                  index = index,
-                  isExpanded = isExpanded,
-                  onCardClick = {
-                    parkingViewModel.selectParking(parking)
-                    navigationActions.navigateTo(Screen.PARKING_DETAILS)
-                  },
-                  options = mapOf(),
-                  userViewModel = userViewModel,
-                  reviewViewModel = reviewViewModel)
-            }
-      }
+                  ReviewCard(
+                      review = curReview,
+                      title = parking.optName ?: stringResource(R.string.default_parking_name),
+                      index = index,
+                      isExpanded = isExpanded,
+                      onCardClick = {
+                        parkingViewModel.selectParking(parking)
+                        navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                      },
+                      options = mapOf(),
+                      userViewModel = userViewModel,
+                      reviewViewModel = reviewViewModel)
+                }
+          }
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -237,7 +237,7 @@ private fun TabLayout(
       }
     }
 
-    HorizontalPager(state = pagerState, modifier = Modifier.fillMaxWidth()) { page ->
+    HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
       when (page) {
         0 -> FavoriteParkingsSection(userViewModel, parkingViewModel, navigationActions)
         1 -> UserReviewsSection(reviewViewModel, userViewModel, parkingViewModel, navigationActions)
@@ -254,19 +254,19 @@ private fun FavoriteParkingsSection(
 ) {
   val favoriteParkings = userViewModel.favoriteParkings.collectAsState().value
 
-  if (favoriteParkings.isEmpty()) {
-    Text(
-        text = stringResource(R.string.view_profile_screen_no_favorite_parking),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("NoFavoritesMessage").padding(16.dp))
-  } else {
-    LazyColumn(
-        modifier = Modifier.fillMaxWidth().testTag("FavoriteParkingList"),
-        contentPadding = PaddingValues(16.dp)) {
-          itemsIndexed(favoriteParkings) { index, parking ->
-            FavoriteParkingCard(navigationActions, parkingViewModel, userViewModel, parking, index)
-          }
+  Box(modifier = Modifier.fillMaxSize().testTag("FavoriteParkingList")) {
+    if (favoriteParkings.isEmpty()) {
+      Text(
+          text = stringResource(R.string.view_profile_screen_no_favorite_parking),
+          style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.testTag("NoFavoritesMessage").padding(16.dp))
+    } else {
+      LazyColumn(modifier = Modifier.fillMaxWidth(), contentPadding = PaddingValues(16.dp)) {
+        itemsIndexed(favoriteParkings) { index, parking ->
+          FavoriteParkingCard(navigationActions, parkingViewModel, userViewModel, parking, index)
         }
+      }
+    }
   }
 }
 
@@ -391,40 +391,40 @@ private fun UserReviewsSection(
     userState?.public?.userId?.let { userId -> reviewViewModel.getReviewsByOwnerId(userId) }
   }
 
-  if (userReviews.isEmpty()) {
-    Text(
-        text = stringResource(R.string.view_profile_screen_no_reviews_message),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.padding(16.dp).testTag("NoReviewsMessage"))
-  } else {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize().testTag("UserReviewsList"),
-        contentPadding = PaddingValues(16.dp)) {
-          items(items = userReviews, key = { it.uid }) { curReview ->
-            val index = userReviews.indexOf(curReview)
-            val isExpanded = true
+  Box(modifier = Modifier.fillMaxSize().testTag("UserReviewsList")) {
+    if (userReviews.isEmpty()) {
+      Text(
+          text = stringResource(R.string.view_profile_screen_no_reviews_message),
+          style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.padding(16.dp).testTag("NoReviewsMessage"))
+    } else {
+      LazyColumn(modifier = Modifier.fillMaxWidth(), contentPadding = PaddingValues(16.dp)) {
+        items(items = userReviews, key = { it.uid }) { curReview ->
+          val index = userReviews.indexOf(curReview)
+          val isExpanded = true
 
-            // We need to get the parking associated with the review to allow clicking on the card
-            var parking by remember { mutableStateOf<Parking?>(null) }
-            parkingViewModel.getParkingById(curReview.parking, { parking = it }, {})
+          // We need to get the parking associated with the review to allow clicking on the card
+          var parking by remember { mutableStateOf<Parking?>(null) }
+          parkingViewModel.getParkingById(curReview.parking, { parking = it }, {})
 
-            // We only display the review if the parking exists in the database
-            val defaultName = stringResource(R.string.default_parking_name)
-            parking?.let {
-              ReviewCard(
-                  review = curReview,
-                  title = it.optName ?: defaultName,
-                  index = index,
-                  isExpanded = isExpanded,
-                  onCardClick = {
-                    parkingViewModel.selectParking(it)
-                    navigationActions.navigateTo(Screen.PARKING_DETAILS)
-                  },
-                  options = mapOf(),
-                  userViewModel = userViewModel,
-                  reviewViewModel = reviewViewModel)
-            }
+          // We only display the review if the parking exists in the database
+          val defaultName = stringResource(R.string.default_parking_name)
+          parking?.let {
+            ReviewCard(
+                review = curReview,
+                title = it.optName ?: defaultName,
+                index = index,
+                isExpanded = isExpanded,
+                onCardClick = {
+                  parkingViewModel.selectParking(it)
+                  navigationActions.navigateTo(Screen.PARKING_DETAILS)
+                },
+                options = mapOf(),
+                userViewModel = userViewModel,
+                reviewViewModel = reviewViewModel)
           }
         }
+      }
+    }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/ViewProfileScreen.kt
@@ -297,21 +297,21 @@ fun FavoriteParkingCard(
                     // Display the personal note if it exists. Otherwise, display a message
                     // indicating that there is no note.
                     val personalNote = userState?.details?.personalNotes?.get(parking.uid)
-                    if (personalNote.isNullOrBlank()) {
-                      Text(
-                          text = stringResource(R.string.view_profile_screen_no_note),
-                          style =
-                              MaterialTheme.typography.bodySmall.copy(
-                                  fontStyle = FontStyle.Italic, fontSize = 12.sp),
-                          testTag = "ParkingNote$index")
-                    } else {
-                      androidx.compose.material3.Text(
-                          text = stringResource(R.string.view_profile_screen_note, personalNote),
-                          style = MaterialTheme.typography.bodyMedium,
-                          maxLines = 2,
-                          overflow = TextOverflow.Ellipsis,
-                          modifier = Modifier.testTag("ParkingNote$index"))
-                    }
+                    Text(
+                        text =
+                            if (personalNote.isNullOrBlank()) {
+                              stringResource(R.string.view_profile_screen_no_note)
+                            } else {
+                              stringResource(R.string.view_profile_screen_note, personalNote)
+                            },
+                        style =
+                            if (personalNote.isNullOrBlank())
+                                MaterialTheme.typography.bodyMedium.copy(
+                                    fontStyle = FontStyle.Italic, fontSize = 12.sp)
+                            else MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.testTag("ParkingNote$index"),
+                        textAlign = TextAlign.Justify)
                   }
 
               Spacer(modifier = Modifier.weight(0.1f).width(8.dp))

--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -208,8 +208,8 @@ fun AllReviewsScreen(
           val defaultUsername = stringResource(R.string.undefined_username)
           // Scrollable Review Cards
           LazyColumn(
-              modifier = Modifier.weight(1f).padding(horizontal = 16.dp).testTag("ReviewList"),
-              contentPadding = PaddingValues(bottom = 16.dp)) {
+              modifier = Modifier.weight(1f).testTag("ReviewList"),
+              contentPadding = PaddingValues(16.dp)) {
                 // Only display "Your Review" section if user is signed in
                 if (userSignedIn) {
                   item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,7 +161,7 @@
     <string name="view_profile_screen_default_profile_picture">Default Profile Picture</string>
     <string name="view_profile_screen_profile_picture">Profile Picture</string>
     <string name="view_profile_screen_edit_profile_picture">Edit Profile Picture</string>
-    <string name="view_profile_screen_no_favorite_parking">No favorite parking</string>
+    <string name="view_profile_screen_no_favorite_parking">You haven\'t added any parking to your favorites yet</string>
     <string name="view_profile_screen_remove_from_favorite">Remove from Favorites</string>
     <string name="view_profile_screen_remove_favorite_dialog_title">Remove favorite</string>
     <string name="view_profile_screen_remove_favorite_dialog_message">Are you sure you want to remove %s from your favorites?</string>
@@ -175,7 +175,8 @@
     <string name="view_profile_screen_sign_out_dialog_cancel_button">Cancel</string>
     <string name="view_profile_screen_favorite_parkings">Favorite Parkings</string>
     <string name="view_profile_screen_my_reviews">My Reviews</string>
-
+    <string name="view_profile_screen_no_note">No personal notes to this parking yet</string>
+    <string name="view_profile_screen_note">Note: %s</string>
     <string name="view_profile_screen_no_reviews_message">You haven\'t written any reviews yet</string>
 
     <!-- All Reviews Screen -->


### PR DESCRIPTION
### Changes
1. **Redesigned Favorite Parking Cards**
   - Cards are now horizontally elongated for better visual appeal and information display.
   - Each card contains:
     - Parking title
     - Personal note (if available)
     - Icon to remove from favorites (retains existing functionality with confirmation dialog)

2. **Slideable Tab Layout**
   - Users can now switch between "Favorite Parkings" and "My Reviews" tabs by swiping horizontally.
   - This enhances the overall user experience and provides a more intuitive navigation method.

First images shows the new parking cards. Second image showcases the sliding feature.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/bc3de06b-ec27-4c3a-a4de-7e8349d96b18">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5f2804b4-0737-40e5-a09b-4e95aee15090">

### Rationale
The redesigned favorite parking cards focus on displaying the most relevant information to users. The personal note should be sufficient for users to recall why they favorited a particular parking. This approach prevents information overload while still providing key details. Adding more textual information will overload the card, but ... (see Future Improvements)

### Future Improvements
**Additional Parking Information**
   - Once we have appropriate icons, we can consider adding more details such as capacity, rack type, and shelter protection.
   - Using icons instead of text will maintain a clean look while providing more information without overwhelming the user.

### Testing
- Updated existing tests to accommodate the new card layout and slideable tabs.
- Added new tests to ensure proper functionality of the slideable tab layout.
