### PR TITLE
Improve Sign-In screen UI

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/authentication/SignInTest.kt
@@ -18,7 +18,6 @@ import com.github.se.cyrcle.model.user.TestInstancesUser
 import com.github.se.cyrcle.model.user.UserRepository
 import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.first
@@ -68,25 +67,11 @@ class SignInTest {
 
     composeTestRule.onNodeWithTag("AppLogo").assertIsDisplayed()
 
-    composeTestRule
-        .onNodeWithTag("LoginTitle")
-        .assertIsDisplayed()
-        .assertTextEquals("Welcome to Cyrcle")
+    composeTestRule.onNodeWithTag("LoginTitle").assertIsDisplayed().assertTextEquals("Welcome to")
 
-    composeTestRule.onNodeWithTag("AuthenticateButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("AuthenticateButton").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("CreateAccountButton").assertIsDisplayed().assertHasClickAction()
-
-    composeTestRule.onNodeWithTag("AnonymousLoginButton").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  fun testCreateProfileButtonGoesToCreateProfileScreen() {
-    composeTestRule.waitForIdle()
-
-    composeTestRule.onNodeWithTag("CreateAccountButton").assertIsDisplayed().performClick()
-
-    verify(navigationActions).navigateTo(Screen.CREATE_PROFILE)
+    composeTestRule.onNodeWithTag("AnonymousLoginButton").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeTestRule
@@ -351,19 +350,8 @@ class MainActivityTest {
 
     fun assertAuthScreen() {
       composeTestRule.onNodeWithTag("LoginScreen").assertIsDisplayed()
-      composeTestRule
-          .onNodeWithTag("LoginTitle")
-          .assertIsDisplayed()
-          .assertTextEquals("Welcome to Cyrcle")
-      composeTestRule
-          .onNodeWithTag("AnonymousLoginButton")
-          .assertIsDisplayed()
-          .assertHasClickAction()
-      composeTestRule
-          .onNodeWithTag("AuthenticateButton")
-          .assertIsDisplayed()
-          .assertHasClickAction()
-          .assertTextContains("Sign in with Google")
+      composeTestRule.onNodeWithTag("LoginTitle").assertIsDisplayed().assertTextEquals("Welcome to")
+      composeTestRule.onNodeWithTag("AnonymousLoginButton").assertIsDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeTestRule
@@ -352,6 +353,11 @@ class MainActivityTest {
       composeTestRule.onNodeWithTag("LoginScreen").assertIsDisplayed()
       composeTestRule.onNodeWithTag("LoginTitle").assertIsDisplayed().assertTextEquals("Welcome to")
       composeTestRule.onNodeWithTag("AnonymousLoginButton").assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("AuthenticateButton")
+          .assertIsDisplayed()
+          .assertHasClickAction()
+          .assertTextContains("Sign in with Google")
     }
 
     @OptIn(ExperimentalTestApi::class)

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
@@ -134,7 +135,9 @@ fun SignInScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
                           }
                     },
                 modifier = Modifier.testTag("AnonymousLoginButton").padding(4.dp),
-                style = TextStyle(textDecoration = TextDecoration.Underline),
+                style =
+                    TextStyle(
+                        textDecoration = TextDecoration.Underline, fontStyle = FontStyle.Italic),
                 onClick = {
                   coroutineScope.launch {
                     clickAnimation(alphaOfGuestButton)
@@ -163,7 +166,9 @@ fun SignInScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
                           }
                     },
                 modifier = Modifier.testTag("OfflineModeButton").padding(4.dp),
-                style = TextStyle(textDecoration = TextDecoration.Underline),
+                style =
+                    TextStyle(
+                        textDecoration = TextDecoration.Underline, fontStyle = FontStyle.Italic),
                 onClick = {
                   coroutineScope.launch {
                     clickAnimation(alphaOfOfflineButton)

--- a/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/authentication/SignInScreen.kt
@@ -1,9 +1,10 @@
 package com.github.se.cyrcle.ui.authentication
 
 import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,11 +13,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,7 +26,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.cyrcle.R
@@ -32,14 +39,14 @@ import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
-import com.github.se.cyrcle.ui.theme.ColorLevel
-import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.GoogleSignInButton
 import com.github.se.cyrcle.ui.theme.atoms.Text
+import kotlinx.coroutines.launch
 
 @Composable
 fun SignInScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
   val context = LocalContext.current
+  val coroutineScope = rememberCoroutineScope()
 
   val failSignInMsg = stringResource(R.string.sign_in_failed_toast)
   val successSignInMsg = stringResource(R.string.sign_in_successful_toast)
@@ -53,26 +60,27 @@ fun SignInScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
+      Spacer(modifier = Modifier.weight(1f))
       // Welcome Text
       Text(
           text = stringResource(R.string.sign_in_welcome),
           style =
               MaterialTheme.typography.headlineLarge.copy(
-                  fontWeight = FontWeight.Bold, fontSize = 57.sp, lineHeight = 64.sp),
+                  fontWeight = FontWeight.SemiBold, fontSize = 45.sp, lineHeight = 64.sp),
           testTag = "LoginTitle")
-      Spacer(modifier = Modifier.height(16.dp))
 
       // App Logo Image
       Image(
           painter = painterResource(id = R.drawable.app_logo_name),
           contentDescription = "App Logo",
           modifier = Modifier.size(250.dp).testTag("AppLogo"))
-
+      // put a spacer that takes all the remaining space
+      Spacer(modifier = Modifier.weight(0.35f))
       // buttons for signing in column container
       Column(
-          modifier = Modifier.fillMaxWidth().padding(16.dp),
+          modifier = Modifier.fillMaxWidth().padding(24.dp),
           horizontalAlignment = Alignment.CenterHorizontally,
-          verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          verticalArrangement = Arrangement.Center) {
             // Authenticate With Google Button
             GoogleSignInButton {
               userViewModel.signIn(
@@ -85,6 +93,7 @@ fun SignInScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
                     when (it) {
                       UserViewModel.SignInFailureReason.ACCOUNT_NOT_FOUND -> {
                         Toast.makeText(context, accountNotFoundToast, Toast.LENGTH_LONG).show()
+                        navigationActions.navigateTo(Screen.CREATE_PROFILE)
                       }
                       UserViewModel.SignInFailureReason.ERROR -> {
                         Toast.makeText(context, failSignInMsg, Toast.LENGTH_LONG).show()
@@ -92,51 +101,78 @@ fun SignInScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
                     }
                   })
             }
-            // Create Account Button
-            Button(
-                text = "Create an account",
-                colorLevel = ColorLevel.SECONDARY,
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .border(BorderStroke(1.dp, Color.LightGray), RoundedCornerShape(50))
-                        .height(48.dp)
-                        .width(250.dp),
-                onClick = { navigationActions.navigateTo(Screen.CREATE_PROFILE) },
-                testTag = "CreateAccountButton")
-
-            // Anonymous Login Button
-            Button(
-                text = stringResource(R.string.sign_in_guest_button),
+            // Seperate main button from other buttons with a spacer
+            Spacer(modifier = Modifier.height(16.dp))
+            val alphaOfGuestButton = remember { Animatable(1f) }
+            val alphaOfOfflineButton = remember { Animatable(1f) }
+            suspend fun clickAnimation(alpha: Animatable<Float, AnimationVector1D>) {
+              alpha.animateTo(
+                  targetValue = 0.1f,
+                  animationSpec =
+                      tween(
+                          durationMillis = 100,
+                      ))
+            }
+            fun resetAlpha(alpha: Animatable<Float, AnimationVector1D>) {
+              coroutineScope.launch {
+                alpha.animateTo(
+                    targetValue = 1f,
+                    animationSpec =
+                        tween(
+                            durationMillis = 100,
+                        ))
+              }
+            }
+            ClickableText(
+                text =
+                    buildAnnotatedString {
+                      withStyle(
+                          style =
+                              SpanStyle(
+                                  color = Color.Black.copy(alpha = alphaOfGuestButton.value))) {
+                            append(stringResource(R.string.sign_in_guest_button))
+                          }
+                    },
+                modifier = Modifier.testTag("AnonymousLoginButton").padding(4.dp),
+                style = TextStyle(textDecoration = TextDecoration.Underline),
                 onClick = {
-                  userViewModel.signInAnonymously(
-                      onComplete = {
-                        userViewModel.setIsOnlineMode(true)
-                        navigationActions.navigateTo(TopLevelDestinations.MAP)
-                      },
-                      onFailure = {
-                        Toast.makeText(context, failSignInMsg, Toast.LENGTH_LONG).show()
-                      })
-                },
-                colorLevel = ColorLevel.TERTIARY,
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .border(BorderStroke(1.dp, Color.LightGray), RoundedCornerShape(50))
-                        .height(48.dp),
-                testTag = "AnonymousLoginButton")
+                  coroutineScope.launch {
+                    clickAnimation(alphaOfGuestButton)
+                    userViewModel.signInAnonymously(
+                        onComplete = {
+                          userViewModel.setIsOnlineMode(true)
+                          navigationActions.navigateTo(TopLevelDestinations.MAP)
+                        },
+                        onFailure = {
+                          Toast.makeText(context, failSignInMsg, Toast.LENGTH_LONG).show()
+                          resetAlpha(alphaOfGuestButton)
+                        })
+                  }
+                })
+            // Seperate between two secondary buttons
+            Spacer(modifier = Modifier.height(8.dp))
             // Offline Mode Button
-            Button(
-                text = stringResource(R.string.sign_in_offline_button),
+            ClickableText(
+                text =
+                    buildAnnotatedString {
+                      withStyle(
+                          style =
+                              SpanStyle(
+                                  color = Color.Black.copy(alpha = alphaOfOfflineButton.value))) {
+                            append(stringResource(R.string.sign_in_offline_button))
+                          }
+                    },
+                modifier = Modifier.testTag("OfflineModeButton").padding(4.dp),
+                style = TextStyle(textDecoration = TextDecoration.Underline),
                 onClick = {
-                  userViewModel.setIsOnlineMode(false)
-                  userViewModel.signOut { navigationActions.navigateTo(TopLevelDestinations.MAP) }
-                },
-                colorLevel = ColorLevel.TERTIARY,
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .border(BorderStroke(1.dp, Color.LightGray), RoundedCornerShape(50))
-                        .height(48.dp),
-                testTag = "OfflineModeButton")
+                  coroutineScope.launch {
+                    clickAnimation(alphaOfOfflineButton)
+                    userViewModel.setIsOnlineMode(false)
+                    navigationActions.navigateTo(TopLevelDestinations.MAP)
+                  }
+                })
           }
+      Spacer(modifier = Modifier.weight(0.25f))
     }
   }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -102,6 +103,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: Use
                     else
                         Toast.makeText(context, incorrectFieldsToastText, Toast.LENGTH_SHORT).show()
                   },
+                  modifier = Modifier.testTag("AuthenticateButton"),
                   text = "Create")
             },
             cancelButton = {})

--- a/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/profile/CreateProfileScreen.kt
@@ -20,7 +20,7 @@ import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.model.user.Wallet
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.TopLevelDestinations
-import com.github.se.cyrcle.ui.theme.atoms.GoogleSignInButton
+import com.github.se.cyrcle.ui.theme.atoms.Button
 import com.github.se.cyrcle.ui.theme.atoms.Text
 import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 
@@ -96,10 +96,13 @@ fun CreateProfileScreen(navigationActions: NavigationActions, userViewModel: Use
                   stringResource(R.string.create_profile_sign_in_explanation),
                   modifier = Modifier.padding(bottom = 5.dp),
                   style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Bold))
-              GoogleSignInButton {
-                if (validInputs) onSignInClick(userAttempt)
-                else Toast.makeText(context, incorrectFieldsToastText, Toast.LENGTH_SHORT).show()
-              }
+              Button(
+                  onClick = {
+                    if (validInputs) onSignInClick(userAttempt)
+                    else
+                        Toast.makeText(context, incorrectFieldsToastText, Toast.LENGTH_SHORT).show()
+                  },
+                  text = "Create")
             },
             cancelButton = {})
       }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="location_picker_top_bar_select_bottom_right">Set the bottom-right corner of the parking, by dragging on the screen</string>
 
     <!-- Sign In -->
-    <string name="sign_in_welcome">Welcome to Cyrcle</string>
+    <string name="sign_in_welcome">Welcome to </string>
     <string name="sign_in_successful_toast">Login successful!</string>
     <string name="sign_in_failed_toast">Login failed!</string>
     <string name="sign_in_guest_button">Continue as Guest</string>


### PR DESCRIPTION

## What 
#### This PR intend to make our sign-In screen looks more professional, mainly by reducing the numbers of buttons.
### Before  vs After
<img width="205" alt="image" src="https://github.com/user-attachments/assets/4fe6bf4f-80f6-4360-87d0-a6452276e8b8">
<img width="200" alt="image" src="https://github.com/user-attachments/assets/45844fbd-add9-41bc-86f3-99f7b3f97eb2">

## How
- Removes create account button instead sign-in with google redirects you if it doesn't find your account
- Transformed the two green buttons into clickable text (with animation on alpha for feedback)
- Moved the buttons down to be closer to the thumb
## Why
Just to make the apps feel less like a student project