### PR TITLE
Polish list screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -427,6 +427,26 @@ class ListScreenTest {
   }
 
   @Test
+  fun testBearingPopUp() {
+    composeTestRule.setContent {
+      SpotCard(
+          navigationActions = mockNavigationActions,
+          parkingViewModel = parkingViewModel,
+          userViewModel = userViewModel,
+          parking = TestInstancesParking.parking1,
+          distance = 0.5, // 500m
+          bearing = 12.0)
+    }
+    // Open the bearing pop up
+    composeTestRule
+        .onNodeWithTag("BearingIcon")
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .performClick()
+    composeTestRule.onNodeWithTag("BearingPopUp").assertIsDisplayed()
+  }
+
+  @Test
   fun assertSearchBarIsDisplayed() {
     composeTestRule.setContent {
       SpotListScreen(

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -119,6 +119,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1,
+          0.0,
           0.0)
     }
 
@@ -135,6 +136,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1,
+          0.0,
           0.0)
     }
 
@@ -153,6 +155,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking3, // not in our user's favorites
+          0.0,
           0.0)
     }
 
@@ -169,6 +172,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1, // in our user's favorites
+          0.0,
           0.0)
     }
 
@@ -185,6 +189,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking3,
+          0.0,
           0.0)
     }
 
@@ -217,6 +222,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking1, // already in favorites
+          0.0,
           0.0)
     }
 
@@ -250,6 +256,7 @@ class ListScreenTest {
           parkingViewModel,
           userViewModel,
           TestInstancesParking.parking3,
+          0.0,
           0.0)
     }
 
@@ -341,7 +348,8 @@ class ListScreenTest {
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = TestInstancesParking.parking1,
-          distance = 0.0)
+          distance = 0.0,
+          0.0)
     }
 
     composeTestRule.onNodeWithTag("SpotListItem", useUnmergedTree = true).assertIsDisplayed()
@@ -353,6 +361,7 @@ class ListScreenTest {
         .onNodeWithTag("ParkingDistance", useUnmergedTree = true)
         .assertIsDisplayed()
         .assertTextEquals(String.format("%.0f m", 0.0))
+    composeTestRule.onNodeWithTag("BearingIcon", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithTag("ParkingNoReviews", useUnmergedTree = true).assertIsNotDisplayed()
   }
 
@@ -364,7 +373,8 @@ class ListScreenTest {
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = TestInstancesParking.parking2,
-          distance = 0.0)
+          distance = 0.0,
+          0.0)
     }
 
     composeTestRule
@@ -388,8 +398,8 @@ class ListScreenTest {
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = TestInstancesParking.parking1,
-          distance = 0.5 // 500m
-          )
+          distance = 0.5, // 500m
+          bearing = 12.0)
     }
 
     // Test meters display
@@ -406,8 +416,8 @@ class ListScreenTest {
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = TestInstancesParking.parking1,
-          distance = 2.5 // 2.5km
-          )
+          distance = 2.5, // 2.5km
+          bearing = 12.0)
     }
 
     // Test kilometers display
@@ -429,7 +439,8 @@ class ListScreenTest {
           parkingViewModel = parkingViewModel,
           userViewModel = userViewModel,
           parking = longNameParking,
-          distance = 0.0)
+          distance = 0.0,
+          0.0)
     }
 
     composeTestRule

--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/list/ListScreenTest.kt
@@ -427,28 +427,6 @@ class ListScreenTest {
   }
 
   @Test
-  fun testParkingNameTruncation() {
-    val longNameParking =
-        TestInstancesParking.parking1.copy(
-            optName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    parkingViewModel.addParking(longNameParking)
-
-    composeTestRule.setContent {
-      SpotCard(
-          navigationActions = mockNavigationActions,
-          parkingViewModel = parkingViewModel,
-          userViewModel = userViewModel,
-          parking = longNameParking,
-          distance = 0.0,
-          0.0)
-    }
-
-    composeTestRule
-        .onNodeWithTag("ParkingName", useUnmergedTree = true)
-        .assertTextEquals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...")
-  }
-
-  @Test
   fun assertSearchBarIsDisplayed() {
     composeTestRule.setContent {
       SpotListScreen(

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -48,6 +47,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.se.cyrcle.R
@@ -315,15 +315,21 @@ fun SpotCard(
                       .testTag("SpotCardContent"),
               verticalAlignment = Alignment.Top,
               horizontalArrangement = Arrangement.SpaceBetween) {
-                Column {
-                  Text(
-                      text =
-                          parking.optName?.let { if (it.length > 35) it.take(32) + "..." else it }
-                              ?: stringResource(R.string.default_parking_name),
+                Column(
+                    modifier =
+                        Modifier.weight(1f) // Allowing this column to take available space
+                            .padding(end = 16.dp),
+                ) {
+                  androidx.compose.material3.Text(
+                      text = parking.optName ?: stringResource(R.string.default_parking_name),
                       style = MaterialTheme.typography.bodyLarge,
-                      testTag = "ParkingName")
+                      maxLines = 1, // Limit to one line
+                      overflow = TextOverflow.Ellipsis, // Use ellipsis for overflow
+                      modifier = Modifier.fillMaxWidth().testTag("ParkingName"),
+                  )
 
                   Spacer(modifier = Modifier.height(8.dp))
+
                   if (parking.nbReviews > 0) {
                     ScoreStars(
                         parking.avgScore,
@@ -339,6 +345,7 @@ fun SpotCard(
                         testTag = "ParkingNoReviews")
                   }
                 }
+
                 Column(horizontalAlignment = Alignment.End) {
                   Text(
                       text =

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -454,7 +454,9 @@ fun BearingIcon(bearing: Double) {
             shape = RoundedCornerShape(8.dp),
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)),
             shadowElevation = 4.dp,
-            modifier = Modifier.padding(start = 128.dp, end = 16.dp, top = 20.dp)) {
+            modifier =
+                Modifier.padding(start = 128.dp, end = 16.dp, top = 20.dp)
+                    .testTag("BearingPopUp")) {
               Text(
                   text = stringResource(R.string.list_screen_bearing_popup),
                   modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),

--- a/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/list/ListScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.cyrcle.ui.list
 
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -20,6 +21,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Favorite
@@ -30,11 +32,13 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -51,6 +55,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import com.github.se.cyrcle.R
 import com.github.se.cyrcle.model.address.AddressViewModel
 import com.github.se.cyrcle.model.map.MapViewModel
@@ -367,12 +372,7 @@ fun SpotCard(
                 Column(horizontalAlignment = Alignment.End) {
                   Row {
                     // Bearing wrt user's location. This is the orientation wrt north
-                    Icon(
-                        imageVector = Icons.Default.ArrowUpward,
-                        contentDescription = "Bearing",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier =
-                            Modifier.size(20.dp).rotate(bearing.toFloat()).testTag("BearingIcon"))
+                    BearingIcon(bearing)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text =
@@ -425,4 +425,42 @@ fun ActionCard(
               )
             }
       }
+}
+
+/**
+ * Composable that displays a bearing icon. Clicking on the icon will display a popup explaining
+ * what the bearing represents. The popup is closed by clicking outside of it.
+ *
+ * @param bearing the bearing to display
+ */
+@Composable
+fun BearingIcon(bearing: Double) {
+  var showPopup by remember { mutableStateOf(false) }
+
+  Box {
+    Icon(
+        imageVector = Icons.Default.ArrowUpward,
+        contentDescription = "Bearing",
+        tint = MaterialTheme.colorScheme.primary,
+        modifier =
+            Modifier.size(20.dp).rotate(bearing.toFloat()).testTag("BearingIcon").clickable {
+              showPopup = true
+            })
+
+    if (showPopup) {
+      Popup(onDismissRequest = { showPopup = false }, alignment = Alignment.TopCenter) {
+        Surface(
+            color = MaterialTheme.colorScheme.surface,
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)),
+            shadowElevation = 4.dp,
+            modifier = Modifier.padding(start = 128.dp, end = 16.dp, top = 20.dp)) {
+              Text(
+                  text = stringResource(R.string.list_screen_bearing_popup),
+                  modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),
+                  style = MaterialTheme.typography.bodyMedium)
+            }
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/Filter.kt
@@ -381,7 +381,8 @@ fun SearchBarListScreen(
       animateDpAsState(targetValue = if (isTextFieldVisible.value) 0.dp else (-200).dp)
 
   Box {
-    // Callback for when a suggestion is clicked. If address is null, the user's location is set.
+    // Callback for when a suggestion is clicked. Either called with a valid (non-null) address or
+    // explicitly called with null to indicate we want to use the user's location.
     val onLocationClicked: (Address?) -> Unit = {
       if (it == null) {
         parkingViewModel.setCircleCenter(mapViewModel.userPosition.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="all_parkings_radius">Parkings within %1$d m</string>
     <string name="list_screen_edit_note">Edit your note</string>
     <string name="list_screen_no_note">Add a note by clicking on +</string>
+    <string name="list_screen_bearing_popup">This arrow shows the direction relative to true north. It doesn\'t reflect your device\'s orientation.</string>
     <string name="sign_in_to_add_note">Please sign in to add notes</string>
     <string name="my_location">My Location</string>
     <string name="search_bar_no_results">No results found</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="list_screen_no_note">Add a note by clicking on +</string>
     <string name="sign_in_to_add_note">Please sign in to add notes</string>
     <string name="my_location">My Location</string>
+    <string name="search_bar_no_results">No results found</string>
 
     <!-- Zoom Controls -->
     <string name="zoom_in">Zoom In</string>


### PR DESCRIPTION
This PR includes several improvements to enhance the user experience and functionality of the list screen:

### Changes:
**1. Prevent parking name from overflowing:**
- Modified the `SpotCard` composable to limit parking name to one line with ellipsis for overflow.
- Adjusted layout to ensure proper spacing between parking name and distance information.

**2. Improved search bar functionality:**
- Implemented distinct suggestions earlier in filtering to avoid empty results.
- Added "No results" message when search yields no suggestions. 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/a5834fc6-730b-4f31-b0ef-4d2e88382367">

- Replaced "My location" option in dropdown menu with a trailing icon when text field is empty (and user has enabled the position permission)
<img width="250" alt="image" src="https://github.com/user-attachments/assets/3384f749-40ba-465e-b6b3-1b3c9580bd39">


**3. Added bearing information to list items:**
- Implemented `computeBearing` function to calculate bearing between user location and parking spot.
- Added bearing icon to `SpotCard` composable, rotating it based on the calculated bearing.
- Updated `SpotListScreen` to pass bearing information to `SpotCard`.

**Overrall result:** 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fc5887d5-6a98-48fa-a417-5b811b4b57a5">