### PR TITLE
Bugfix MapScreen network changes

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -52,6 +52,11 @@ class MapViewModel : ViewModel() {
           } ?: false
         }
 
+  private val _mapScreenCoordinates =
+      MutableStateFlow<Pair<Point, Point>>(
+          Pair(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
+  val mapScreenCoordinates: StateFlow<Pair<Point, Point>> = _mapScreenCoordinates
+
   private val _screenCoordinates = MutableStateFlow<List<ScreenCoordinate>>(listOf())
   val screenCoordinates: StateFlow<List<ScreenCoordinate>> = _screenCoordinates
 
@@ -205,15 +210,13 @@ class MapViewModel : ViewModel() {
   }
 
   /**
-   * Get the bottom left and top right corners of the screen in latitude and longitude coordinates.
-   * The corners are calculated based on the center of the screen and the viewport dimensions. If
-   * useBuffer is true, the corners are calculated with a buffer of 2x the viewport dimensions. This
-   * is useful for loading parkings that are not yet visible on the screen.
+   * Updates the bottom left and top right corners of the screen in latitude and longitude
+   * coordinates. The corners are calculated based on the center of the screen and the viewport
+   * dimensions.
    *
    * @param mapView the MapView to get the screen corners from
-   * @return a pair of the bottom left and top right corners of the screen
    */
-  fun getScreenCorners(mapView: MapView): Pair<Point, Point> {
+  fun updateScreenCoordinates(mapView: MapView) {
     // Retrieve viewport dimensions
     val viewportWidth = mapView.width
     val viewportHeight = mapView.height
@@ -235,7 +238,7 @@ class MapViewModel : ViewModel() {
                 centerPixel.x + (viewportWidth * multiplier),
                 centerPixel.y - (viewportHeight * multiplier)))
 
-    return Pair(bottomLeftCorner, topRightCorner)
+    _mapScreenCoordinates.value = Pair(bottomLeftCorner, topRightCorner)
   }
 
   private val handler = Handler(Looper.getMainLooper())

--- a/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/map/MapViewModel.kt
@@ -54,7 +54,7 @@ class MapViewModel : ViewModel() {
 
   private val _mapScreenCoordinates =
       MutableStateFlow<Pair<Point, Point>>(
-          Pair(Point.fromLngLat(0.0, 0.0), Point.fromLngLat(0.0, 0.0)))
+          Pair(TestInstancesParking.EPFLCenter, TestInstancesParking.EPFLCenter))
   val mapScreenCoordinates: StateFlow<Pair<Point, Point>> = _mapScreenCoordinates
 
   private val _screenCoordinates = MutableStateFlow<List<ScreenCoordinate>>(listOf())

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -131,6 +131,7 @@ const val thresholdDisplayZoom = 13.0
 const val ADVANCED_MODE_ZOOM_THRESHOLD = 15.5
 const val CLUSTER_COLORS = "#1A4988"
 const val MAX_SUGGESTION_DISPLAY_NAME_LENGTH_MAP = 100
+const val PIN_BITMAP_SIZE = 80
 
 @Composable
 fun MapScreen(
@@ -221,7 +222,7 @@ fun MapScreen(
 
   val resizedBitmap = remember {
     val bitmap = BitmapFactory.decodeResource(context.resources, R.drawable.dot)
-    Bitmap.createScaledBitmap(bitmap, 80, 80, false)
+    Bitmap.createScaledBitmap(bitmap, PIN_BITMAP_SIZE, PIN_BITMAP_SIZE, false)
   }
 
   LaunchedEffect(isOnlineMode) {

--- a/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/github/se/cyrcle/ui/map/MapScreen.kt
@@ -142,6 +142,9 @@ fun MapScreen(
     addressViewModel: AddressViewModel,
     zoomState: MutableState<Double> = remember { mutableDoubleStateOf(defaultZoom) }
 ) {
+
+  val context = LocalContext.current
+
   // Collect the list of parkings from the ParkingViewModel as a state
   val listOfParkings by parkingViewModel.filteredRectParkings.collectAsState(emptyList())
 
@@ -211,8 +214,10 @@ fun MapScreen(
   // Show suggestions screen
   val showSuggestions = remember { mutableStateOf(false) }
 
-  val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, R.drawable.dot)
-  val resizedBitmap = Bitmap.createScaledBitmap(bitmap, 80, 80, false)
+  val resizedBitmap = remember {
+    val bitmap = BitmapFactory.decodeResource(context.resources, R.drawable.dot)
+    Bitmap.createScaledBitmap(bitmap, 80, 80, false)
+  }
 
   // Draw markers on the map when the list of parkings changes
   LaunchedEffect(


### PR DESCRIPTION
## What is this PR? 
This PR aims to bugfix the Network connectivity changes not updating the parkings on the map.

## How?
This was done by adding a state in the `MapViewModel` that remembers the screen location coordinates. This allows to add a `LaunchedEffect` in the `MapScreen` that updates on connectivity changes.

## Testing:
To test that the behavior is correct: swapping between offline and online mode should keep the parkings displayed without having to move around the map.

* closes: #386
