### PR TITLE
Go to map from zone manager screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
@@ -101,4 +101,19 @@ class ZoneManagerScreenTest {
     composeTestRule.onNodeWithTag("ZoneManagerHeaderLastRefreshed").assertIsDisplayed()
     composeTestRule.onNodeWithContentDescription("Refresh").assertIsDisplayed()
   }
+
+  @Test
+  fun verifyGoToMap() {
+    val zone =
+        Zone(
+            BoundingBox.fromLngLats(0.0, 0.0, 1.0, 1.0),
+            "Test Zone",
+        )
+    val zonesState = mutableStateOf(listOf(zone))
+    composeTestRule.setContent {
+      ZoneCard(parkingViewModel, mapViewModel, navigationActions, zone, zonesState)
+    }
+    composeTestRule.onNodeWithTag("ZoneCardName").performClick()
+    verify(navigationActions).navigateTo(Screen.MAP)
+  }
 }

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreenTest.kt
@@ -81,7 +81,9 @@ class ZoneManagerScreenTest {
             "Test Zone",
         )
     val zonesState = mutableStateOf(listOf(zone))
-    composeTestRule.setContent { ZoneCard(parkingViewModel, zone, zonesState) }
+    composeTestRule.setContent {
+      ZoneCard(parkingViewModel, mapViewModel, navigationActions, zone, zonesState)
+    }
     composeTestRule
         .onNodeWithContentDescription("Refresh")
         .assertIsDisplayed()

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -126,13 +126,14 @@ class MapViewModel : ViewModel() {
    * is set to the max zoom defined in the UI.
    *
    * @param location the location to zoom on.
+   * @param zoom the zoom level to set.
    */
-  fun zoomOnLocation(location: Location) {
+  fun zoomOnLocation(location: Location, zoom: Double = maxZoom) {
     _cameraPosition.value =
         CameraState(
             location.center,
             MapConfig.defaultCameraState().padding,
-            maxZoom,
+            zoom,
             MapConfig.defaultCameraState().bearing,
             MapConfig.defaultCameraState().pitch)
   }

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -140,7 +140,7 @@ fun ZoneCard(
                 TextStyle(textDecoration = TextDecoration.Underline, fontStyle = FontStyle.Italic),
             textAlign = TextAlign.Left,
             modifier =
-                Modifier.weight(2f).clickable {
+                Modifier.weight(2f).testTag("ZoneCardName").clickable {
                   mapViewModel.updateTrackingMode(false)
                   mapViewModel.updateMapRecentering(true)
                   mapViewModel.zoomOnLocation(Location(zone.boundingBox.southwest()), minZoom)

--- a/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/zone/ZoneManagerScreen.kt
@@ -32,14 +32,19 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.map.MapViewModel
+import com.github.se.cyrcle.model.parking.Location
 import com.github.se.cyrcle.model.parking.ParkingViewModel
 import com.github.se.cyrcle.model.zone.Zone
 import com.github.se.cyrcle.ui.map.MapConfig
+import com.github.se.cyrcle.ui.map.minZoom
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.navigation.Screen
 import com.github.se.cyrcle.ui.theme.ColorLevel
@@ -78,7 +83,7 @@ fun ZoneManagerScreen(
             }
             LazyColumn(modifier = Modifier.fillMaxSize().padding(bottom = 8.dp)) {
               items(zones.value) { zone ->
-                ZoneCard(parkingViewModel, zone, zones)
+                ZoneCard(parkingViewModel, mapViewModel, navigationActions, zone, zones)
                 if (zone != zones.value.last()) {
                   HorizontalDivider(
                       color = MaterialTheme.colorScheme.onBackground.copy(0.5f),
@@ -118,12 +123,29 @@ fun AddZoneButton(mapViewModel: MapViewModel, navigationActions: NavigationActio
 }
 // Display relevant information about a zone. Allows the user to refresh the zone or delete it.
 @Composable
-fun ZoneCard(parkingViewModel: ParkingViewModel, zone: Zone, zones: MutableState<List<Zone>>) {
+fun ZoneCard(
+    parkingViewModel: ParkingViewModel,
+    mapViewModel: MapViewModel,
+    navigationActions: NavigationActions,
+    zone: Zone,
+    zones: MutableState<List<Zone>>
+) {
   val context = LocalContext.current
   Row(
       modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("ZoneCard"),
       horizontalArrangement = Arrangement.SpaceBetween) {
-        Text(text = zone.name, textAlign = TextAlign.Left, modifier = Modifier.weight(2f))
+        Text(
+            text = zone.name,
+            style =
+                TextStyle(textDecoration = TextDecoration.Underline, fontStyle = FontStyle.Italic),
+            textAlign = TextAlign.Left,
+            modifier =
+                Modifier.weight(2f).clickable {
+                  mapViewModel.updateTrackingMode(false)
+                  mapViewModel.updateMapRecentering(true)
+                  mapViewModel.zoomOnLocation(Location(zone.boundingBox.southwest()), minZoom)
+                  navigationActions.navigateTo(Screen.MAP)
+                })
         Text(text = zone.lastRefreshed.toString(), modifier = Modifier.weight(1f))
         Icon(
             Icons.Filled.Refresh,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,7 +291,7 @@
     <string name="zone_manager_screen_title">Offline Maps</string>
     <string name="zone_selection_screen_title">Select Zone</string>
     <string name ="zone_manager_no_zones">Nothing downloaded yet</string>
-    <string name ="zone_manager_header_area">Map Name</string>
+    <string name ="zone_manager_header_area">Map Name \n(Click to show on map)</string>
     <string name ="zone_manager_header_lastRefreshed">Last Refreshed</string>
     <string name ="zone_selection_alert_tilte">Please name the Area you are about to download</string>
     <string name ="zone_selection_button_when_none_set">Set top left corner</string>


### PR DESCRIPTION
- fix : #383 
## What
Allow user to open the map centered on a zone he downloaded

<img width="200" alt="image" src="https://github.com/user-attachments/assets/6063e157-804b-4b59-af75-8e06f7e66a1f" />

## How 
Re-using André's function for the go-to-map feature but overloading it with a zoom parameter, because we don't want to be too zoomed here

## Why
Because offline, the search bar doesn't work and so navigating between areas is only possible via scrolling 