### PR TITLE
Assert a minimum area for new parking

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.test.swipeUp
 import com.github.se.cyrcle.MainActivity
 import com.github.se.cyrcle.di.mocks.MockParkingRepository
 import com.github.se.cyrcle.model.parking.Parking
@@ -202,8 +203,9 @@ class MainActivityTest {
 
     @OptIn(ExperimentalTestApi::class)
     fun makeRectangleAndNext() = runTest {
-      composeTestRule.onNodeWithTag("LocationPickerScreen").performTouchInput {
-        swipe(start = Offset(0.5f, 0.5f), end = Offset(0.7f, 0.7f), durationMillis = 10)
+      composeTestRule.onNodeWithTag("canvas").performTouchInput {
+        swipeUp(bottom, bottom - 50)
+        swipeRight(left, left + 50)
       }
       composeTestRule.awaitIdle()
       composeTestRule.onNodeWithTag("nextButton").performClick()

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/testEnd2End/MainActivityTest.kt
@@ -204,8 +204,8 @@ class MainActivityTest {
     @OptIn(ExperimentalTestApi::class)
     fun makeRectangleAndNext() = runTest {
       composeTestRule.onNodeWithTag("canvas").performTouchInput {
-        swipeUp(bottom, bottom - 50)
-        swipeRight(left, left + 50)
+        swipeUp(bottom, bottom - 30)
+        swipeRight(left, left + 30)
       }
       composeTestRule.awaitIdle()
       composeTestRule.onNodeWithTag("nextButton").performClick()

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import com.github.se.cyrcle.model.parking.Location
 import com.github.se.cyrcle.model.parking.PARKING_MAX_AREA
 import com.github.se.cyrcle.model.parking.PARKING_MAX_SIDE_LENGTH
+import com.github.se.cyrcle.model.parking.PARKING_MIN_AREA
 import com.github.se.cyrcle.model.parking.Parking
 import com.github.se.cyrcle.model.parking.TestInstancesParking
 import com.github.se.cyrcle.ui.map.MapConfig
@@ -48,6 +49,7 @@ class MapViewModel : ViewModel() {
             val heightAndWidth = location.computeHeightAndWidth()
             heightAndWidth.first <= PARKING_MAX_SIDE_LENGTH &&
                 heightAndWidth.second <= PARKING_MAX_SIDE_LENGTH &&
+                area >= PARKING_MIN_AREA &&
                 area <= PARKING_MAX_AREA
           } ?: false
         }

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -34,6 +34,7 @@ const val NB_REPORTS_THRESH = 1
 const val NB_REPORTS_MAXSEVERITY_THRESH = 4
 const val MAX_SEVERITY = 3
 
+const val PARKING_MIN_AREA = 5.0
 const val PARKING_MAX_AREA = 1000.0
 const val PARKING_MAX_SIDE_LENGTH = 50.0
 

--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -34,8 +34,8 @@ const val NB_REPORTS_THRESH = 1
 const val NB_REPORTS_MAXSEVERITY_THRESH = 4
 const val MAX_SEVERITY = 3
 
-const val PARKING_MIN_AREA = 5.0
-const val PARKING_MAX_AREA = 1000.0
+const val PARKING_MIN_AREA = 5
+const val PARKING_MAX_AREA = 1000
 const val PARKING_MAX_SIDE_LENGTH = 50.0
 
 /**

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/LocationPickerBottomBar.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
 import com.github.se.cyrcle.model.map.MapViewModel.LocationPickerState
+import com.github.se.cyrcle.model.parking.PARKING_MAX_AREA
+import com.github.se.cyrcle.model.parking.PARKING_MIN_AREA
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.Typography
@@ -88,15 +90,15 @@ fun LocationPickerBottomBar(
                           textAlign = TextAlign.Center)
                     }
               } else if (locationPickerState == LocationPickerState.TOP_LEFT_SET) {
+                val invalidAreaText =
+                    stringResource(
+                        R.string.location_picker_invalid_area, PARKING_MIN_AREA, PARKING_MAX_AREA)
                 Button(
                     {
                       if (isLocationValid) {
                         onBottomRightSelected(mapViewModel)
                       } else {
-                        Toast.makeText(
-                                mapView.value?.context,
-                                R.string.location_picker_invalid_area,
-                                Toast.LENGTH_SHORT)
+                        Toast.makeText(mapView.value?.context, invalidAreaText, Toast.LENGTH_SHORT)
                             .show()
                       }
                     },

--- a/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/addParking/location/overlay/RectangleSelection.kt
@@ -59,6 +59,7 @@ fun RectangleSelection(
         modifier =
             Modifier.padding(paddingValues)
                 .fillMaxSize()
+                .testTag("canvas")
                 .then(
                     if (!mapGesturesEnabled.value) {
                       Modifier.pointerInput(Unit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,7 +66,7 @@
     <!-- Location Picker Bottom Bar -->
     <string name="location_picker_bottom_bar_cancel_button">Cancel</string>
     <string name="location_picker_bottom_bar_next_button">Next</string>
-    <string name="location_picker_invalid_area">Please select a valid area</string>
+    <string name="location_picker_invalid_area">The parking should be at least %d[m²] and at max. %d[m²]</string>
     <!-- Location Picker Top Bar -->
     <string name="location_picker_top_bar_where">Where is the Parking ?</string>
     <string name="location_picker_top_bar_select_top_left">Set the top-left corner of the parking, by placing it under the crosshair below</string>


### PR DESCRIPTION
- fix : #411 
## What
Ensure parking are minimum 5 meters square

<img src="https://github.com/user-attachments/assets/6e1173fe-05f4-4f22-af0b-0c79ae5f6f56" width=200>

## How
reuse the `isValid` function that already asserted an upper bound
adapts test so that they don't create a parking with a 0 area anymore

## Why
to prevent having invisible parking on the advanced mode, because rectangles are too small to be visible. 
