### PR TITLE
Bugfix topappbar title overflows

### DIFF
--- a/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBarTest.kt
+++ b/app/src/androidTest/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBarTest.kt
@@ -76,4 +76,28 @@ class TopAppBarTest {
         .assertIsDisplayed()
         .assertHasClickAction()
   }
+
+  @Test
+  fun displayTopAppBarWithLongTitle() {
+    val tag2 = "TopAppBar2"
+    val title =
+        "This is a very long title that should be truncated but just in case it is not, I am making it longer"
+    composeTestRule.setContent {
+      Scaffold(topBar = { TopAppBar(navigationActions, title, tag2) }) { innerPadding ->
+        Column(modifier = Modifier.padding(innerPadding)) {}
+      }
+    }
+
+    // Top App Bar
+    composeTestRule.onNodeWithTag(tag2).assertIsDisplayed()
+
+    // Title
+    composeTestRule.onNodeWithTag("${tag2}Title", true).assertIsDisplayed().assertTextEquals(title)
+
+    // Ensure button is still displayed
+    composeTestRule
+        .onNodeWithTag("${tag2}GoBackButton", true)
+        .assertIsDisplayed()
+        .assertHasClickAction()
+  }
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBar.kt
@@ -1,5 +1,10 @@
 package com.github.se.cyrcle.ui.theme.molecules
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -14,6 +19,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.cyrcle.ui.navigation.NavigationActions
 import com.github.se.cyrcle.ui.theme.Typography
@@ -36,9 +44,12 @@ fun TopAppBar(navigationActions: NavigationActions, title: String, testTag: Stri
       title = {
         Text(
             text = title,
-            style = Typography.titleLarge.copy(fontSize = scaledFontSize),
+            style =
+                Typography.titleLarge.copy(fontSize = scaledFontSize, fontWeight = FontWeight.Bold),
             color = Color.White,
-            modifier = Modifier.testTag("${testTag}Title"))
+            modifier = Modifier.testTag("${testTag}Title"),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis)
       },
       colors =
           TopAppBarColors(
@@ -49,10 +60,18 @@ fun TopAppBar(navigationActions: NavigationActions, title: String, testTag: Stri
               scrolledContainerColor = MaterialTheme.colorScheme.primaryContainer),
       modifier = Modifier.testTag(testTag),
       navigationIcon = {
-        IconButton(
-            onClick = { navigationActions.goBack() },
-            modifier = Modifier.testTag("${testTag}GoBackButton")) {
-              Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Go Back")
-            }
+        Box(modifier = Modifier.padding(8.dp)) {
+          IconButton(
+              onClick = { navigationActions.goBack() },
+              modifier =
+                  Modifier.testTag("${testTag}GoBackButton")
+                      .background(Color.White.copy(alpha = 0.1f), shape = RoundedCornerShape(12.dp))
+                      .size(40.dp)) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Go Back",
+                    modifier = Modifier.size(24.dp))
+              }
+        }
       })
 }

--- a/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBar.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/theme/molecules/TopAppBar.kt
@@ -15,16 +15,20 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.cyrcle.ui.navigation.NavigationActions
-import com.github.se.cyrcle.ui.theme.Typography
 
 /**
  * Create a themed bottom navigation bar, with simplified arguments.
@@ -38,18 +42,15 @@ import com.github.se.cyrcle.ui.theme.Typography
 fun TopAppBar(navigationActions: NavigationActions, title: String, testTag: String = "TopAppBar") {
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp
-  val scaledFontSize = (screenWidth * 0.05).sp // Adjust the scaling factor as needed
+  val initialFontSize = (screenWidth * 0.05).sp
 
   CenterAlignedTopAppBar(
       title = {
-        Text(
+        AutoResizingText(
             text = title,
-            style =
-                Typography.titleLarge.copy(fontSize = scaledFontSize, fontWeight = FontWeight.Bold),
-            color = Color.White,
-            modifier = Modifier.testTag("${testTag}Title"),
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis)
+            initialFontSize = initialFontSize,
+            modifier = Modifier.testTag("${testTag}Title").padding(horizontal = 8.dp),
+            maxLines = 2)
       },
       colors =
           TopAppBarColors(
@@ -72,6 +73,45 @@ fun TopAppBar(navigationActions: NavigationActions, title: String, testTag: Stri
                     contentDescription = "Go Back",
                     modifier = Modifier.size(24.dp))
               }
+        }
+      })
+}
+
+/**
+ * A composable function that manages the resizing of the text to fit the available space. The text
+ * will be resized until it fits the available space, or until the font size is 6sp. Both the font
+ * size and the line height will be reduced by 5% at each iteration.
+ *
+ * @param text The text to display
+ * @param initialFontSize The initial font size of the text
+ * @param modifier The modifier of the text
+ * @param maxLines The maximum number of lines the text can take
+ */
+@Composable
+fun AutoResizingText(
+    text: String,
+    initialFontSize: TextUnit,
+    modifier: Modifier = Modifier,
+    maxLines: Int
+) {
+  var fontSize by remember { mutableStateOf(initialFontSize) }
+  var lineHeight by remember { mutableStateOf(initialFontSize * 1.2f) }
+  var readyToDraw by remember { mutableStateOf(false) }
+
+  Text(
+      text = text,
+      color = Color.White,
+      fontSize = fontSize,
+      fontWeight = FontWeight.Bold,
+      lineHeight = lineHeight,
+      maxLines = maxLines,
+      modifier = modifier.drawWithContent { if (readyToDraw) drawContent() },
+      onTextLayout = { textLayoutResult ->
+        if (textLayoutResult.didOverflowHeight && fontSize > 6.sp) {
+          fontSize *= 0.95f
+          lineHeight *= 0.95f
+        } else {
+          readyToDraw = true
         }
       })
 }


### PR DESCRIPTION
## Title: Fix TopAppBar Title Overflow

### Description:

This PR addresses the issue of TopAppBar title overflowing beyond two lines, improving readability and UI consistency across the app.

### Changes:
**1. Implemented AutoResizingText composable:**
- Created a new `AutoResizingText` composable that dynamically adjusts font size to fit within the available space.
- Both font size and line height are reduced by 5% in each iteration until text fits or reaches a minimum font size of 6sp to maintain proper text scaling.
- Replaced the standard `Text` composable with the new `AutoResizingText` in the TopAppBar with a maximum of 2 lines

**2. Improved UI layout:**
- Added horizontal padding to the title for better spacing.
- Adjusted the navigation icon to use a semi-transparent white background for improved visibility.

### Before vs after:

Let us see the difference between before and after for the same "long title"

<img width="250" alt="image" src="https://github.com/user-attachments/assets/a5834fc6-730b-4f31-b0ef-4d2e88382367">
![image](https://github.com/user-attachments/assets/ae8b6997-21af-45ae-82cc-4d2552067b55)
![image](https://github.com/user-attachments/assets/f79150f7-1f0a-40f4-9780-79cb628991a0)
