### PR TITLE
Adapt UI elements when offline. 

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
+++ b/app/src/main/java/com/github/se/cyrcle/CyrcleNavHost.kt
@@ -150,7 +150,7 @@ fun CyrcleNavHost(
         route = Route.ZONE,
     ) {
       composable(Screen.ZONE_MANAGER) {
-        ZoneManagerScreen(mapViewModel, parkingViewModel, navigationActions)
+        ZoneManagerScreen(mapViewModel, parkingViewModel, navigationActions, userViewModel)
       }
       composable(Screen.ZONE_SELECTION) {
         ZoneSelectionScreen(navigationActions, mapViewModel, parkingViewModel, addressViewModel)

--- a/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/user/UserViewModel.kt
@@ -10,6 +10,7 @@ import com.github.se.cyrcle.model.parking.online.ParkingRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
 class UserViewModel(
@@ -43,6 +44,14 @@ class UserViewModel(
   // Keep track of whether the user has connection to the internet or not.
   private val _hasConnection = MutableStateFlow(true)
   val hasConnection: StateFlow<Boolean> = _hasConnection
+
+  // Combine the connectivity status and the mode selected to decide if we show ui elements that
+  // require internet.
+  // (i.e the search bars)
+  val displayOnlineElementFlow =
+      combine(_isOnlineMode, _hasConnection) { isOnlineMode, hasConnection ->
+        isOnlineMode && hasConnection
+      }
   // === === === === === === ===
 
   /**

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -97,6 +97,7 @@ fun SpotListScreen(
   // location permission from location manager
   val locPermission = permissionHandler.getLocalisationPerm().collectAsState().value
 
+  val displayOnlineElement = userViewModel.displayOnlineElementFlow.collectAsState(initial = false)
   /*
    * Function that computes the distance between the user's location and a parking spot
    * @param parking: the parking spot for which we want to compute the distance
@@ -138,7 +139,8 @@ fun SpotListScreen(
               displayHeader = true,
               addressViewModel,
               mapViewModel,
-              permissionHandler)
+              permissionHandler,
+              userViewModel)
           val listState = rememberLazyListState()
           LazyColumn(state = listState, modifier = Modifier.testTag("SpotListColumn")) {
             // Pinned parking spots if any (includes titles and dividers)

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -151,6 +151,8 @@ fun MapScreen(
   // Collect the boolean to enable the parking addition from the UserViewModel as a state
   val enableParkingAddition by userViewModel.isSignedIn.collectAsState(false)
 
+  val displayOnlineElement = userViewModel.displayOnlineElementFlow.collectAsState(initial = false)
+
   // create a remember  state to store if the markers or the rectangles are displayed
   val mapMode: State<MapViewModel.MapMode> = mapViewModel.mapMode.collectAsState()
 
@@ -485,33 +487,38 @@ fun MapScreen(
           // Search bar and Settings button row
           Row(
               modifier = Modifier.fillMaxWidth().padding(5.dp).align(Alignment.TopStart),
-              verticalAlignment = Alignment.CenterVertically) {
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.End) {
                 // Search bar
-                OutlinedTextField(
-                    value = searchQuery.value,
-                    onValueChange = { searchQuery.value = it },
-                    placeholder = { Text(text = stringResource(R.string.search_bar_placeholder)) },
-                    modifier = Modifier.weight(1f).height(56.dp).testTag("SearchBar"),
-                    shape = RoundedCornerShape(16.dp),
-                    colors = getOutlinedTextFieldColorsSearchBar(ColorLevel.PRIMARY),
-                    trailingIcon = {
-                      if (searchQuery.value.isNotEmpty()) {
-                        Icon(
-                            imageVector = Icons.Filled.Clear,
-                            contentDescription = "Clear search",
-                            tint = defaultOnColor(),
-                            modifier = Modifier.clickable { searchQuery.value = "" })
-                      }
-                    },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
-                    keyboardActions =
-                        KeyboardActions(
-                            onSearch = {
-                              virtualKeyboardManager?.hide()
-                              runBlocking { addressViewModel.search(searchQuery.value) }
-                              showSuggestions.value = true
-                            }))
+                if (displayOnlineElement.value) {
+                  OutlinedTextField(
+                      value = searchQuery.value,
+                      onValueChange = { searchQuery.value = it },
+                      placeholder = {
+                        Text(text = stringResource(R.string.search_bar_placeholder))
+                      },
+                      modifier = Modifier.weight(1f).height(56.dp).testTag("SearchBar"),
+                      shape = RoundedCornerShape(16.dp),
+                      colors = getOutlinedTextFieldColorsSearchBar(ColorLevel.PRIMARY),
+                      trailingIcon = {
+                        if (searchQuery.value.isNotEmpty()) {
+                          Icon(
+                              imageVector = Icons.Filled.Clear,
+                              contentDescription = "Clear search",
+                              tint = defaultOnColor(),
+                              modifier = Modifier.clickable { searchQuery.value = "" })
+                        }
+                      },
+                      singleLine = true,
+                      keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+                      keyboardActions =
+                          KeyboardActions(
+                              onSearch = {
+                                virtualKeyboardManager?.hide()
+                                runBlocking { addressViewModel.search(searchQuery.value) }
+                                showSuggestions.value = true
+                              }))
+                }
 
                 // Filter button
                 Box(modifier = Modifier.size(56.dp).padding(start = 5.dp)) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -62,6 +62,7 @@ import com.github.se.cyrcle.model.parking.ParkingCapacity
 import com.github.se.cyrcle.model.parking.ParkingProtection
 import com.github.se.cyrcle.model.parking.ParkingRackType
 import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.permission.PermissionHandler
 import com.github.se.cyrcle.ui.list.MAX_SUGGESTION_DISPLAY_NAME_LENGTH_LIST
 import com.github.se.cyrcle.ui.list.NUMBER_OF_SUGGESTIONS_FOR_MENU
@@ -89,6 +90,8 @@ import kotlinx.coroutines.runBlocking
  * @param addressViewModel The view model that contains the address search functionality
  * @param mapViewModel The view model that manage the Map
  * @param permissionHandler The handler for managing permissions
+ * @param userViewModel The view model that contains the user information (if not specified, we
+ *   always display the online elements)
  */
 @Composable
 fun FilterPanel(
@@ -96,7 +99,8 @@ fun FilterPanel(
     displayHeader: Boolean,
     addressViewModel: AddressViewModel,
     mapViewModel: MapViewModel,
-    permissionHandler: PermissionHandler
+    permissionHandler: PermissionHandler,
+    userViewModel: UserViewModel? = null
 ) {
   val showProtectionOptions = remember { mutableStateOf(false) }
   val showRackTypeOptions = remember { mutableStateOf(false) }
@@ -116,6 +120,14 @@ fun FilterPanel(
 
   val radius = parkingViewModel.radius.collectAsState()
 
+  // Check for user connectivity and mode selected to decide if we display the elements that require
+  // online connection.
+  // (i.e the search bar). If not specified, we always display the online elements. (Mapcreen, test,
+  // ect..)
+  val displayOnlineElement =
+      userViewModel?.displayOnlineElementFlow?.collectAsState(initial = false)
+          ?: remember { mutableStateOf(true) }
+
   Column(modifier = Modifier.padding(if (displayHeader) 16.dp else 0.dp)) {
     if (displayHeader) {
 
@@ -125,12 +137,15 @@ fun FilterPanel(
           horizontalArrangement = Arrangement.End,
           verticalAlignment = Alignment.CenterVertically) {
             // Button transforms into a close button
-            SmallFloatingActionButton(
-                icon = if (isTextFieldVisible.value) Icons.Default.Close else Icons.Default.Search,
-                onClick = { isTextFieldVisible.value = !isTextFieldVisible.value },
-                modifier = Modifier.testTag("ShowSearchButton"),
-                contentDescription = "Search List Screen",
-            )
+            if (displayOnlineElement.value) {
+              SmallFloatingActionButton(
+                  icon =
+                      if (isTextFieldVisible.value) Icons.Default.Close else Icons.Default.Search,
+                  onClick = { isTextFieldVisible.value = !isTextFieldVisible.value },
+                  modifier = Modifier.testTag("ShowSearchButton"),
+                  contentDescription = "Search List Screen",
+              )
+            }
 
             // Text field slides out to the right of the button
             if (isTextFieldVisible.value) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -38,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.parking.ParkingViewModel
+import com.github.se.cyrcle.model.user.UserViewModel
 import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.map.MapConfig
 import com.github.se.cyrcle.ui.navigation.NavigationActions
@@ -52,10 +54,12 @@ import com.github.se.cyrcle.ui.theme.molecules.TopAppBar
 fun ZoneManagerScreen(
     mapViewModel: MapViewModel,
     parkingViewModel: ParkingViewModel,
-    navigationActions: NavigationActions
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel
 ) {
   val context = LocalContext.current
   val zones = remember { mutableStateOf<List<Zone>>(emptyList()) }
+  val displayOnlineElement = userViewModel.displayOnlineElementFlow.collectAsState(initial = false)
   LaunchedEffect(Unit) {
     zones.value = Zone.loadZones(context)
     Log.d("ZoneManagerScreen", "Zones: ${zones.value}")
@@ -92,7 +96,10 @@ fun ZoneManagerScreen(
             }
           }
           // === Overlay ===
-          AddZoneButton(mapViewModel, navigationActions)
+          if (displayOnlineElement.value) {
+            AddZoneButton(mapViewModel, navigationActions)
+          }
+
           // ===  === ===  ===
         }
       }


### PR DESCRIPTION
- fix : #409 
## What
- Hides the search bars on the map screen as well as list screen when the user either has no connectivity or he is using the offline mode.
- Hides the add button on zone selection screen

[Screen_recording_20241213_143641.webm](https://github.com/user-attachments/assets/d79d6d86-a955-4865-9b3f-92c871405a51)



## How
Use a state of the viewmodel to make the decision that combine both `hasConnection` and `isOnlineMode` state

## Why
The search bars are useless when in offline mode or without connection and displaying them can be missleading. Same for the zone selection screen

