### PR TITLE
Implement ordering of the parkings in List Screen

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -75,8 +75,8 @@ import kotlin.math.roundToInt
 
 const val CARD_HEIGHT = 120
 const val MAX_SWIPE_DISTANCE = 150
-const val maxSuggestionDisplayNameLengthList = 70
-const val NumberOfSuggestionsForMenu = 6
+const val MAX_SUGGESTION_DISPLAY_NAME_LENGTH_LIST = 70
+const val NUMBER_OF_SUGGESTIONS_FOR_MENU = 6
 
 @Composable
 fun SpotListScreen(
@@ -147,16 +147,35 @@ fun SpotListScreen(
                 HorizontalDivider(
                     thickness = 1.dp, color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
               }
+              // The parkings are sorted by distance to the user's location (default being the EPFL)
+              // or by distance to the chosen location if any
               items(
-                  items = filteredParkingSpots.filter { it in pinnedParkings },
+                  items =
+                      filteredParkingSpots
+                          .filter { it in pinnedParkings }
+                          .sortedBy {
+                            TurfMeasurement.distance(
+                                if (myLocation.value) userPosition
+                                else
+                                    Point.fromLngLat(
+                                        chosenLocation.value.longitude.toDouble(),
+                                        chosenLocation.value.latitude.toDouble()),
+                                it.location.center)
+                          },
                   key = { parking -> parking.uid + "pin" }) { parking ->
-                    val distance = TurfMeasurement.distance(userPosition, parking.location.center)
                     SpotCard(
                         navigationActions = navigationActions,
                         parkingViewModel = parkingViewModel,
                         userViewModel = userViewModel,
                         parking = parking,
-                        distance = distance)
+                        distance =
+                            TurfMeasurement.distance(
+                                if (myLocation.value) userPosition
+                                else
+                                    Point.fromLngLat(
+                                        chosenLocation.value.longitude.toDouble(),
+                                        chosenLocation.value.latitude.toDouble()),
+                                parking.location.center))
                   }
               item { Spacer(modifier = Modifier.height(32.dp)) }
             }
@@ -173,19 +192,38 @@ fun SpotListScreen(
             }
 
             // All parking spots
-            items(items = filteredParkingSpots, key = { parking -> parking.uid }) { parking ->
-              val distance = TurfMeasurement.distance(userPosition, parking.location.center)
-              SpotCard(
-                  navigationActions = navigationActions,
-                  parkingViewModel = parkingViewModel,
-                  userViewModel = userViewModel,
-                  parking = parking,
-                  distance = distance)
+            // The parkings are sorted by distance to the user's location (default being the EPFL)
+            // or by distance to the chosen location if any
+            items(
+                items =
+                    filteredParkingSpots.sortedBy {
+                      TurfMeasurement.distance(
+                          if (myLocation.value) userPosition
+                          else
+                              Point.fromLngLat(
+                                  chosenLocation.value.longitude.toDouble(),
+                                  chosenLocation.value.latitude.toDouble()),
+                          it.location.center)
+                    },
+                key = { parking -> parking.uid }) { parking ->
+                  SpotCard(
+                      navigationActions = navigationActions,
+                      parkingViewModel = parkingViewModel,
+                      userViewModel = userViewModel,
+                      parking = parking,
+                      distance =
+                          TurfMeasurement.distance(
+                              if (myLocation.value) userPosition
+                              else
+                                  Point.fromLngLat(
+                                      chosenLocation.value.longitude.toDouble(),
+                                      chosenLocation.value.latitude.toDouble()),
+                              parking.location.center))
 
-              if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
-                parkingViewModel.incrementRadius()
-              }
-            }
+                  if (filteredParkingSpots.indexOf(parking) == filteredParkingSpots.size - 1) {
+                    parkingViewModel.incrementRadius()
+                  }
+                }
           }
         }
       }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -62,8 +62,8 @@ import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.permission.PermissionHandler
-import com.github.se.cyrcle.ui.list.NumberOfSuggestionsForMenu
-import com.github.se.cyrcle.ui.list.maxSuggestionDisplayNameLengthList
+import com.github.se.cyrcle.ui.list.MAX_SUGGESTION_DISPLAY_NAME_LENGTH_LIST
+import com.github.se.cyrcle.ui.list.NUMBER_OF_SUGGESTIONS_FOR_MENU
 import com.github.se.cyrcle.ui.theme.ColorLevel
 import com.github.se.cyrcle.ui.theme.atoms.SmallFloatingActionButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
@@ -438,7 +438,7 @@ fun SearchBarListScreen(
                 listOfSuggestions.value.filter { suggestion ->
                   val displayName =
                       suggestion.suggestionFormatDisplayName(
-                          maxSuggestionDisplayNameLengthList, Address.Mode.LIST)
+                          MAX_SUGGESTION_DISPLAY_NAME_LENGTH_LIST, Address.Mode.LIST)
                   if (displayName in seenNames) {
                     false
                   } else {
@@ -447,12 +447,12 @@ fun SearchBarListScreen(
                   }
                 }
 
-            for (address in uniqueSuggestions.value.take(NumberOfSuggestionsForMenu)) {
+            for (address in uniqueSuggestions.value.take(NUMBER_OF_SUGGESTIONS_FOR_MENU)) {
               DropdownMenuItem(
                   text = {
                     Text(
                         address.suggestionFormatDisplayName(
-                            maxSuggestionDisplayNameLengthList, Address.Mode.LIST),
+                            MAX_SUGGESTION_DISPLAY_NAME_LENGTH_LIST, Address.Mode.LIST),
                         textAlign = TextAlign.Start)
                   },
                   modifier = Modifier.testTag("SuggestionMenuItem${address.city}"),
@@ -464,7 +464,7 @@ fun SearchBarListScreen(
                     isTextFieldVisible.value = false
                     textFieldValue.value =
                         address.suggestionFormatDisplayName(
-                            maxSuggestionDisplayNameLengthList, Address.Mode.LIST)
+                            MAX_SUGGESTION_DISPLAY_NAME_LENGTH_LIST, Address.Mode.LIST)
                     focusManager.clearFocus()
                   })
             }


### PR DESCRIPTION
## Content of the PR

This PR is fixing the bug related to the ordering of the list of parkings in the List Screen. Now, when a location is chosen, the ordering is done with respect to the chosen position. If my location is chosen as a suggestion then it is done with respect to the User position. 

## How ? 

This was done by using `sortBy()` and chosing as a criteria the distance between the parking and the chosen location/ user position. 

Two possibilities : 

- The user didn't look for any specific location. In this case, his location serves as the reference to compute the distance, the default position being the EPFL if the permission was not granted. 
- The user selected a specific location. Then, the chosen location serves as the reference to order the parking. 

## Additional adding

I also corrected the naming of 2 constants since they were not consistent with the rest of the constants. 