### PR TITLE
Attemp to bugfix missing credentials

### DIFF
--- a/app/src/main/java/com/github/se/cyrcle/model/authentication/AuthenticationRepositoryGoogle.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/authentication/AuthenticationRepositoryGoogle.kt
@@ -50,6 +50,14 @@ constructor(
     makeRequest(onSuccess, onFailure, true)
   }
 
+  /**
+   * Semi recursive function to make a credential request. The first attempt will try to use the
+   * last account used to sign in. If that fails, it will prompt the user to link a Google account
+   *
+   * @param onSuccess a function to be called once the user is authenticated
+   * @param onFailure a function to be called if the authentication fails
+   * @param firstTry a boolean to indicate if this is the first attempt to sign in
+   */
   private fun makeRequest(
       onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit,
@@ -94,9 +102,7 @@ constructor(
           onFailure(Exception("Unexpected type of credential"))
         }
       } catch (e: GetCredentialException) {
-        if (firstTry) makeRequest(onSuccess, onFailure, false)
-        else onFailure(e)
-
+        if (firstTry) makeRequest(onSuccess, onFailure, false) else onFailure(e)
       } catch (e: Exception) {
         onFailure(e)
       }

--- a/app/src/main/java/com/github/se/cyrcle/model/authentication/AuthenticationRepositoryGoogle.kt
+++ b/app/src/main/java/com/github/se/cyrcle/model/authentication/AuthenticationRepositoryGoogle.kt
@@ -1,7 +1,6 @@
 package com.github.se.cyrcle.model.authentication
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CredentialManager
@@ -79,8 +78,6 @@ constructor(
             .setServerClientId(webClientId)
             .setNonce(hashedNonce)
             .build()
-
-    Log.d("GoogleIdToken", "Made request $firstTry")
 
     val request = GetCredentialRequest.Builder().addCredentialOption(signInWithGoogleOption).build()
 


### PR DESCRIPTION
## What is this PR?
This PR aims at bug-fixing an issue where the prompt to enter your credentials does not show up when credentials are missing. There is a trace of this issue being present in this github thread: https://github.com/android/identity-samples/issues/53

The issue in itself is not solved in the app, but this is the best try to apply the Google Credential Manager tutorial (first ask with `.setFilterByAuthorizedAccounts(true)` and then `.setFilterByAuthorizedAccounts(false)` if there were no credentials).

## How?
For this, the code for making the credential request was moved into a "semi-recursive" helper function. The request is then made once with `.setFilterByAuthorizedAccounts(true)` and then recurses calling this time with `setFilterByAuthorizedAccounts(false)` then if authentication still fails, it calls the `onFailure` with the correct exception.

Concerns #365 