### PR TITLE
Forth E2E test 

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -127,6 +127,26 @@ class MainActivityTest {
     mapRobot.assertIsOfflineMode()
   }
 
+  @Test
+  fun testReview(){
+
+    // Authenticated user
+    authRobot.assertAuthScreen()
+    authRobot.performSignIn()
+
+    mapRobot.assertMapScreen()
+
+
+    // Anonymous user
+    authRobot.assertAuthScreen()
+    authRobot.performAnonymousSignIn()
+
+    mapRobot.assertMapScreen()
+
+
+
+  }
+
   // ============================================================================
   // ============================ ADDPARKINGS ROBOT =============================
   // ============================================================================
@@ -437,6 +457,16 @@ class MainActivityTest {
       composeTestRule.waitUntilExactlyOneExists(hasTestTag("LoginScreen"))
     }
   }
+  // ============================================================================
+  // ============================= REVIEW SCREEN ROBOT =============================
+  // ============================================================================
+  private class ReviewRobot(val composeTestRule: ComposeTestRule) {
+
+
+
+
+  }
+
 
   // ============================================================================
   // ============================= HELPER FUNCTIONS =============================

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -540,7 +540,6 @@ class MainActivityTest {
           .assertIsDisplayed()
           .assertHasClickAction()
           .performClick()
-      Thread.sleep(5000)
       composeTestRule
           .onNodeWithTag(TopLevelDestinations.PROFILE.textId)
           .assertHasClickAction()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -51,6 +51,7 @@ class MainActivityTest {
   private lateinit var cardRobot: ParkingDetailsScreenRobot
   private lateinit var addParkingRobot: AddParkingRobot
   private lateinit var allReviewsRobot: AllReviewRobot
+  private lateinit var reviewRobot: ReviewRobot
 
   private lateinit var permissionHandler: PermissionHandler
 
@@ -67,6 +68,7 @@ class MainActivityTest {
     cardRobot = ParkingDetailsScreenRobot(composeTestRule)
     addParkingRobot = AddParkingRobot(composeTestRule)
     allReviewsRobot = AllReviewRobot(composeTestRule)
+    reviewRobot = ReviewRobot(composeTestRule)
   }
 
   @Test
@@ -132,6 +134,8 @@ class MainActivityTest {
   @Test
   fun testReview() {
 
+    composeTestRule.activity.userRepository.addUser(TestInstancesUser.user1, {}, {})
+
     // Authenticated user
     authRobot.assertAuthScreen()
     authRobot.performSignIn()
@@ -147,6 +151,11 @@ class MainActivityTest {
 
     allReviewsRobot.assertAllReviewScreen(true)
     allReviewsRobot.goToReview()
+
+    reviewRobot.assertReviewScreen()
+    reviewRobot.addReview()
+
+    allReviewsRobot.assertReviewIsAdded()
 
     // Anonymous user
     authRobot.assertAuthScreen()
@@ -515,6 +524,35 @@ class MainActivityTest {
           .assertIsDisplayed()
           .assertHasClickAction()
           .performClick()
+    }
+
+    fun assertReviewIsAdded() {
+      composeTestRule.onNodeWithTag("ReviewCard-1").assertIsDisplayed()
+    }
+  }
+
+  // ============================================================================
+  // ============================= MAPSCREEN ROBOT ==============================
+  // ============================================================================
+  private class ReviewRobot(val composeTestRule: ComposeTestRule) {
+
+    fun assertReviewScreen() {
+      composeTestRule.onNodeWithTag("ExperienceText").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("Slider").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("ReviewInput").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("AddReviewButton")
+    }
+
+    fun addReview() {
+      composeTestRule.onNodeWithTag("Slider").performTouchInput {
+        swipe(start = Offset(0f, centerY), end = Offset(1f, centerY))
+      }
+
+      composeTestRule
+          .onNodeWithTag("ReviewInput")
+          .performTextInput("Trop bien mais juste pour test")
+
+      composeTestRule.onNodeWithTag("AddReviewButton").assertHasClickAction().performClick()
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -159,6 +159,7 @@ class MainActivityTest {
     addReviewRobot.addReview()
 
     allReviewsRobot.assertReviewIsAdded()
+    allReviewsRobot.deleteReviewAndAssertDeleted()
     allReviewsRobot.toUserProfile()
 
     userProfileRobot.signOut()
@@ -536,16 +537,27 @@ class MainActivityTest {
           .assertHasClickAction()
           .performClick()
       composeTestRule
-          .onNodeWithTag("TopAppBarGoBackButton")
-          .assertIsDisplayed()
-          .assertHasClickAction()
-          .performClick()
-      composeTestRule
           .onNodeWithTag(TopLevelDestinations.PROFILE.textId)
           .assertHasClickAction()
           .performClick()
 
       composeTestRule.waitUntilExactlyOneExists(hasTestTag("ViewProfileScreen"))
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    fun deleteReviewAndAssertDeleted() {
+      composeTestRule
+          .onNodeWithTag("MoreOptions-1Button")
+          .assertIsDisplayed()
+          .assertHasClickAction()
+          .performClick()
+      composeTestRule.waitUntilExactlyOneExists(hasTestTag("MoreOptions-1DeleteReviewItem"))
+      composeTestRule
+          .onNodeWithTag("MoreOptions-1DeleteReviewItem")
+          .assertIsDisplayed()
+          .assertHasClickAction()
+          .performClick()
+      composeTestRule.onNodeWithTag("ReviewCard-1").assertIsNotDisplayed().assertDoesNotExist()
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -50,6 +50,7 @@ class MainActivityTest {
   private lateinit var userProfileRobot: UserProfileRobot
   private lateinit var cardRobot: ParkingDetailsScreenRobot
   private lateinit var addParkingRobot: AddParkingRobot
+  private lateinit var allReviewsRobot: AllReviewRobot
 
   private lateinit var permissionHandler: PermissionHandler
 
@@ -65,6 +66,7 @@ class MainActivityTest {
     userProfileRobot = UserProfileRobot(composeTestRule)
     cardRobot = ParkingDetailsScreenRobot(composeTestRule)
     addParkingRobot = AddParkingRobot(composeTestRule)
+    allReviewsRobot = AllReviewRobot(composeTestRule)
   }
 
   @Test
@@ -128,23 +130,38 @@ class MainActivityTest {
   }
 
   @Test
-  fun testReview(){
+  fun testReview() {
 
     // Authenticated user
     authRobot.assertAuthScreen()
     authRobot.performSignIn()
 
     mapRobot.assertMapScreen()
+    mapRobot.toList()
 
+    listRobot.assertListScreen()
+    listRobot.toCard(0)
+
+    cardRobot.assertParkingDetailsScreen()
+    cardRobot.goAllReviews()
+
+    allReviewsRobot.assertAllReviewScreen(true)
+    allReviewsRobot.goToReview()
 
     // Anonymous user
     authRobot.assertAuthScreen()
     authRobot.performAnonymousSignIn()
 
     mapRobot.assertMapScreen()
+    mapRobot.toList()
 
+    listRobot.assertListScreen()
+    listRobot.toCard(0)
 
+    cardRobot.assertParkingDetailsScreen()
+    cardRobot.goAllReviews()
 
+    allReviewsRobot.assertAllReviewScreen(false)
   }
 
   // ============================================================================
@@ -245,6 +262,16 @@ class MainActivityTest {
           .performClick()
       composeTestRule.waitUntilAtLeastOneExists(
           hasTestTag("SpotListScreen").or(hasTestTag("MapScreen")))
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    fun goAllReviews() {
+      composeTestRule
+          .onNodeWithTag("SeeAllReviewsText")
+          .assertIsDisplayed()
+          .assertHasClickAction()
+          .performClick()
+      composeTestRule.waitUntilExactlyOneExists(hasTestTag("ReviewCard0"))
     }
   }
 
@@ -458,15 +485,38 @@ class MainActivityTest {
     }
   }
   // ============================================================================
-  // ============================= REVIEW SCREEN ROBOT =============================
+  // ============================= ALL REVIEWS SCREEN ROBOT =============================
   // ============================================================================
-  private class ReviewRobot(val composeTestRule: ComposeTestRule) {
+  private class AllReviewRobot(val composeTestRule: ComposeTestRule) {
 
+    fun assertAllReviewScreen(SignedIn: Boolean) {
+      composeTestRule.onNodeWithTag("ReviewCard0").assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("ReviewTitle0")
+          .assertIsDisplayed()
+          .assertTextEquals("All Reviews")
+      composeTestRule.onNodeWithTag("ReviewCardContent0").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("ReviewActions0").assertIsDisplayed().assertHasClickAction()
+      composeTestRule.onNodeWithTag("LikeButton0").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("DislikeButton0").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("LikeCount0").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("DislikeCount0").assertIsDisplayed()
 
+      if (SignedIn) {
+        composeTestRule.onNodeWithTag("AddReviewButton").assertIsDisplayed().assertHasClickAction()
+      } else {
+        composeTestRule.onNodeWithTag("AddReviewButton").assertIsNotDisplayed()
+      }
+    }
 
-
+    fun goToReview() {
+      composeTestRule
+          .onNodeWithTag("AddReviewButton")
+          .assertIsDisplayed()
+          .assertHasClickAction()
+          .performClick()
+    }
   }
-
 
   // ============================================================================
   // ============================= HELPER FUNCTIONS =============================

--- a/app/src/main/java/com/github/se/cyrcle/model/review/TestInstancesReview.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/review/TestInstancesReview.kt
@@ -50,4 +50,14 @@ object TestInstancesReview {
           dislikedBy = listOf(),
           time = Timestamp.now(),
           reportingUsers = emptyList())
+
+  val review6 =
+      Review(
+          uid = "2",
+          owner = "user2",
+          text = "Okay parking.",
+          rating = 3.0,
+          parking = "Test_spot_1",
+          time = Timestamp.now(),
+          reportingUsers = emptyList())
 }


### PR DESCRIPTION
## Content of the PR 

This PR adds the 4th E2E test needed for the Milestone 3. I kept the same structure as previous tests since they were already very clear. The Review side of the App was the last essential part of the app that needed to be included in the E2E tests so it is the center of this one. I also asserted major screen like `MapScreen` since it was easy to do, and kept the tests clear/relevant. 

## How the test proceed 

The test proceeds with 2 different case : `Signed In User` and `Anonymous User`

 For `Signed In User` :
 
1. Assert `AuthenticationScreen` 
2. Sign In 
3. Assert `MapScreen`
4. Go to `ListScreen`
5. Assert `ListScreen`
6. Click on the first parking on the `ListScreen` 
7. Assert `ParkingDetailsScreen`
8. Click on `seeAllReviews` button
9. Assert there is one review on the parking
10. Click On `addReview` 
11. Assert the `AddReviewScreen` 
12. Submit a New Review
13. Check that the review appears where it is supposed to
14. Go to `UserProfileScreen` 
15. Sign Out

For `Anonymous User` : 

1. Assert `AuthenticationScreen` 
2. Sign In as anonymous user
3. Assert `MapScreen`
4. Go to `ListScreen`
5. Assert `ListScreen`
6. Click on the first parking on the `ListScreen` 
7. Assert `ParkingDetailsScreen`
8. Click on `seeAllReviews` button
9. Assert there is one review on the parking
10. Assert the `AddButton` is not available
11. Go to `UserProfileScreen` 
12. Sign Out