### PR TITLE
Bugfix Initialisation of the List Screen with localisation on

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/FilterTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/FilterTest.kt
@@ -22,6 +22,7 @@ import com.github.se.cyrcle.di.mocks.MockPermissionHandler
 import com.github.se.cyrcle.di.mocks.MockReportedObjectRepository
 import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.image.ImageRepository
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
@@ -47,6 +48,7 @@ class FilterTest {
   private lateinit var parkingViewModel: ParkingViewModel
   private lateinit var addressViewModel: AddressViewModel
   private lateinit var permissionHandler: MockPermissionHandler
+  private lateinit var mapViewModel: MapViewModel
 
   @Before
   fun setUp() {
@@ -58,6 +60,7 @@ class FilterTest {
     mockAddressRepository = MockAddressRepository()
 
     addressViewModel = AddressViewModel(mockAddressRepository)
+    mapViewModel = MapViewModel()
     permissionHandler = MockPermissionHandler()
     parkingViewModel =
         ParkingViewModel(
@@ -73,7 +76,12 @@ class FilterTest {
   @Test
   fun testCCTVCheckboxInteraction() {
     composeTestRule.setContent {
-      FilterPanel(parkingViewModel, true, addressViewModel, permissionHandler = permissionHandler)
+      FilterPanel(
+          parkingViewModel,
+          true,
+          addressViewModel,
+          permissionHandler = permissionHandler,
+          mapViewModel = mapViewModel)
     }
 
     // Show filters first
@@ -87,7 +95,12 @@ class FilterTest {
   @Test
   fun testShowFiltersButtonInitiallyDisplaysShowFilters() {
     composeTestRule.setContent {
-      FilterPanel(parkingViewModel, true, addressViewModel, permissionHandler = permissionHandler)
+      FilterPanel(
+          parkingViewModel,
+          true,
+          addressViewModel,
+          permissionHandler = permissionHandler,
+          mapViewModel = mapViewModel)
     }
 
     // Act & Assert
@@ -98,7 +111,12 @@ class FilterTest {
   @OptIn(ExperimentalTestApi::class)
   fun testShowFiltersButtonTogglesFilterSection() {
     composeTestRule.setContent {
-      FilterPanel(parkingViewModel, true, addressViewModel, permissionHandler = permissionHandler)
+      FilterPanel(
+          parkingViewModel,
+          true,
+          addressViewModel,
+          permissionHandler = permissionHandler,
+          mapViewModel = mapViewModel)
     }
 
     // Act: Click to show filters
@@ -125,7 +143,12 @@ class FilterTest {
   fun testProtectionFilters() {
 
     composeTestRule.setContent {
-      FilterPanel(parkingViewModel, true, addressViewModel, permissionHandler = permissionHandler)
+      FilterPanel(
+          parkingViewModel,
+          true,
+          addressViewModel,
+          permissionHandler = permissionHandler,
+          mapViewModel = mapViewModel)
     }
 
     // Act: Click to show filters
@@ -160,7 +183,12 @@ class FilterTest {
   @OptIn(ExperimentalTestApi::class)
   fun testRackTypeFilters() {
     composeTestRule.setContent {
-      FilterPanel(parkingViewModel, true, addressViewModel, permissionHandler = permissionHandler)
+      FilterPanel(
+          parkingViewModel,
+          true,
+          addressViewModel,
+          permissionHandler = permissionHandler,
+          mapViewModel = mapViewModel)
     }
 
     // Act: Click to show filters
@@ -194,7 +222,12 @@ class FilterTest {
   @OptIn(ExperimentalTestApi::class)
   fun testCapacityFilters() {
     composeTestRule.setContent {
-      FilterPanel(parkingViewModel, true, addressViewModel, permissionHandler = permissionHandler)
+      FilterPanel(
+          parkingViewModel,
+          true,
+          addressViewModel,
+          permissionHandler = permissionHandler,
+          mapViewModel = mapViewModel)
     }
 
     // Act: Click to show filters

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -509,7 +509,7 @@ class ParkingViewModel(
     // This coroutine will update the closest parkings when all the tiles have been fetched. Note
     // that we don't need to apply the filter again since we use the filteredRectParkings flow.
     viewModelScope.launch {
-      Log.e("ParkingViewModelCenter", "${_circleCenter.value}")
+      Log.d("ParkingViewModelCenter", "${_circleCenter.value}")
       filteredRectParkings
           .map { parkings ->
             parkings

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -503,7 +503,7 @@ class ParkingViewModel(
    *   the function will update the closest parkings and if the result is empty, it will increment
    *   the radius.
    */
-  fun updateClosestParkings(nbRequestLeft: Int = 0) {
+  private fun updateClosestParkings(nbRequestLeft: Int = 0) {
     if (_circleCenter.value == null || nbRequestLeft != 0) return // avoid updating if not ready
 
     // This coroutine will update the closest parkings when all the tiles have been fetched. Note

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -503,12 +503,13 @@ class ParkingViewModel(
    *   the function will update the closest parkings and if the result is empty, it will increment
    *   the radius.
    */
-  private fun updateClosestParkings(nbRequestLeft: Int = 0) {
+  fun updateClosestParkings(nbRequestLeft: Int = 0) {
     if (_circleCenter.value == null || nbRequestLeft != 0) return // avoid updating if not ready
 
     // This coroutine will update the closest parkings when all the tiles have been fetched. Note
     // that we don't need to apply the filter again since we use the filteredRectParkings flow.
     viewModelScope.launch {
+        Log.e("ParkingViewModelCenter", "${_circleCenter.value}")
       filteredRectParkings
           .map { parkings ->
             parkings

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -509,7 +509,7 @@ class ParkingViewModel(
     // This coroutine will update the closest parkings when all the tiles have been fetched. Note
     // that we don't need to apply the filter again since we use the filteredRectParkings flow.
     viewModelScope.launch {
-        Log.e("ParkingViewModelCenter", "${_circleCenter.value}")
+      Log.e("ParkingViewModelCenter", "${_circleCenter.value}")
       filteredRectParkings
           .map { parkings ->
             parkings

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -92,7 +92,7 @@ fun SpotListScreen(
   // chosen location by the user for the list Screen
   val chosenLocation = parkingViewModel.chosenLocation.collectAsState()
 
-  // value that says wether the user clicked on my Location Suggestion or not
+  // value that says whether the user clicked on my Location Suggestion or not
   val myLocation = parkingViewModel.myLocation.collectAsState()
 
   // location permission from location manager
@@ -118,6 +118,7 @@ fun SpotListScreen(
     // center
     // to user position
     if (locPermission && myLocation.value) {
+        Log.e("SpotListScreen", "User Position: $userPosition")
       parkingViewModel.setCircleCenter(userPosition)
     }
 
@@ -188,7 +189,8 @@ fun SpotListScreen(
             // The parkings are sorted by distance to the user's location (default being the EPFL)
             // or by distance to the chosen location if any
             items(
-                items = filteredParkingSpots.sortedBy { computeDistance(it) },
+                items = filteredParkingSpots.sortedBy {
+                    computeDistance(it) },
                 key = { parking -> parking.uid }) { parking ->
                   SpotCard(
                       navigationActions = navigationActions,

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -112,19 +112,20 @@ fun SpotListScreen(
         parking.location.center)
   }
 
-  LaunchedEffect(userPosition, myLocation, chosenLocation.value) {
+  LaunchedEffect(userPosition, myLocation.value, chosenLocation.value) {
+
+      Log.e("SpotListScreen", "userPosition: $userPosition and chosenLocation: $chosenLocation")
 
     // if suggestion MyLocation is chosen and user has location permission then set the circle
     // center
     // to user position
     if (locPermission && myLocation.value) {
-        Log.e("SpotListScreen", "User Position: $userPosition")
-      parkingViewModel.setCircleCenter(userPosition)
+        parkingViewModel.setCircleCenter(userPosition)
     }
 
     // else if the user has chosen a location or hasn't given his location permission then set the
     // circle center to the chosen location (default position is EPFL)
-    else Log.d("SpotListScreen", parkingViewModel.closestParkings.value.toString())
+    else
     parkingViewModel.setCircleCenter(
         Point.fromLngLat(
             chosenLocation.value.longitude.toDouble(), chosenLocation.value.latitude.toDouble()))

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -1,6 +1,5 @@
 package com.github.se.cyrcle.ui.list
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -113,8 +112,6 @@ fun SpotListScreen(
   }
 
   LaunchedEffect(userPosition, myLocation.value, chosenLocation.value) {
-    Log.e("SpotListScreen", "userPosition: $userPosition and chosenLocation: $chosenLocation")
-
     // if suggestion MyLocation is chosen and user has location permission then set the circle
     // center
     // to user position

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -113,22 +113,22 @@ fun SpotListScreen(
   }
 
   LaunchedEffect(userPosition, myLocation.value, chosenLocation.value) {
-
-      Log.e("SpotListScreen", "userPosition: $userPosition and chosenLocation: $chosenLocation")
+    Log.e("SpotListScreen", "userPosition: $userPosition and chosenLocation: $chosenLocation")
 
     // if suggestion MyLocation is chosen and user has location permission then set the circle
     // center
     // to user position
     if (locPermission && myLocation.value) {
-        parkingViewModel.setCircleCenter(userPosition)
+      parkingViewModel.setCircleCenter(userPosition)
     }
 
     // else if the user has chosen a location or hasn't given his location permission then set the
     // circle center to the chosen location (default position is EPFL)
     else
-    parkingViewModel.setCircleCenter(
-        Point.fromLngLat(
-            chosenLocation.value.longitude.toDouble(), chosenLocation.value.latitude.toDouble()))
+        parkingViewModel.setCircleCenter(
+            Point.fromLngLat(
+                chosenLocation.value.longitude.toDouble(),
+                chosenLocation.value.latitude.toDouble()))
   }
 
   Scaffold(
@@ -190,8 +190,7 @@ fun SpotListScreen(
             // The parkings are sorted by distance to the user's location (default being the EPFL)
             // or by distance to the chosen location if any
             items(
-                items = filteredParkingSpots.sortedBy {
-                    computeDistance(it) },
+                items = filteredParkingSpots.sortedBy { computeDistance(it) },
                 key = { parking -> parking.uid }) { parking ->
                   SpotCard(
                       navigationActions = navigationActions,

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -98,6 +98,10 @@ fun SpotListScreen(
   // location permission from location manager
   val locPermission = permissionHandler.getLocalisationPerm().collectAsState().value
 
+  /*
+   * Function that computes the distance between the user's location and a parking spot
+   * @param parking: the parking spot for which we want to compute the distance
+   */
   fun computeDistance(parking: Parking): Double {
     return TurfMeasurement.distance(
         if (myLocation.value) userPosition
@@ -113,7 +117,9 @@ fun SpotListScreen(
     // if suggestion MyLocation is chosen and user has location permission then set the circle
     // center
     // to user position
-    if (locPermission && myLocation.value) parkingViewModel.setCircleCenter(userPosition)
+    if (locPermission && myLocation.value) {
+      parkingViewModel.setCircleCenter(userPosition)
+    }
 
     // else if the user has chosen a location or hasn't given his location permission then set the
     // circle center to the chosen location (default position is EPFL)
@@ -132,8 +138,7 @@ fun SpotListScreen(
               parkingViewModel = parkingViewModel,
               displayHeader = true,
               addressViewModel,
-              myLocation,
-              chosenLocation,
+              mapViewModel,
               permissionHandler)
           val listState = rememberLazyListState()
           LazyColumn(state = listState, modifier = Modifier.testTag("SpotListColumn")) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -554,6 +554,7 @@ fun MapScreen(
               parkingViewModel,
               addressViewModel,
               permissionHandler,
+              mapViewModel,
               onDismiss = { showFilter.value = false })
         }
 
@@ -777,6 +778,9 @@ fun SettingsDialog(
  * Composable function to display the filter dialog.
  *
  * @param parkingViewModel The ViewModel for managing parking-related data and actions.
+ * @param addressViewModel The ViewModel for managing address-related data and actions.
+ * @param permissionHandler The handler for managing permissions.
+ * @param mapViewModel The ViewModel for managing map-related data and actions.
  * @param onDismiss The function to dismiss the dialog.
  */
 @Composable
@@ -784,6 +788,7 @@ fun FilterDialog(
     parkingViewModel: ParkingViewModel,
     addressViewModel: AddressViewModel,
     permissionHandler: PermissionHandler,
+    mapViewModel: MapViewModel,
     onDismiss: () -> Unit
 ) {
   AlertDialog(
@@ -800,6 +805,7 @@ fun FilterDialog(
               parkingViewModel,
               displayHeader = false,
               addressViewModel,
+              mapViewModel,
               permissionHandler = permissionHandler)
         }
       },

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.address.Address
 import com.github.se.cyrcle.model.address.AddressViewModel
+import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
@@ -96,9 +96,7 @@ fun FilterPanel(
     parkingViewModel: ParkingViewModel,
     displayHeader: Boolean,
     addressViewModel: AddressViewModel,
-    myLocation: State<Boolean> = mutableStateOf(false),
-    chosenLocation: State<Address> =
-        mutableStateOf(Address(latitude = "46.518467", longitude = "6.566397")),
+    mapViewModel: MapViewModel,
     permissionHandler: PermissionHandler
 ) {
   val showProtectionOptions = remember { mutableStateOf(false) }
@@ -141,9 +139,8 @@ fun FilterPanel(
                   addressViewModel,
                   parkingViewModel,
                   isTextFieldVisible,
-                  myLocation,
-                  chosenLocation,
                   permissionHandler,
+                  mapViewModel,
                   textFieldValue)
             } else {
               Text(
@@ -333,10 +330,10 @@ fun FilterSection(
  * Composable function that displays a search bar for the list screen.
  *
  * @param addressViewModel The ViewModel responsible for managing addresses.
+ * @param parkingViewModel the ViewModel responsible for managing parkings
  * @param isTextFieldVisible A state that controls the visibility of the text field.
- * @param myLocation A state that indicates whether the user has selected "My Location".
- * @param chosenLocation A state that holds the address chosen by the user.
  * @param permissionHandler The handler for managing permissions.
+ * @param mapViewModel The ViewModel reponsible for the Map
  * @param textFieldValue The current value of the text field.
  */
 @Composable
@@ -344,9 +341,8 @@ fun SearchBarListScreen(
     addressViewModel: AddressViewModel,
     parkingViewModel: ParkingViewModel,
     isTextFieldVisible: MutableState<Boolean>,
-    myLocation: State<Boolean>,
-    chosenLocation: State<Address>,
     permissionHandler: PermissionHandler,
+    mapViewModel: MapViewModel,
     textFieldValue: MutableState<String>
 ) {
 
@@ -428,6 +424,7 @@ fun SearchBarListScreen(
                   modifier = Modifier.testTag("MyLocationSuggestionMenuItem"),
                   contentPadding = PaddingValues(8.dp),
                   onClick = {
+                    parkingViewModel.setCircleCenter(mapViewModel.userPosition.value)
                     parkingViewModel.setMyLocation(true)
                     showSuggestions.value = false
                     textFieldValue.value = context.resources.getString(R.string.my_location)

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -87,8 +87,7 @@ import kotlinx.coroutines.runBlocking
  *   a floating action button will be displayed to show/hide the filter options. If false, the
  *   filter the filter options and sections will be expanded and not collapsible.
  * @param addressViewModel The view model that contains the address search functionality
- * @param myLocation A state that indicates whether the user has selected "My Location"
- * @param chosenLocation A state that holds the address chosen by the user
+ * @param mapViewModel The view model that manage the Map
  * @param permissionHandler The handler for managing permissions
  */
 @Composable


### PR DESCRIPTION
## Bug

When the localisation permission is granted, on initialisation, the ListScreen displays parking that are far from the current position sometimes more than 1km away despite the maximum radius allowed.

## Fix 

The fix was to make the "MyLocation" suggestion set `cyrcleCenter` to userPosition on Click. Also updating the launchedEffect of the list Screen, passing the argument from `myLocation` to `myLocation.value` contributed to fixing the problem. 
I also updated the documentation.   

This PR completes my first PR #399 