### PR TITLE
fix: stale cache, displays out of sync data

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/parking/ParkingViewModel.kt
@@ -159,7 +159,15 @@ class ParkingViewModel(
 
   fun deleteParkingByUid(uid: String) {
     parkingRepository.deleteParkingById(
-        uid, {}, { Log.d("ParkingViewModel", "Error deleting Parking") })
+        uid,
+        {
+          // can not use updateCache() here as we remove the parking from the cache, also we can't
+          // get the tile from the uid so we iterate over the whole cache.
+          tilesToParking.forEach { (tile, parkings) ->
+            tilesToParking[tile] = parkings.filter { parking -> parking.uid != uid }
+          }
+        },
+        { Log.d("ParkingViewModel", "Error deleting Parking") })
   }
 
   /**
@@ -248,6 +256,7 @@ class ParkingViewModel(
    * @param endPos the opposite corner of the rectangle
    */
   fun getParkingsInRect(startPos: Point, endPos: Point) {
+    Log.d("ParkingViewModel", "Parkings in Cache : ${tilesToParking.size}")
     // flush the list of parkings
     _rectParkings.value = emptyList()
     if (startPos.latitude() == endPos.latitude() || startPos.longitude() == endPos.longitude()) {
@@ -512,12 +521,13 @@ class ParkingViewModel(
     parkingRepository.getParkingById(
         parkingId,
         onSuccess = { parking ->
-          val updatedImages = parking.images.filterNot { it.equals(imgId) }
+          val updatedImages = parking.images.filterNot { it == imgId }
           val updatedParking = parking.copy(images = updatedImages)
 
           parkingRepository.updateParking(
               updatedParking,
               onSuccess = {
+                updateCache(updatedParking)
                 Log.d("deleteImageFromParking", "Image removed successfully from parking.")
               },
               onFailure = { exception ->
@@ -841,7 +851,7 @@ class ParkingViewModel(
           0.0
         }
     parking.nbReviews -= 1
-    parkingRepository.updateParking(parking, {}, {})
+    parkingRepository.updateParking(parking, { updateCache(parking) }, {})
   }
 
   /**
@@ -862,7 +872,9 @@ class ParkingViewModel(
         (100 * ((parking.avgScore * parking.nbReviews) + newScore) / (parking.nbReviews + 1))
             .toInt() / 100.00
     parking.nbReviews += 1
-    parkingRepository.updateParking(parking, onSuccess = {}, onFailure = {})
+    parkingRepository.updateParking(parking, onSuccess = { updateCache(parking) }, onFailure = {})
+    // updates the cache  :
+
   }
 
   /**
@@ -886,7 +898,7 @@ class ParkingViewModel(
     if (parking.nbReviews != 0) {
       val delta = (newScore - oldScore) / parking.nbReviews
       parking.avgScore += delta
-      parkingRepository.updateParking(parking, {}, {})
+      parkingRepository.updateParking(parking, { updateCache(parking) }, {})
     } else {
       Log.e("ParkingViewModel", "An unexpect error occured (0 reviews)")
     }
@@ -968,7 +980,10 @@ class ParkingViewModel(
           selectParking(updatedParking)
           parkingRepository.updateParking(
               updatedParking,
-              { onSuccess() },
+              {
+                onSuccess()
+                updateCache(updatedParking)
+              },
               { Log.e("ParkingViewModel", "Error adding image path to parking firestore $it") })
         },
         onFailure = { Log.e("ParkingViewModel", "Error uploading image") },
@@ -1037,6 +1052,12 @@ class ParkingViewModel(
     offlineParkingRepository.deleteTiles(tilesToDelete - tilesToKeep) {
       Log.d("ParkingViewModel", "Tiles deleted successfully")
     }
+  }
+
+  private fun updateCache(parking: Parking) {
+    val tile = TileUtils.getTileFromPoint(parking.location.center)
+    tilesToParking[tile] =
+        tilesToParking[tile]?.map { if (it.uid == parking.uid) parking else it }!!
   }
 
   /** Changes the parking view model to offline mode. */


### PR DESCRIPTION
- fix : #407 

## What
#### maintains  the displayed informations  in sync with the datas.
In particular : 
- Adding/editing/Deleting a review is now reflected persistently in the ui
- Adding/removing a picture is reflected persistently in the ui
- Deleting a parking is reflected persistently in the ui

## How
Add a private function `updateCache` that does that. 
call this function every time the viewmodel makes a change that is passed to a repo.

## Why
To keep the UI in sync with data