### PR TITLE
Fix reviews not sorted by time

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/review/AllReviewsScreen.kt
@@ -177,7 +177,7 @@ fun AllReviewsScreen(
   val sortedReviews =
       remember(reviewsList, selectedSortingOption) {
         when (selectedSortingOption) {
-          ReviewSortingOption.DateTime -> reviewsList.sortedByDescending { it.time.nanoseconds }
+          ReviewSortingOption.DateTime -> reviewsList.sortedByDescending { it.time.seconds }
           ReviewSortingOption.ReviewScore -> reviewsList.sortedByDescending { it.rating }
           ReviewSortingOption.Interactions ->
               reviewsList.sortedByDescending { it.likedBy.size + it.dislikedBy.size }
@@ -452,6 +452,7 @@ fun ReviewCard(
       }
 }
 
+/** Converts a [Timestamp] to a formatted date string. */
 fun Timestamp?.toFormattedDate(): String {
   return if (this != null) {
     val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())


### PR DESCRIPTION
## Fix 

When we took a look at the reviews of a parking, the sorting by time was not working properly.  This PR fixes that. 

## How ? 

We needed to sort by seconds and not nanoseconds.  
